### PR TITLE
svelte-demo 실행시 typescript 에러가 발생하지 않도록, vite 설정에서 @ssgoi/core와 @meursyphus/ssgoi-svelte 패키지를 번들에 포함하도록 설정.

### DIFF
--- a/apps/svelte-demo/vite.config.ts
+++ b/apps/svelte-demo/vite.config.ts
@@ -2,5 +2,8 @@ import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-	plugins: [sveltekit()]
+	plugins: [sveltekit()],
+	ssr: {
+		noExternal: ['@ssgoi/core', '@meursyphus/ssgoi-svelte']
+	}
 });


### PR DESCRIPTION
svelte-demo 실행시 다음과 같은 에러가 발생합니다.

오전 8:40:48 [vite] (ssr) Error when evaluating SSR module /src/routes/+page.svelte: Unknown file extension ".ts" for /Users/zerodice0/workspace/zerodice0/development/ssgoi/packages/core/src/lib/index.ts
      at Object.getFileProtocolModuleFormat [as file:] (node:internal/modules/esm/get_format:219:9)
      at defaultGetFormat (node:internal/modules/esm/get_format:245:36)
      at defaultLoad (node:internal/modules/esm/load:120:22)
      at async ModuleLoader.loadAndTranslate (node:internal/modules/esm/loader:514:32)
      at async ModuleJob._link (node:internal/modules/esm/module_job:115:19)
TypeError [ERR_UNKNOWN_FILE_EXTENSION]: Unknown file extension ".ts" for /Users/zerodice0/workspace/zerodice0/development/ssgoi/packages/core/src/lib/index.ts
    at Object.getFileProtocolModuleFormat [as file:] (node:internal/modules/esm/get_format:219:9)
    at defaultGetFormat (node:internal/modules/esm/get_format:245:36)
    at defaultLoad (node:internal/modules/esm/load:120:22)
    at async ModuleLoader.loadAndTranslate (node:internal/modules/esm/loader:514:32)
    at async ModuleJob._link (node:internal/modules/esm/module_job:115:19) {
  code: 'ERR_UNKNOWN_FILE_EXTENSION'
}

svelte-demo 실행 시 core 패키지와 ssgoi-svelte 패키지가 컴파일된 JS 대신 원본 TS 파일을 직접 export하고 있기 때문에 발생하는 문제라고 합니다. vite.config.js의 ssr.noExternal 옵션에 core, ssgoi-svelte 패키지를 추가하여, SSR 번들 시 두 패키지를 포함하도록 설정했습니다.