### PR TITLE
fix: docs landing link

### DIFF
--- a/apps/docs/src/app/[lang]/page.tsx
+++ b/apps/docs/src/app/[lang]/page.tsx
@@ -336,7 +336,7 @@ export default function Home() {
                 </p>
                 <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
                   <Link
-                    href="/ko/docs/getting-started/installation"
+                    href="/ko/docs/getting-started/introduction"
                     className="btn-primary text-lg"
                   >
                     <Zap className="h-5 w-5" />


### PR DESCRIPTION
# Fix incorrect documentation link (href) on landing page
## Changes
- Updated the "문서보기" button href on the docs landing page to the correct path:` /ko/docs/getting-started/introduction.`

## Background & Motivation
- Previously, clicking the "문서보기" button would navigate to an incorrect or broken path, preventing users from accessing the Getting Started documentation directly.
- This fix ensures users are directed to the correct introduction page as intended.
## Impact
- Affects only the CTA ("문서보기") button link on the docs landing page.
- No other UI or functional changes.