### PR TITLE
feat: Implement Pinterest-style view transition effect

### DIFF
--- a/apps/docs/src/components/demo/layout.tsx
+++ b/apps/docs/src/components/demo/layout.tsx
@@ -57,12 +57,12 @@ export default function DemoLayout({ children }: DemoLayoutProps) {
         {
           from: "/demo/pinterest/*",
           to: "/demo/pinterest",
-          transition: pinterest({ spring: { stiffness: 100, damping: 50 } }),
+          transition: pinterest({ spring: { stiffness: 50, damping: 50 } }),
         },
         {
           from: "/demo/pinterest",
           to: "/demo/pinterest/*",
-          transition: pinterest({ spring: { stiffness: 100, damping: 50 } }),
+          transition: pinterest({ spring: { stiffness: 50, damping: 50 } }),
         },
 
         // Products transitions - hero

--- a/apps/docs/src/components/demo/layout.tsx
+++ b/apps/docs/src/components/demo/layout.tsx
@@ -57,12 +57,12 @@ export default function DemoLayout({ children }: DemoLayoutProps) {
         {
           from: "/demo/pinterest/*",
           to: "/demo/pinterest",
-          transition: pinterest({ spring: { stiffness: 1, damping: 50 } }),
+          transition: pinterest({ spring: { stiffness: 200, damping: 50 } }),
         },
         {
           from: "/demo/pinterest",
           to: "/demo/pinterest/*",
-          transition: pinterest({ spring: { stiffness: 100, damping: 50 } }),
+          transition: pinterest({ spring: { stiffness: 200, damping: 50 } }),
         },
 
         // Products transitions - hero

--- a/apps/docs/src/components/demo/layout.tsx
+++ b/apps/docs/src/components/demo/layout.tsx
@@ -57,12 +57,12 @@ export default function DemoLayout({ children }: DemoLayoutProps) {
         {
           from: "/demo/pinterest/*",
           to: "/demo/pinterest",
-          transition: pinterest(),
+          transition: pinterest({ spring: { stiffness: 100, damping: 50 } }),
         },
         {
           from: "/demo/pinterest",
           to: "/demo/pinterest/*",
-          transition: pinterest(),
+          transition: pinterest({ spring: { stiffness: 100, damping: 50 } }),
         },
 
         // Products transitions - hero

--- a/apps/docs/src/components/demo/layout.tsx
+++ b/apps/docs/src/components/demo/layout.tsx
@@ -57,12 +57,12 @@ export default function DemoLayout({ children }: DemoLayoutProps) {
         {
           from: "/demo/pinterest/*",
           to: "/demo/pinterest",
-          transition: pinterest({ spring: { stiffness: 50, damping: 50 } }),
+          transition: pinterest({ spring: { stiffness: 1, damping: 50 } }),
         },
         {
           from: "/demo/pinterest",
           to: "/demo/pinterest/*",
-          transition: pinterest({ spring: { stiffness: 50, damping: 50 } }),
+          transition: pinterest({ spring: { stiffness: 100, damping: 50 } }),
         },
 
         // Products transitions - hero

--- a/apps/docs/src/components/demo/pinterest/detail.tsx
+++ b/apps/docs/src/components/demo/pinterest/detail.tsx
@@ -51,7 +51,7 @@ export default function PinterestDetail({ onBack }: PinterestDetailProps) {
             src={item.image}
             alt={item.title}
             style={{ aspectRatio: item.aspectRatio }}
-            data-pinterest-enter-key={item.id}
+            data-pinterest-detail-key={item.id}
           />
           
           <div>

--- a/apps/docs/src/components/demo/pinterest/index.tsx
+++ b/apps/docs/src/components/demo/pinterest/index.tsx
@@ -60,7 +60,7 @@ function PinCard({ item, router }: PinCardProps) {
           src={item.image}
           alt={item.title}
           className="w-full h-full object-cover bg-gray-800"
-          data-pinterest-exit-key={item.id}
+          data-pinterest-gallery-key={item.id}
         />
         {/* Overlay on hover */}
         <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-200" />

--- a/packages/core/src/lib/view-transitions/pinterest.ts
+++ b/packages/core/src/lib/view-transitions/pinterest.ts
@@ -56,9 +56,17 @@ function createDetailIn(
   node: HTMLElement
 ): AnimationFunc {
   // 시작 위치 (from)와 끝 위치 (to) 사이의 거리 계산
-  const dx = toRect.left - fromRect.left + (toRect.width - fromRect.width) / 2;
-  const dy = toRect.top - fromRect.top + (toRect.height - fromRect.height) / 2;
-
+  const dx =
+    toRect.left -
+    fromRect.left +
+    (toRect.width - fromRect.width) / 2 -
+    scrollOffset.x;
+  const dy =
+    toRect.top -
+    fromRect.top +
+    (toRect.height - fromRect.height) / 2 -
+    scrollOffset.y;
+  console.log(dx, dy, scrollOffset);
   // scale 계산
   const scaleX = toRect.width / fromRect.width;
   const scaleY = toRect.height / fromRect.height;
@@ -74,6 +82,7 @@ function createDetailIn(
     100;
   const startLeft = (fromRect.left / pageRect.width) * 100;
 
+  node.style.transformOrigin = `${fromRect.left + fromRect.width / 2}px ${fromRect.top + fromRect.height / 2}px`;
   return (progress: number) => {
     const u = 1 - progress;
     const currentTop = startTop * u;
@@ -82,7 +91,6 @@ function createDetailIn(
     const currentLeft = startLeft * u;
 
     node.style.clipPath = `inset(${currentTop}% ${currentRight}% ${currentBottom}% ${currentLeft}%)`;
-    node.style.transformOrigin = `${fromRect.left + fromRect.width / 2}px ${fromRect.top + fromRect.height / 2}px`;
     node.style.transform = `translate(${dx * u}px, ${dy * u}px) scale(${1 + (scale - 1) * u})`;
   };
 }
@@ -100,8 +108,16 @@ function createGalleryOut(
   node: HTMLElement
 ): AnimationFunc {
   // 시작 위치 (from)와 끝 위치 (to) 사이의 거리 계산
-  const dx = toRect.left - fromRect.left + (toRect.width - fromRect.width) / 2;
-  const dy = toRect.top - fromRect.top + (toRect.height - fromRect.height) / 2;
+  const dx =
+    toRect.left -
+    fromRect.left +
+    (toRect.width - fromRect.width) / 2 +
+    scrollOffset.x;
+  const dy =
+    toRect.top -
+    fromRect.top +
+    (toRect.height - fromRect.height) / 2 +
+    scrollOffset.y;
 
   // scale 계산
   const scaleX = toRect.width / fromRect.width;
@@ -111,7 +127,7 @@ function createGalleryOut(
   return (progress: number) => {
     node.style.transformOrigin = `${fromRect.left + fromRect.width / 2}px ${fromRect.top + fromRect.height / 2}px`;
     const t = 1 - progress; // 0 -> 1
-    node.style.transform = `translate(${dx * t}px, ${dy * t}px) scale(${1 + (scale - 1) * t})`;
+    node.style.transform = `translate(${dx * t - scrollOffset.x}px, ${dy * t - scrollOffset.y}px) scale(${1 + (scale - 1) * t})`;
     node.style.opacity = `${1 - t}`;
   };
 }

--- a/packages/core/src/lib/view-transitions/pinterest.ts
+++ b/packages/core/src/lib/view-transitions/pinterest.ts
@@ -160,7 +160,7 @@ function createGalleryOut(
   // scale 계산
   const scaleX = toRect.width / fromRect.width;
   const scaleY = toRect.height / fromRect.height;
-  const scale = Math.max(scaleX, scaleY);
+  const scale = Math.min(scaleX, scaleY);
 
   // clip-path 계산
   const startTop = (fromRect.top / pageRect.height) * 100;
@@ -171,18 +171,16 @@ function createGalleryOut(
     ((pageRect.height - (fromRect.top + fromRect.height)) / pageRect.height) *
     100;
   const startLeft = (fromRect.left / pageRect.width) * 100;
-
+  node.style.transformOrigin = `${fromRect.left + fromRect.width / 2}px ${fromRect.top + fromRect.height / 2}px`;
   return (progress: number) => {
-    const t = progress; // 1 → 0 for out transitions
+    const t = 1 - progress; // 1 → 0 for out transitions
     const currentTop = startTop * t;
     const currentRight = startRight * t;
     const currentBottom = startBottom * t;
     const currentLeft = startLeft * t;
 
     node.style.clipPath = `inset(${currentTop}% ${currentRight}% ${currentBottom}% ${currentLeft}%)`;
-    node.style.transformOrigin = `${fromRect.left + fromRect.width / 2}px ${fromRect.top + fromRect.height / 2}px`;
     node.style.transform = `translate(${dx * t}px, ${dy * t}px) scale(${1 + (scale - 1) * t})`;
-    node.style.opacity = "1";
   };
 }
 
@@ -274,7 +272,7 @@ function createAnimationConfig(
         toNode
       ),
       outAnimation: createGalleryOut(
-        { fromRect: galleryRect, toRect: detailRect, pageRect },
+        { fromRect: detailRect, toRect: galleryRect, pageRect },
         fromNode
       ),
     };

--- a/packages/core/src/lib/view-transitions/pinterest.ts
+++ b/packages/core/src/lib/view-transitions/pinterest.ts
@@ -66,7 +66,7 @@ function createDetailIn(
     fromRect.top +
     (toRect.height - fromRect.height) / 2 -
     scrollOffset.y;
-  console.log(dx, dy, scrollOffset);
+
   // scale 계산
   const scaleX = toRect.width / fromRect.width;
   const scaleY = toRect.height / fromRect.height;
@@ -144,8 +144,16 @@ function createGalleryIn(
   },
   node: HTMLElement
 ): AnimationFunc {
-  const dx = toRect.left - fromRect.left + (toRect.width - fromRect.width) / 2;
-  const dy = toRect.top - fromRect.top + (toRect.height - fromRect.height) / 2;
+  const dx =
+    toRect.left -
+    fromRect.left +
+    (toRect.width - fromRect.width) / 2 -
+    scrollOffset.x;
+  const dy =
+    toRect.top -
+    fromRect.top +
+    (toRect.height - fromRect.height) / 2 -
+    scrollOffset.y;
 
   // scale 계산
   const scaleX = toRect.width / fromRect.width;
@@ -153,8 +161,8 @@ function createGalleryIn(
   const scale = Math.max(scaleX, scaleY);
 
   return (progress: number) => {
-    const t = 1 - progress;
-    const u = progress;
+    const t = 1 - progress; // 1 -> 0;
+    const u = progress; // 0 -> 1;
     node.style.transformOrigin = `${fromRect.left + fromRect.width / 2}px ${fromRect.top + fromRect.height / 2}px`;
     node.style.transform = `translate(${dx * t}px, ${dy * t}px) scale(${1 + (scale - 1) * t})`;
     node.style.opacity = `${u}`;
@@ -176,8 +184,16 @@ function createDetailOut(
   node: HTMLElement
 ): AnimationFunc {
   // 시작 위치 (from)와 끝 위치 (to) 사이의 거리 계산
-  const dx = toRect.left - fromRect.left + (toRect.width - fromRect.width) / 2;
-  const dy = toRect.top - fromRect.top + (toRect.height - fromRect.height) / 2;
+  const dx =
+    toRect.left -
+    fromRect.left +
+    (toRect.width - fromRect.width) / 2 +
+    scrollOffset.x;
+  const dy =
+    toRect.top -
+    fromRect.top +
+    (toRect.height - fromRect.height) / 2 +
+    scrollOffset.y;
 
   // scale 계산
   const scaleX = toRect.width / fromRect.width;
@@ -195,14 +211,14 @@ function createDetailOut(
   const startLeft = (fromRect.left / pageRect.width) * 100;
   node.style.transformOrigin = `${fromRect.left + fromRect.width / 2}px ${fromRect.top + fromRect.height / 2}px`;
   return (progress: number) => {
-    const t = 1 - progress; // 1 → 0 for out transitions
+    const t = 1 - progress; // 0 -> 1 for out transitions
     const currentTop = startTop * t;
     const currentRight = startRight * t;
     const currentBottom = startBottom * t;
     const currentLeft = startLeft * t;
 
     node.style.clipPath = `inset(${currentTop}% ${currentRight}% ${currentBottom}% ${currentLeft}%)`;
-    node.style.transform = `translate(${dx * t}px, ${dy * t}px) scale(${1 + (scale - 1) * t})`;
+    node.style.transform = `translate(${dx * t - scrollOffset.x}px, ${dy * t - scrollOffset.y}px) scale(${1 + (scale - 1) * t})`;
   };
 }
 

--- a/packages/core/src/lib/view-transitions/pinterest.ts
+++ b/packages/core/src/lib/view-transitions/pinterest.ts
@@ -43,12 +43,12 @@ type AnimationFunc = (progress: number) => void;
 // Animation creators for each transition type
 function createDetailIn(
   {
-    fromRect,
-    toRect,
+    detailRect: fromRect,
+    galleryRect: toRect,
     pageRect,
   }: {
-    fromRect: DOMRect;
-    toRect: DOMRect;
+    detailRect: DOMRect;
+    galleryRect: DOMRect;
     pageRect: DOMRect;
   },
   node: HTMLElement
@@ -85,15 +85,13 @@ function createDetailIn(
   };
 }
 
-function createDetailOut(
+function createGalleryOut(
   {
-    fromRect,
-    toRect,
-    pageRect,
+    galleryRect: fromRect,
+    detailRect: toRect,
   }: {
-    fromRect: DOMRect;
-    toRect: DOMRect;
-    pageRect: DOMRect;
+    galleryRect: DOMRect;
+    detailRect: DOMRect;
   },
   node: HTMLElement
 ): AnimationFunc {
@@ -116,11 +114,11 @@ function createDetailOut(
 
 function createGalleryIn(
   {
-    fromRect,
-    toRect,
+    galleryRect: fromRect,
+    detailRect: toRect,
   }: {
-    fromRect: DOMRect;
-    toRect: DOMRect;
+    galleryRect: DOMRect;
+    detailRect: DOMRect;
   },
   node: HTMLElement
 ): AnimationFunc {
@@ -141,14 +139,14 @@ function createGalleryIn(
   };
 }
 
-function createGalleryOut(
+function createDetailOut(
   {
-    fromRect,
-    toRect,
+    detailRect: fromRect,
+    galleryRect: toRect,
     pageRect,
   }: {
-    fromRect: DOMRect;
-    toRect: DOMRect;
+    detailRect: DOMRect;
+    galleryRect: DOMRect;
     pageRect: DOMRect;
   },
   node: HTMLElement
@@ -257,22 +255,16 @@ function createAnimationConfig(
   if (isEnterMode) {
     return {
       inAnimation: createDetailIn(
-        { fromRect: detailRect, toRect: galleryRect, pageRect },
+        { detailRect, galleryRect, pageRect },
         toNode
       ),
-      outAnimation: createDetailOut(
-        { fromRect: galleryRect, toRect: detailRect, pageRect },
-        fromNode
-      ),
+      outAnimation: createGalleryOut({ galleryRect, detailRect }, fromNode),
     };
   } else {
     return {
-      inAnimation: createGalleryIn(
-        { fromRect: galleryRect, toRect: detailRect },
-        toNode
-      ),
-      outAnimation: createGalleryOut(
-        { fromRect: detailRect, toRect: galleryRect, pageRect },
+      inAnimation: createGalleryIn({ galleryRect, detailRect }, toNode),
+      outAnimation: createDetailOut(
+        { detailRect, galleryRect, pageRect },
         fromNode
       ),
     };
@@ -292,7 +284,7 @@ export const pinterest = (options: PinterestOptions = {}): SggoiTransition => {
   let handlers: AnimationHandlers | null = null;
 
   return {
-    in: async (element) => {
+    in: async (element, { scrollOffset }) => {
       const toNode = element;
 
       // Wait for fromNode to be set by out transition
@@ -338,7 +330,7 @@ export const pinterest = (options: PinterestOptions = {}): SggoiTransition => {
         },
       };
     },
-    out: async (element) => {
+    out: async (element, { scrollOffset }) => {
       return {
         spring,
         onStart: () => {

--- a/packages/core/src/lib/view-transitions/pinterest.ts
+++ b/packages/core/src/lib/view-transitions/pinterest.ts
@@ -42,59 +42,70 @@ type AnimationFunc = (progress: number) => void;
 
 // Animation creators for each transition type
 function createDetailIn(
-  galleryRect: DOMRect,
-  detailRect: DOMRect,
-  pageRect: DOMRect,
-  toNode: HTMLElement
+  {
+    galleryRect,
+    detailRect,
+    pageRect,
+  }: {
+    galleryRect: DOMRect;
+    detailRect: DOMRect;
+    pageRect: DOMRect;
+  },
+  node: HTMLElement
 ): AnimationFunc {
   const dx =
-    galleryRect.left -
-    detailRect.left +
-    (galleryRect.width - detailRect.width) / 2;
+    detailRect.left -
+    galleryRect.left +
+    (detailRect.width - galleryRect.width) / 2;
   const dy =
-    galleryRect.top -
-    detailRect.top +
-    (galleryRect.height - detailRect.height) / 2;
+    detailRect.top -
+    galleryRect.top +
+    (detailRect.height - galleryRect.height) / 2;
 
   // Scale from gallery size to detail size
-  const scaleX = galleryRect.width / detailRect.width;
-  const scaleY = galleryRect.height / detailRect.height;
+  const scaleX = detailRect.width / galleryRect.width;
+  const scaleY = detailRect.height / galleryRect.height;
   const scale = Math.max(scaleX, scaleY);
 
   // Clip bounds based on gallery position (starting small)
   const clipBounds = {
-    top: (detailRect.top / pageRect.height) * 100,
+    top: (galleryRect.top / pageRect.height) * 100,
     right:
-      ((pageRect.width - (detailRect.left + detailRect.width)) /
+      ((pageRect.width - (galleryRect.left + galleryRect.width)) /
         pageRect.width) *
       100,
     bottom:
-      ((pageRect.height - (detailRect.top + detailRect.height)) /
+      ((pageRect.height - (galleryRect.top + galleryRect.height)) /
         pageRect.height) *
       100,
-    left: (detailRect.left / pageRect.width) * 100,
+    left: (galleryRect.left / pageRect.width) * 100,
   };
 
   // Transform origin at gallery center
-  const transformOrigin = `${detailRect.left + detailRect.width / 2}px ${detailRect.top + detailRect.height / 2}px`;
+  const transformOrigin = `${galleryRect.left + galleryRect.width / 2}px ${galleryRect.top + galleryRect.height / 2}px`;
 
   return (progress: number) => {
-    const t = progress; // 0 → 1 (for in transitions)
     const u = 1 - progress; // 1 → 0
 
     // Clip expands from gallery bounds to full (inset goes from gallery to 0)
-    toNode.style.clipPath = `inset(${clipBounds.top * u}% ${clipBounds.right * u}% ${clipBounds.bottom * u}% ${clipBounds.left * u}%)`;
-    toNode.style.transformOrigin = transformOrigin;
+    node.style.clipPath = `inset(${clipBounds.top * u}% ${clipBounds.right * u}% ${clipBounds.bottom * u}% ${clipBounds.left * u}%)`;
+    node.style.transformOrigin = transformOrigin;
     // Transform moves and scales from gallery position/size to detail position/size
-    toNode.style.transform = `translate(${dx * u}px, ${dy * u}px) scale(${1 + (scale - 1) * u})`;
+    node.style.transform = `translate(${dx * u}px, ${dy * u}px) scale(${1 + (scale - 1) * u})`;
   };
 }
 
 function createGalleryOut(
-  galleryRect: DOMRect,
-  detailRect: DOMRect,
-  pageRect: DOMRect,
-  fromNode: HTMLElement
+  {
+    galleryRect,
+    detailRect,
+    pageRect,
+  }: {
+    galleryRect: DOMRect;
+    detailRect: DOMRect;
+    pageRect: DOMRect;
+  },
+  node: HTMLElement
 ): AnimationFunc {
   const dx =
     detailRect.left -
@@ -127,16 +138,21 @@ function createGalleryOut(
     // progress goes from 1 to 0 for out transitions
 
     const u = 1 - progress; // 0 → 1
-    fromNode.style.clipPath = `inset(${clipBounds.top * u}% ${clipBounds.right * u}% ${clipBounds.bottom * u}% ${clipBounds.left * u}%)`;
-    fromNode.style.transformOrigin = transformOrigin;
-    fromNode.style.transform = `translate(${dx * u}px, ${dy * u}px) scale(${1 + (scale - 1) * u})`;
+    node.style.clipPath = `inset(${clipBounds.top * u}% ${clipBounds.right * u}% ${clipBounds.bottom * u}% ${clipBounds.left * u}%)`;
+    node.style.transformOrigin = transformOrigin;
+    node.style.transform = `translate(${dx * u}px, ${dy * u}px) scale(${1 + (scale - 1) * u})`;
   };
 }
 
 function createGalleryIn(
-  galleryRect: DOMRect,
-  detailRect: DOMRect,
-  toNode: HTMLElement
+  {
+    galleryRect,
+    detailRect,
+  }: {
+    galleryRect: DOMRect;
+    detailRect: DOMRect;
+  },
+  node: HTMLElement
 ): AnimationFunc {
   const dx =
     galleryRect.left -
@@ -155,16 +171,21 @@ function createGalleryIn(
 
   return (progress: number) => {
     const t = 1 - progress;
-    toNode.style.transformOrigin = transformOrigin;
-    toNode.style.transform = `translate(${-dx * t}px, ${-dy * t}px) scale(${1 + (inverseScale - 1) * t})`;
-    toNode.style.opacity = `${progress}`;
+    node.style.transformOrigin = transformOrigin;
+    node.style.transform = `translate(${-dx * t}px, ${-dy * t}px) scale(${1 + (inverseScale - 1) * t})`;
+    node.style.opacity = `${progress}`;
   };
 }
 
 function createDetailOut(
-  detailRect: DOMRect,
-  galleryRect: DOMRect,
-  fromNode: HTMLElement
+  {
+    detailRect,
+    galleryRect,
+  }: {
+    detailRect: DOMRect;
+    galleryRect: DOMRect;
+  },
+  node: HTMLElement
 ): AnimationFunc {
   const dx =
     detailRect.left -
@@ -185,9 +206,9 @@ function createDetailOut(
     // progress goes from 1 to 0 for out transitions
     const t = progress; // 1 → 0
     const u = 1 - progress; // 0 → 1
-    fromNode.style.transformOrigin = transformOrigin;
-    fromNode.style.transform = `translate(${-dx * u}px, ${-dy * u}px) scale(${1 + (inverseScale - 1) * u})`;
-    fromNode.style.opacity = `${t}`;
+    node.style.transformOrigin = transformOrigin;
+    node.style.transform = `translate(${-dx * u}px, ${-dy * u}px) scale(${1 + (inverseScale - 1) * u})`;
+    node.style.opacity = `${t}`;
   };
 }
 
@@ -196,7 +217,7 @@ interface AnimationHandlers {
   outAnimation: AnimationFunc;
 }
 
-function detectAndPrepare(
+function createAnimationConfig(
   fromNode: HTMLElement,
   toNode: HTMLElement
 ): AnimationHandlers | null {
@@ -263,18 +284,16 @@ function detectAndPrepare(
   // Return appropriate animation functions based on mode
   if (isEnterMode) {
     return {
-      inAnimation: createDetailIn(galleryRect, detailRect, pageRect, toNode),
+      inAnimation: createDetailIn({ galleryRect, detailRect, pageRect }, toNode),
       outAnimation: createGalleryOut(
-        galleryRect,
-        detailRect,
-        pageRect,
+        { galleryRect, detailRect, pageRect },
         fromNode
       ),
     };
   } else {
     return {
-      inAnimation: createGalleryIn(galleryRect, detailRect, toNode),
-      outAnimation: createDetailOut(detailRect, galleryRect, fromNode),
+      inAnimation: createGalleryIn({ galleryRect, detailRect }, toNode),
+      outAnimation: createDetailOut({ detailRect, galleryRect }, fromNode),
     };
   }
 }
@@ -320,7 +339,7 @@ export const pinterest = (options: PinterestOptions = {}): SggoiTransition => {
       }
 
       // Detect and prepare animation handlers
-      handlers = detectAndPrepare(fromNode, toNode);
+      handlers = createAnimationConfig(fromNode, toNode);
       if (!handlers) {
         return {
           spring,

--- a/packages/core/src/lib/view-transitions/pinterest.ts
+++ b/packages/core/src/lib/view-transitions/pinterest.ts
@@ -46,10 +46,12 @@ function createDetailIn(
     detailRect: fromRect,
     galleryRect: toRect,
     pageRect,
+    scrollOffset,
   }: {
     detailRect: DOMRect;
     galleryRect: DOMRect;
     pageRect: DOMRect;
+    scrollOffset: { x: number; y: number };
   },
   node: HTMLElement
 ): AnimationFunc {
@@ -89,9 +91,11 @@ function createGalleryOut(
   {
     galleryRect: fromRect,
     detailRect: toRect,
+    scrollOffset,
   }: {
     galleryRect: DOMRect;
     detailRect: DOMRect;
+    scrollOffset: { x: number; y: number };
   },
   node: HTMLElement
 ): AnimationFunc {
@@ -116,9 +120,11 @@ function createGalleryIn(
   {
     galleryRect: fromRect,
     detailRect: toRect,
+    scrollOffset,
   }: {
     galleryRect: DOMRect;
     detailRect: DOMRect;
+    scrollOffset: { x: number; y: number };
   },
   node: HTMLElement
 ): AnimationFunc {
@@ -144,10 +150,12 @@ function createDetailOut(
     detailRect: fromRect,
     galleryRect: toRect,
     pageRect,
+    scrollOffset,
   }: {
     detailRect: DOMRect;
     galleryRect: DOMRect;
     pageRect: DOMRect;
+    scrollOffset: { x: number; y: number };
   },
   node: HTMLElement
 ): AnimationFunc {
@@ -189,7 +197,8 @@ interface AnimationHandlers {
 
 function createAnimationConfig(
   fromNode: HTMLElement,
-  toNode: HTMLElement
+  toNode: HTMLElement,
+  scrollOffset: { x: number; y: number }
 ): AnimationHandlers | null {
   // Find detail element first (only one per page)
   const fromDetail = fromNode.querySelector(
@@ -255,16 +264,22 @@ function createAnimationConfig(
   if (isEnterMode) {
     return {
       inAnimation: createDetailIn(
-        { detailRect, galleryRect, pageRect },
+        { detailRect, galleryRect, pageRect, scrollOffset },
         toNode
       ),
-      outAnimation: createGalleryOut({ galleryRect, detailRect }, fromNode),
+      outAnimation: createGalleryOut(
+        { galleryRect, detailRect, scrollOffset },
+        fromNode
+      ),
     };
   } else {
     return {
-      inAnimation: createGalleryIn({ galleryRect, detailRect }, toNode),
+      inAnimation: createGalleryIn(
+        { galleryRect, detailRect, scrollOffset },
+        toNode
+      ),
       outAnimation: createDetailOut(
-        { detailRect, galleryRect, pageRect },
+        { detailRect, galleryRect, pageRect, scrollOffset },
         fromNode
       ),
     };
@@ -311,8 +326,8 @@ export const pinterest = (options: PinterestOptions = {}): SggoiTransition => {
         };
       }
 
-      // Detect and prepare animation handlers
-      handlers = createAnimationConfig(fromNode, toNode);
+      // Detect and prepare animation handlers with saved scrollOffset
+      handlers = createAnimationConfig(fromNode, toNode, scrollOffset);
       if (!handlers) {
         return {
           spring,
@@ -330,7 +345,7 @@ export const pinterest = (options: PinterestOptions = {}): SggoiTransition => {
         },
       };
     },
-    out: async (element, { scrollOffset }) => {
+    out: async (element) => {
       return {
         spring,
         onStart: () => {

--- a/packages/core/src/lib/view-transitions/pinterest.ts
+++ b/packages/core/src/lib/view-transitions/pinterest.ts
@@ -47,31 +47,41 @@ function createDetailIn(
   pageRect: DOMRect,
   toNode: HTMLElement
 ): AnimationFunc {
-  // Legacy: detailIn(toRect, fromRect) where to=detail, from=gallery
-  // Calculate movement from detail position to gallery position
-  const dx = detailRect.left - galleryRect.left + (detailRect.width - galleryRect.width) / 2;
-  const dy = detailRect.top - galleryRect.top + (detailRect.height - galleryRect.height) / 2;
-  
+  const dx =
+    galleryRect.left -
+    detailRect.left +
+    (galleryRect.width - detailRect.width) / 2;
+  const dy =
+    galleryRect.top -
+    detailRect.top +
+    (galleryRect.height - detailRect.height) / 2;
+
   // Scale from gallery size to detail size
-  const scaleX = detailRect.width / galleryRect.width;
-  const scaleY = detailRect.height / galleryRect.height;
+  const scaleX = galleryRect.width / detailRect.width;
+  const scaleY = galleryRect.height / detailRect.height;
   const scale = Math.max(scaleX, scaleY);
 
   // Clip bounds based on gallery position (starting small)
   const clipBounds = {
-    top: (galleryRect.top / pageRect.height) * 100,
-    right: ((pageRect.width - (galleryRect.left + galleryRect.width)) / pageRect.width) * 100,
-    bottom: ((pageRect.height - (galleryRect.top + galleryRect.height)) / pageRect.height) * 100,
-    left: (galleryRect.left / pageRect.width) * 100,
+    top: (detailRect.top / pageRect.height) * 100,
+    right:
+      ((pageRect.width - (detailRect.left + detailRect.width)) /
+        pageRect.width) *
+      100,
+    bottom:
+      ((pageRect.height - (detailRect.top + detailRect.height)) /
+        pageRect.height) *
+      100,
+    left: (detailRect.left / pageRect.width) * 100,
   };
 
   // Transform origin at gallery center
-  const transformOrigin = `${galleryRect.left + galleryRect.width / 2}px ${galleryRect.top + galleryRect.height / 2}px`;
+  const transformOrigin = `${detailRect.left + detailRect.width / 2}px ${detailRect.top + detailRect.height / 2}px`;
 
   return (progress: number) => {
     const t = progress; // 0 → 1 (for in transitions)
     const u = 1 - progress; // 1 → 0
-    
+
     // Clip expands from gallery bounds to full (inset goes from gallery to 0)
     toNode.style.clipPath = `inset(${clipBounds.top * u}% ${clipBounds.right * u}% ${clipBounds.bottom * u}% ${clipBounds.left * u}%)`;
     toNode.style.transformOrigin = transformOrigin;
@@ -115,7 +125,7 @@ function createGalleryOut(
 
   return (progress: number) => {
     // progress goes from 1 to 0 for out transitions
-    const t = progress; // 1 → 0
+
     const u = 1 - progress; // 0 → 1
     fromNode.style.clipPath = `inset(${clipBounds.top * u}% ${clipBounds.right * u}% ${clipBounds.bottom * u}% ${clipBounds.left * u}%)`;
     fromNode.style.transformOrigin = transformOrigin;
@@ -157,19 +167,19 @@ function createDetailOut(
   fromNode: HTMLElement
 ): AnimationFunc {
   const dx =
-    galleryRect.left -
-    detailRect.left +
-    (galleryRect.width - detailRect.width) / 2;
+    detailRect.left -
+    galleryRect.left +
+    (detailRect.width - galleryRect.width) / 2;
   const dy =
-    galleryRect.top -
-    detailRect.top +
-    (galleryRect.height - detailRect.height) / 2;
-  const scaleX = galleryRect.width / detailRect.width;
-  const scaleY = galleryRect.height / detailRect.height;
+    detailRect.top -
+    galleryRect.top +
+    (detailRect.height - galleryRect.height) / 2;
+  const scaleX = detailRect.width / galleryRect.width;
+  const scaleY = detailRect.height / galleryRect.height;
   const scale = Math.max(scaleX, scaleY);
   const inverseScale = 1 / scale;
 
-  const transformOrigin = `${detailRect.left + detailRect.width / 2}px ${detailRect.top + detailRect.height / 2}px`;
+  const transformOrigin = `${galleryRect.left + galleryRect.width / 2}px ${galleryRect.top + galleryRect.height / 2}px`;
 
   return (progress: number) => {
     // progress goes from 1 to 0 for out transitions
@@ -330,6 +340,7 @@ export const pinterest = (options: PinterestOptions = {}): SggoiTransition => {
     },
     out: async (element) => {
       return {
+        spring,
         onStart: () => {
           // Store fromNode
           fromNode = element;


### PR DESCRIPTION
## Summary
- Implemented Pinterest-style view transition animation for gallery/detail views
- Added smooth clip-path and transform animations for seamless transitions
- Integrated scroll offset support for better user experience during page transitions

## Implementation Details
- Created four animation functions: `createDetailIn`, `createDetailOut`, `createGalleryIn`, `createGalleryOut`
- Each function handles specific transition scenarios with appropriate animations
- Added scroll offset compensation to maintain visual continuity during scrolled transitions

## Test Plan
- [ ] Test gallery to detail transition (enter mode)
- [ ] Test detail to gallery transition (exit mode)
- [ ] Verify animations work smoothly with different scroll positions
- [ ] Check performance on various devices

🤖 Generated with [Claude Code](https://claude.ai/code)