### PR TITLE
Animation singleton management system

### DIFF
--- a/packages/core/src/lib/animator.ts
+++ b/packages/core/src/lib/animator.ts
@@ -1,4 +1,5 @@
 import type { SpringConfig } from "./types";
+import { VSync } from "./vsync";
 
 interface AnimationOptions {
   from: number;
@@ -97,7 +98,7 @@ export class Animator {
       Math.abs(displacement) < 0.01 && Math.abs(this.velocity) < 0.01;
 
     if (!isComplete) {
-      this.animationId = requestAnimationFrame(() => this.animate(reverse));
+      this.animationId = VSync.requestAnimationFrame(() => this.animate(reverse));
     } else {
       // Snap to final value
       this.currentValue = target;

--- a/packages/core/src/lib/animator.ts
+++ b/packages/core/src/lib/animator.ts
@@ -229,7 +229,7 @@ export class Animator {
   stop() {
     this.isAnimating = false;
     if (this.animationId) {
-      cancelAnimationFrame(this.animationId);
+      VSync.cancelAnimationFrame(this.animationId);
       this.animationId = null;
     }
     this.lastTime = null; // Reset for next animation

--- a/packages/core/src/lib/vsync.ts
+++ b/packages/core/src/lib/vsync.ts
@@ -13,6 +13,7 @@ export class VSync {
 	private reservedCallbacks: VSyncCallback[] = [];
 	private requestAnimationFrameId: number | null = null;
 	public referenceCount = 0;
+	private idCounter = 0;
 
 	constructor() {
 		this.isRunning = false;
@@ -46,14 +47,16 @@ export class VSync {
 	}
 
 	public request(callback: () => void) {
+		const id:number = (this.idCounter++ % Number.MAX_SAFE_INTEGER);
+
 		if (!this.isRunning) {
-			this.callbacks.push({ id: Date.now(), callback });
+			this.callbacks.push({ id, callback });
 			this.run();
 		} else {
-			this.reservedCallbacks.push({ id: Date.now(), callback });
+			this.reservedCallbacks.push({ id, callback });
 		}
 
-		return this.referenceCount;
+		return id;
 	}
 
 	public cancel(id: number) {
@@ -102,6 +105,7 @@ export class VSync {
 				} else {
 					// 모든 callbacks이 실행되어 더 이상 실행될 내용이 없다면 메모리 해제
 					this.destroy();
+					this.idCounter = 0;
 				}
 			});
 		}

--- a/packages/core/src/lib/vsync.ts
+++ b/packages/core/src/lib/vsync.ts
@@ -1,0 +1,101 @@
+declare const global: any
+const getGlobalContext = (): any => (typeof global !== undefined ? global : window);
+const INSTANCE_SYMBOL = Symbol.for('__SSGOI_CONTEXT_INSTANCE__');
+
+interface VSyncCallback {
+	id: number;
+	callback: () => void;
+}
+
+export class VSync {
+	private isRunning = false;
+	private callbacks: VSyncCallback[] = [];
+	private reservedCallbacks: VSyncCallback[] = [];
+	private requestAnimationFrameId: number | null = null;
+	// public referenceCount = 0;
+
+	constructor() {
+		this.isRunning = false;
+		this.callbacks = [];
+		this.reservedCallbacks = []; // callbacks that are waiting to be executed after the current frame
+		this.requestAnimationFrameId = null;
+	}
+
+	static getInstance() {
+		const globalContext = getGlobalContext();
+
+		if (globalContext[INSTANCE_SYMBOL] === undefined) {
+			globalContext[INSTANCE_SYMBOL] = new VSync();
+		}
+
+		// globalContext[INSTANCE_SYMBOL].referenceCount++;
+
+		return globalContext[INSTANCE_SYMBOL];
+	}
+
+	private destroy() {
+		const globalContext = getGlobalContext();
+
+		if (globalContext[INSTANCE_SYMBOL] !== undefined) {
+			// globalContext[INSTANCE_SYMBOL].referenceCount--;
+
+			if (globalContext[INSTANCE_SYMBOL].referenceCount === 0) {
+				globalContext[INSTANCE_SYMBOL] = undefined;
+			}
+		}
+	}
+
+	public request(callback: () => void) {
+		if (!this.isRunning) {
+			this.callbacks.push({ id: Date.now(), callback });
+			this.run();
+		} else {
+			this.reservedCallbacks.push({ id: Date.now(), callback });
+		}
+	}
+
+	public cancel(id: number) {
+		if (!this.isRunning) {
+			this.callbacks = [...this.callbacks.filter((cb) => cb.id !== id)];
+		} else {
+			this.reservedCallbacks = [...this.reservedCallbacks.filter((cb) => cb.id !== id)];
+		}
+	}
+
+	public static requestAnimationFrame(callback: () => void): number {
+		return VSync.getInstance().request(callback);
+	}
+
+	public static cancelAnimationFrame(id: number): void {
+		VSync.getInstance().cancel(id);
+	}
+
+	private run() {	
+		if (this.requestAnimationFrameId === null && !this.isRunning && this.callbacks.length > 0) { 
+			this.requestAnimationFrameId = requestAnimationFrame(() => {
+				this.isRunning = true;
+	
+				// callbacks에 있는 모든 콜백을 실행
+				for (const callback of this.callbacks) {
+					callback.callback();
+				}
+	
+				// run이 실행되는 중안에 요청된 reservedCallbacks를 callbacks로 이동
+				// 얕은 복사가 발생하더라도 큰 문제가 없을 듯
+				this.callbacks = this.reservedCallbacks;
+				this.reservedCallbacks = [];
+	
+				this.isRunning = false;
+				this.requestAnimationFrameId = null;
+	
+				// callbacks가 비어있지 않다면 다음 requestAnimationFrame에서 실행되도록 다시 실행
+				if (this.callbacks.length > 0) {
+					this.run();
+				} else {
+					// 모든 callbacks이 실행되어 더 이상 실행될 내용이 없다면 메모리 해제
+					this.destroy();
+				}
+			});
+		}
+	}
+}


### PR DESCRIPTION
https://velog.io/@k-svelte-master/optimize-request-animation-frame-frontend

글을 참고하여 VSync 객체를 구현했습니다.

아래와 같이 `getInstance()`를 통해 글로벌 컨텍스트에 VSync 객체를 등록하고, 외부에서는 `VSync.requestAnimationFrame()`과 `VSync.cancelAnimationFrame()`을 사용해서 기존 `requestAnimationFrame()`과 `cancelAnimationFrame()`을 대체하게 됩니다.
```typescript
static getInstance() {
  const globalContext = getGlobalContext();

  if (globalContext[INSTANCE_SYMBOL] === undefined) {
    globalContext[INSTANCE_SYMBOL] = new VSync();
  }

  return globalContext[INSTANCE_SYMBOL];
}

public static requestAnimationFrame(callback: () => void): number {
  return VSync.getInstance().request(callback);
}

public static cancelAnimationFrame(id: number): void {
  VSync.getInstance().cancel(id);
}
```

`VSync.requestAnimationFrame()`은 `request()`와 `cancel(id:number)`를 호출하며, 실제 `window.requestAnimationFrame()`이 실행중인 경우에는 `reservedCallbacks`에, 실행중이 아닐 경우에는 `callbacks`에 콜백 함수를 추가합니다. 그리고 callbacks이 비어있지 않다면 run()을 호출하여 `window.requestAnimationFrame()`을 실행합니다. 마찬가지로 `cancel(id:number)`는 `window.requestAnimationFrame()`이 실행중인 경우에는 `reservedCallbacks`에서, 실행중이 아닐 경우에는 `callbacks`에서 등록한 콜백 함수를 제거합니다.

`run()`은 `window.requestAnimationFrame()`을 실행하며, `window.requestAnimationFrame()`에 의해 등록된 `callbacks`들이 처리되는 중에는 `isRunning` 값을 `true`로 변경합니다. 이후 `callbacks`에 등록된 함수들이 처리가 완료되면 `reservedCallbacks`에 등록된 함수를 `callbacks`로 옮기는 과정을 반복하며, 더 이상 `request()`에 의해 콜백이 등록되지 않을 때 까지 `window.requestAnimationFrame()`을 요청하게 됩니다.

더 이상 처리해야 할 콜백이 없다면 `destroy()`를 통해 자원을 정리합니다. 처음에는 레퍼런스 카운터에 대한 얘기가 있었는데요. 더 이상 처리할 콜백 함수가 없을 때 자원을 정리하는 방식으로 구현하게 됐을 때 레퍼런스 카운터를 추적하는게 큰 의미가 없는 것 같아서, 관련 코드는 제거했습니다.
```typescript
private getNextId(): number {
  return (this.idCounter++ % Number.MAX_SAFE_INTEGER);
}

public request(callback: () => void) {
  const id:number = this.getNextId();

  if (!this.isRunning) {
    this.callbacks.push({ id, callback });
    this.run();
  } else {
    this.reservedCallbacks.push({ id, callback });
  }

  return id;
}

public cancel(id: number) {
  if (!this.isRunning) {
    this.callbacks = [...this.callbacks.filter((cb) => cb.id !== id)];
    if (this.callbacks.length === 0 && this.requestAnimationFrameId !== null) {
      cancelAnimationFrame(this.requestAnimationFrameId);
      this.requestAnimationFrameId = null;
      this.isRunning = false;
    }
  } else {
    this.reservedCallbacks = [...this.reservedCallbacks.filter((cb) => cb.id !== id)];
  }
}

private run() {	
  if (this.requestAnimationFrameId === null && !this.isRunning && this.callbacks.length > 0) { 
      this.requestAnimationFrameId = requestAnimationFrame(() => {
        this.isRunning = true;
	
        // callbacks에 있는 모든 콜백을 실행
        for (const callback of this.callbacks) {
          callback.callback();
        }
	
        // run이 실행되는 중안에 요청된 reservedCallbacks를 callbacks로 이동
        // 얕은 복사가 발생하더라도 큰 문제가 없을 듯
        this.callbacks = this.reservedCallbacks;
        this.reservedCallbacks = [];
	
        this.isRunning = false;
        this.requestAnimationFrameId = null;
	
        // callbacks가 비어있지 않다면 다음 requestAnimationFrame에서 실행되도록 다시 실행
        if (this.callbacks.length > 0) {
          this.run();
        } else {
          // 모든 callbacks이 실행되어 더 이상 실행될 내용이 없다면 메모리 해제
          this.destroy();
        }
      });
  }
}

private destroy() {
  const globalContext = getGlobalContext();

  if (globalContext[INSTANCE_SYMBOL] !== undefined) {
    globalContext[INSTANCE_SYMBOL] = undefined;
  }
}
```