### PR TITLE
Fix fade animation

### DIFF
--- a/packages/ssgoi/src/lib/transitions/fade.ts
+++ b/packages/ssgoi/src/lib/transitions/fade.ts
@@ -22,7 +22,7 @@ const fade: Transition = ({
 			delay,
 			easing,
 			css(t) {
-				return `${out}; opacity: ${t}`;
+				return `${out} opacity: ${t}`;
 			}
 		};
 	}


### PR DESCRIPTION
For me the fade animation is broken in chrome, safari and firefox (just no animation). I reproduced this in the demo application, by replacing defined transitions with fade.

## Details

The fade out of the previous page is not animated and just pops out after the animation duration. It's pretty visible if the transitioned-in page has no background (for example, the shared layout is providing a common background). I can provide a video, if required.

## Changes

- Remove redundant `;` which also breaks the css animation. Also matches other usages in `transitions.none`, `transitions.ripple`, `transitions.scroll`.