### PR TITLE
feat: add run build when run start (not found ssgoi module issue)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "packages/*"
   ],
   "scripts": {
-    "start": "npm run dev --workspace=docs",
+    "start": "npm run build && npm run dev --workspace=docs",
     "build": "npm run package --workspace=ssgoi",
     "docs:build": "npm run build --workspace=docs"
   },
@@ -20,8 +20,13 @@
   "bugs": {
     "url": "https://github.com/meursyphus/ssgoi/issues"
   },
-  "keywords": ["svelte", "sveltekit", "page-transition", "animation"],
+  "keywords": [
+    "svelte",
+    "sveltekit",
+    "page-transition",
+    "animation"
+  ],
   "dependencies": {
-
+    "ssgoi": "^1.0.1"
   }
 }


### PR DESCRIPTION
컨트리뷰트 개발 초기에 문서에 나와있지않아, npm run start시 ssgoi 모듈을 찾을 수 없는 애러를 해결하기위해, start시 build를 추가함.