### PR TITLE
feat(docs): add Japanese language support

### DIFF
--- a/apps/docs/content/ja/01.getting-started/01.introduction.mdx
+++ b/apps/docs/content/ja/01.getting-started/01.introduction.mdx
@@ -1,0 +1,89 @@
+---
+title: "SSGOIの紹介"
+description: "SSGOIは、ウェブ上でネイティブアプリのようなスムーズなページ遷移アニメーションを実現するライブラリです。"
+nav-title: "はじめに"
+---
+
+<Note type="tip">SSGOIは「スゴイ」と発音し、素晴らしいという意味です！</Note>
+
+<Demo autoPlay={false} />
+
+## なぜSSGOI？
+
+### 1. すべてのブラウザで動作
+
+ブラウザのChrome View Transition APIとは異なり、SSGOIはすべての最新ブラウザで一貫した体験を提供します。Chrome、Firefox、Safariで同じアニメーションが動作することを保証します。
+
+<Grid cols={3}>
+  <Card title="Chrome">
+    <Badge variant="success">✓ 完全サポート</Badge>
+  </Card>
+  <Card title="Firefox">
+    <Badge variant="success">✓ 完全サポート</Badge>
+  </Card>
+  <Card title="Safari">
+    <Badge variant="success">✓ 完全サポート</Badge>
+  </Card>
+</Grid>
+
+### 2. 完璧なサーバーサイドレンダリングサポート
+
+- **SSR/SSG対応**: Next.js、Nuxt、SvelteKitでハイドレーション問題なく完璧に動作
+- **SEOフレンドリー**: アニメーションは検索エンジン最適化に影響しません
+- **最適化された初期ロード**: サーバーレンダリングされたHTMLをそのまま活用
+
+### 3. フレームワークのルーティングをそのまま使用
+
+<Note>
+  SSGOIは既存のルーティングシステムと完全に互換性があります。ルーターを変更する必要はありません！
+</Note>
+
+フレームワークのルーティングをそのまま使用しながら、アニメーションを追加できます。Next.jsの`Link`、SvelteKitの`goto`、Vue Routerなど、すべてのルーティングアプローチと互換性があります。
+
+## 主な機能
+
+<CodeDemo>
+```typescript
+// わずか数行のコードで始められます
+const config = {
+  defaultTransition: fade(),
+  transitions: [
+    {
+      from: '/home',
+      to: '/about',
+      transition: slide({ direction: 'left' })
+    }
+  ]
+}
+```
+</CodeDemo>
+
+### 🎨 豊富なトランジションエフェクト
+
+- **フェード**: スムーズなフェードイン/アウト
+- **スライド**: 方向性のあるスライド
+- **スケール**: ズームイン/アウトエフェクト
+- **ヒーロー**: 共有要素アニメーション
+- **Pinterest**: Pinterestスタイルの展開
+- **リップル**: Material Designリップルエフェクト
+
+### ⚡ 最適化されたパフォーマンス
+
+- スプリングベースの物理アニメーションによる自然な動き
+- 小さなバンドルサイズ（< 20KB gzipped）
+- 使用する機能のみを含めるTree-shakingサポート
+
+### 🛠️ 開発者フレンドリー
+
+- 完全なTypeScriptサポート
+- 直感的なAPI設計
+- 豊富なドキュメントとサンプル
+- React、Svelte、Vueを含むすべての主要フレームワークのサポート
+
+## はじめに
+
+<Note type="info">
+  SSGOIは現在、ReactとSvelteを公式にサポートしており、Vueサポートは近日公開予定です。
+</Note>
+
+次のセクションのクイックスタートガイドを通じて、SSGOIをプロジェクトに適用する方法を学びましょう！

--- a/apps/docs/content/ja/01.getting-started/02.quick-start.mdx
+++ b/apps/docs/content/ja/01.getting-started/02.quick-start.mdx
@@ -1,0 +1,231 @@
+---
+title: "クイックスタート"
+description: "5分でSSGOIを使った初めてのページ遷移アニメーションを作成"
+nav-title: "クイックスタート"
+---
+
+import { Tabs, TabPanel } from "@/components/docs/mdx-components/tabs";
+
+## パッケージのインストール
+
+<Tabs
+  items={[
+    { label: "React", value: "react" },
+    { label: "Svelte", value: "svelte" },
+  ]}
+  defaultValue="react"
+>
+  <TabPanel value="react">
+    ```bash 
+    npm install @ssgoi/react 
+    # or yarn add @ssgoi/react 
+    # or pnpm add @ssgoi/react 
+    ```
+  </TabPanel>
+  <TabPanel value="svelte">
+    ```bash 
+    npm install @ssgoi/svelte 
+    # or yarn add @ssgoi/svelte 
+    # or pnpm add @ssgoi/svelte 
+    ```
+  </TabPanel>
+</Tabs>
+
+## 基本セットアップ（2分）
+
+<Tabs
+  items={[
+    { label: "React", value: "react" },
+    { label: "Svelte", value: "svelte" },
+  ]}
+  defaultValue="react"
+>
+  <TabPanel value="react">
+    ### 1. ルートレイアウトの設定 (Next.js App Router)
+
+    ```tsx
+    // app/layout.tsx
+    import { Ssgoi } from "@ssgoi/react";
+    import { fade } from "@ssgoi/react/view-transitions";
+
+    export default function RootLayout({
+      children,
+    }: {
+      children: React.ReactNode;
+    }) {
+      return (
+        <html>
+          <body>
+            <Ssgoi config={{ defaultTransition: fade() }}>
+              {/* ⚠️ 重要: position: relativeが必要です！ */}
+              <div style={{ position: "relative", minHeight: "100vh" }}>
+                {children}
+              </div>
+            </Ssgoi>
+          </body>
+        </html>
+      );
+    }
+    ```
+
+    > **なぜposition: relativeが必要なのか？**
+    > ページがアニメーションで出ていくとき、`position: absolute`が適用されます。親要素に`position: relative`がないと、ページが間違った位置に移動する可能性があります。
+
+    ### 2. ページのラップ
+
+    ```tsx
+    // app/page.tsx
+    import { SsgoiTransition } from "@ssgoi/react";
+
+    export default function HomePage() {
+      return (
+        <SsgoiTransition id="/">
+          <main>
+            <h1>ホームページ</h1>
+            {/* ページコンテンツ */}
+          </main>
+        </SsgoiTransition>
+      );
+    }
+
+    // app/about/page.tsx
+    export default function AboutPage() {
+      return (
+        <SsgoiTransition id="/about">
+          <main>
+            <h1>紹介ページ</h1>
+            {/* ページコンテンツ */}
+          </main>
+        </SsgoiTransition>
+      );
+    }
+    ```
+
+  </TabPanel>
+  <TabPanel value="svelte">
+    ### 1. ルートレイアウトの設定 (SvelteKit)
+
+    ```svelte
+    <!-- src/routes/+layout.svelte -->
+    <script>
+      import { Ssgoi } from "@ssgoi/svelte";
+      import { fade } from "@ssgoi/svelte/view-transitions";
+    </script>
+
+    <Ssgoi config={{ defaultTransition: fade() }}>
+      <!-- ⚠️ 重要: position: relativeが必要です！ -->
+      <div style="position: relative; min-height: 100vh;">
+        <slot />
+      </div>
+    </Ssgoi>
+    ```
+
+    > **なぜposition: relativeが必要なのか？**
+    > ページがアニメーションで出ていくとき、`position: absolute`が適用されます。親要素に`position: relative`がないと、ページが間違った位置に移動する可能性があります。
+
+    ### 2. ページのラップ
+
+    ```svelte
+    <!-- src/routes/+page.svelte -->
+    <script>
+      import { SsgoiTransition } from "@ssgoi/svelte";
+    </script>
+
+    <SsgoiTransition id="/">
+      <main>
+        <h1>ホームページ</h1>
+        <!-- ページコンテンツ -->
+      </main>
+    </SsgoiTransition>
+    ```
+
+    ```svelte
+    <!-- src/routes/about/+page.svelte -->
+    <script>
+      import { SsgoiTransition } from "@ssgoi/svelte";
+    </script>
+
+    <SsgoiTransition id="/about">
+      <main>
+        <h1>紹介ページ</h1>
+        <!-- ページコンテンツ -->
+      </main>
+    </SsgoiTransition>
+    ```
+
+  </TabPanel>
+</Tabs>
+
+## 様々なトランジションの適用
+
+<Tabs
+  items={[
+    { label: "React", value: "react" },
+    { label: "Svelte", value: "svelte" },
+  ]}
+  defaultValue="react"
+>
+  <TabPanel value="react">
+    ```tsx
+    // app/layout.tsx
+    import { slide, fade, scale } from "@ssgoi/react/view-transitions";
+
+    const ssgoiConfig = {
+      transitions: [
+        // ホーム → 紹介: 左にスライド
+        { from: "/", to: "/about", transition: slide({ direction: "left" }) },
+        // 紹介 → ホーム: 右にスライド
+        { from: "/about", to: "/", transition: slide({ direction: "right" }) },
+        // リスト → 詳細: スケール
+        { from: "/list", to: "/detail/*", transition: scale() },
+      ],
+    };
+
+    export default function RootLayout({ children }) {
+      return (
+        <html>
+          <body>
+            <Ssgoi config={ssgoiConfig}>
+              <div style={{ position: "relative", minHeight: "100vh" }}>
+                {children}
+              </div>
+            </Ssgoi>
+          </body>
+        </html>
+      );
+    }
+    ```
+
+  </TabPanel>
+  <TabPanel value="svelte">
+    ```svelte
+    <!-- src/routes/+layout.svelte -->
+    <script>
+      import { Ssgoi } from "@ssgoi/svelte";
+      import { slide, fade, scale } from "@ssgoi/svelte/view-transitions";
+
+      const ssgoiConfig = {
+        transitions: [
+          // ホーム → 紹介: 左にスライド
+          { from: "/", to: "/about", transition: slide({ direction: "left" }) },
+          // 紹介 → ホーム: 右にスライド
+          { from: "/about", to: "/", transition: slide({ direction: "right" }) },
+          // リスト → 詳細: スケール
+          { from: "/list", to: "/detail/*", transition: scale() },
+        ],
+      };
+    </script>
+
+    <Ssgoi config={ssgoiConfig}>
+      <div style="position: relative; min-height: 100vh;">
+        <slot />
+      </div>
+    </Ssgoi>
+    ```
+
+  </TabPanel>
+</Tabs>
+
+## 完成！ 🎉
+
+おめでとうございます！あなたのウェブサイトにネイティブアプリのようなページ遷移が適用されました。

--- a/apps/docs/content/ja/02.core-concepts/01.element-transitions.mdx
+++ b/apps/docs/content/ja/02.core-concepts/01.element-transitions.mdx
@@ -1,0 +1,164 @@
+---
+title: "要素アニメーション"
+description: "個々のDOM要素にアニメーションを適用"
+nav-title: "要素アニメーション"
+---
+
+import { TransitionPlayground } from '@/components/transition-playground';
+import { Tabs, TabPanel } from '@/components/mdx-components';
+
+## トランジションプレイグラウンド
+
+様々なトランジション効果を直接体験してください：
+
+<TransitionPlayground />
+
+## 基本構造
+
+### TransitionConfigインターフェース
+
+```typescript
+interface TransitionConfig {
+  spring?: {
+    stiffness: number; // スプリングの硅さ (デフォルト: 300)
+    damping: number; // 減衰係数 (デフォルト: 30)
+  };
+  tick?: (progress: number) => void; // in: 0→1, out: 1→0
+  prepare?: (element: HTMLElement) => void; // アニメーション開始前の初期設定
+  onStart?: () => void;
+  onEnd?: () => void;
+}
+```
+
+### トランジションの定義
+
+```typescript
+interface Transition {
+  in?: (element: HTMLElement) => TransitionConfig;
+  out?: (element: HTMLElement) => TransitionConfig;
+}
+```
+
+### 動作の仕組み
+
+1. **マウント時**: 要素がDOMに追加されたとき`in`関数を実行
+2. **アンマウント時**: 要素が削除される前に`out`関数を実行
+3. **アニメーション**: スプリング物理エンジンがprogressを生成
+   - in: 0 → 1
+   - out: 1 → 0
+4. **tickコールバック**: 毎フレーム呼び出されてスタイルを更新
+
+### トランジションプリセット
+
+```typescript
+import { fade, scale /** etc */ } from "@ssgoi/react/transitions";
+```
+
+## フレームワーク別の使用方法
+
+<Tabs items={[{ label: "React", value: "react" }, { label: "Svelte", value: "svelte" }]}>
+  <TabPanel value="react">
+    ```jsx
+    import { transition } from "@ssgoi/react";
+
+    <div
+      ref={transition({
+        key: "unique-key",
+        in: (element) => ({
+          tick: (progress) => {
+            element.style.opacity = progress;
+            element.style.transform = `translateY(${20 * (1 - progress)}px)`;
+          },
+        }),
+        out: (element) => ({
+          tick: (progress) => {
+            element.style.opacity = 1 - progress;
+          },
+        }),
+      })}
+    >
+      コンテンツ
+    </div>
+    ```
+  </TabPanel>
+  
+  <TabPanel value="svelte">
+    ```svelte
+    <script>
+      import { transition } from '@ssgoi/svelte';
+    </script>
+
+    <div use:transition={{
+      key: 'unique-key',
+      in: (element) => ({
+        tick: (progress) => {
+          element.style.opacity = progress;
+          element.style.transform = `translateY(${20 * (1 - progress)}px)`;
+        }
+      }),
+      out: (element) => ({
+        tick: (progress) => {
+          element.style.opacity = 1 - progress;
+        }
+      })
+    }}>
+      コンテンツ
+    </div>
+    ```
+  </TabPanel>
+</Tabs>
+
+## Progressの動作
+
+### inアニメーション
+
+- progress: 0 → 1
+- 要素が表示されるときに実行
+- 不透明度が0から1へ、小さいサイズから元のサイズへ
+
+### outアニメーション
+
+- progress: 1 → 0
+- 要素が消えるときに実行
+- 不透明度が1から0へ、元のサイズから小さいサイズへ
+
+```jsx
+// 例： inとoutの違い
+{
+  in: (element) => ({
+    tick: (progress) => {
+      // progress: 0 → 1
+      element.style.opacity = progress;  // 0 → 1
+    }
+  }),
+  out: (element) => ({
+    tick: (progress) => {
+      // progress: 1 → 0
+      element.style.opacity = progress;  // 1 → 0
+    }
+  })
+}
+```
+
+## prepareコールバック
+
+アニメーション開始前にDOM要素を準備する段階：
+
+```jsx
+{
+  in: {
+    prepare: (element) => {
+      // tick実行前に初期状態を設定
+      element.style.willChange = 'opacity, transform';
+    },
+    tick: (progress) => ({
+      opacity: progress,
+      transform: `translateY(${20 * (1 - progress)}px)`
+    })
+  }
+}
+```
+
+## 重要な注意事項
+
+- `key`はページ内で一意である必要があります（DOMが作成された後削除されたり、削除された後作成されたりしてもアニメーション状態を追跡できるようにするため）

--- a/apps/docs/content/ja/02.core-concepts/02.view-transitions.md
+++ b/apps/docs/content/ja/02.core-concepts/02.view-transitions.md
@@ -1,0 +1,175 @@
+---
+title: "ページトランジション"
+description: "ルートベースのページ遷移システム"
+nav-title: "ページトランジション"
+---
+
+## 設定インターフェース
+
+### SsgoiConfig
+
+```typescript
+interface SsgoiConfig {
+  transitions: Array<{
+    from: string; // 遷移元のルートパターン
+    to: string; // 遷移先のルートパターン
+    transition: SggoiTransition;
+    symmetric?: boolean; // 双方向トランジションを自動生成
+  }>;
+  defaultTransition?: SggoiTransition;
+}
+```
+
+### 基本設定
+
+```jsx
+import { Ssgoi } from "@ssgoi/react";
+import { fade, slide } from "@ssgoi/react/view-transitions";
+
+const config = {
+  defaultTransition: fade(),
+  transitions: [
+    { from: "/", to: "/about", transition: slide({ direction: "left" }) },
+    { from: "/about", to: "/", transition: slide({ direction: "right" }) },
+  ],
+};
+
+<Ssgoi config={config}>{children}</Ssgoi>;
+```
+
+## ルートマッチングルール
+
+### パターンタイプ
+
+1. **完全一致**: `/home` → `/home`と完全に一致
+2. **ワイルドカードサフィックス**: `/products/*` → `/products/123`にマッチ
+3. **完全ワイルドカード**: `*` → すべてのルートにマッチ
+
+### マッチング優先度
+
+より具体的なパターンが優先されます：
+
+```javascript
+transitions: [
+  // 第1優先: 完全一致
+  { from: "/blog/post-1", to: "/blog/post-2", transition: slide() },
+
+  // 第2優先: ワイルドカードマッチ
+  { from: "/blog/*", to: "/blog/*", transition: fade() },
+
+  // 第3優先: defaultTransition
+];
+```
+
+## 対称オプション
+
+双方向トランジションを自動生成します：
+
+```javascript
+{
+  from: '/home',
+  to: '/about',
+  transition: fade(),
+  symmetric: true  // 逆方向のトランジションを自動生成
+}
+
+// 上記の設定は以下のように動作します：
+// /home → /about: fade
+// /about → /home: fade (自動生成)
+```
+
+## ビュートランジションの構造
+
+ビュートランジションは要素トランジションと同じ構造に従います：
+
+```typescript
+interface ViewTransition {
+  in?: (
+    element: HTMLElement,
+    context?: SggoiTransitionContext
+  ) => TransitionConfig;
+  out?: (
+    element: HTMLElement,
+    context?: SggoiTransitionContext
+  ) => TransitionConfig;
+}
+```
+
+- **out**: fromページ（退出するページ）に適用
+- **in**: toページ（入ってくるページ）に適用
+
+## コンテキストオブジェクト
+
+前のページと現在のページ間のスクロール差がビュートランジションの第2引数として渡されます：
+
+```typescript
+interface SggoiTransitionContext {
+  scrollOffset: {
+    x: number; // 前のページと現在のページ間のスクロールX差
+    y: number; // 前のページと現在のページ間のスクロールY差
+  };
+}
+
+// 例： スクロールを考慮したトランジション
+const scrollAwareTransition = {
+  in: (element, context) => {
+    const { scrollOffset } = context;
+    return {
+      prepare: (el) => {
+        // スクロール差分移動した状態から開始
+        el.style.transform = `translateY(${-scrollOffset.y}px)`;
+      },
+      tick: (progress) => ({
+        // 元の位置に戻る
+        transform: `translateY(${-scrollOffset.y * (1 - progress)}px)`,
+      }),
+    };
+  },
+};
+```
+
+## SsgoiTransitionコンポーネント
+
+各ページをラップするラッパーコンポーネント：
+
+```jsx
+<SsgoiTransition id="/page-path">
+  <PageContent />
+</SsgoiTransition>
+```
+
+- `id`: ルートマッチングに使用される識別子
+- このIDはconfigのfrom/toパターンとマッチングされます
+
+## 動作フロー
+
+1. **ルート変更検出**: ルーターがルートを変更
+2. **パターンマッチング**: from/toパターンを使用して適用するトランジションを找す
+3. **Outアニメーション**: 現在のページにoutトランジションを適用
+4. **同期**: outとinアニメーションの準備を待つ
+5. **Inアニメーション**: 新しいページにinトランジションを適用
+6. **完了**: 両方のアニメーションが完了したらクリーンアップ
+
+## 実用例
+
+### 階層ナビゲーション
+
+```javascript
+const config = {
+  transitions: [
+    // リスト → 詳細
+    {
+      from: "/products",
+      to: "/products/*",
+      transition: scale({ from: 0.95 }),
+      symmetric: true, // 詳細 → リストも自動処理
+    },
+
+    // タブナビゲーション
+    { from: "/tab1", to: "/tab2", transition: slide({ direction: "left" }) },
+    { from: "/tab2", to: "/tab3", transition: slide({ direction: "left" }) },
+    { from: "/tab3", to: "/tab2", transition: slide({ direction: "right" }) },
+    { from: "/tab2", to: "/tab1", transition: slide({ direction: "right" }) },
+  ],
+};
+```

--- a/apps/docs/content/ja/03.view-transitions/no-content.md
+++ b/apps/docs/content/ja/03.view-transitions/no-content.md
@@ -1,0 +1,9 @@
+---
+title: "Coming Soon"
+description: "Page transition preset documentation coming soon"
+nav-title: "Coming Soon"
+---
+
+# Coming Soon
+
+Detailed documentation for page transition presets is being prepared.

--- a/apps/docs/content/ja/04.transitions/no-content.md
+++ b/apps/docs/content/ja/04.transitions/no-content.md
@@ -1,0 +1,9 @@
+---
+title: "Coming Soon"
+description: "Element animation preset documentation coming soon"
+nav-title: "Coming Soon"
+---
+
+# Coming Soon
+
+Detailed documentation for element animation presets is being prepared.

--- a/apps/docs/src/i18n/messages/ja.tsx
+++ b/apps/docs/src/i18n/messages/ja.tsx
@@ -1,0 +1,139 @@
+import { Messages } from "./types";
+
+const ja: Messages = {
+  header: {
+    home: "ホーム",
+    blog: "ブログ",
+    github: "Github",
+    docs: "ドキュメント",
+    tutorial: "チュートリアル",
+    contributing: "貢献",
+    showcase: "ショーケース",
+    openMenu: "メニューを開く",
+    githubRepository: "GitHubリポジトリ",
+  },
+  home: {
+    title: "モダンウェブアプリのための\n美しいページトランジション",
+    getStarted: "はじめる",
+    readMore: "ドキュメントを読む",
+    // Hero Section
+    badge: {
+      text: "SSR対応",
+    },
+    heroTitle: {
+      line1: "ビュー",
+      line2: "トランジション",
+    },
+    subtitle: (
+      <>
+        ウェブに<span className="font-semibold text-white">ネイティブアプリのようなページトランジション</span>を構築。
+      </>
+    ),
+    description: "Next.js、Nuxt、SvelteKitなどのすべてのSSRフレームワークと完全に互換性があります。SEOを犠牲にすることなく、素晴らしいアニメーションを作成できます。",
+    buttons: {
+      getStarted: "はじめる",
+      github: "GitHub",
+    },
+    quickInstall: {
+      react: "React",
+      svelte: "Svelte",
+      vue: "Vue (近日公開)",
+      solidjs: "SolidJS (近日公開)",
+      qwik: "Qwik (近日公開)",
+    },
+    floatingBadges: {
+      performance: "常に60fps",
+      stateMemory: "状態記憶",
+    },
+    // Framework Support Section
+    frameworks: {
+      title: (
+        <>
+          <span className="gradient-orange">すべての環境</span>で同じ体験
+        </>
+      ),
+      subtitle: "フレームワークに関係なく一貫したAPIを使用",
+      comingSoon: "(近日公開)",
+    },
+    // Why SSGOI Section
+    whySSGOI: {
+      title: (
+        <>
+          なぜ<span className="gradient-orange">SSGOI</span>？
+        </>
+      ),
+      subtitle: "この3つを覚えるだけ",
+      features: {
+        ssr: {
+          title: "完璧なSSRサポート",
+          description: "Next.js、Nuxt、SvelteKitなどのSSRフレームワークで完璧に動作します。SEOを犠牲にすることなく、美しいページトランジションを作成できます。",
+        },
+        browserCompat: {
+          title: "すべてのブラウザ対応",
+          description: "Chrome、Firefox、Safari、すべての最新ブラウザで一貫した体験を提供します。",
+        },
+        zeroConfig: {
+          title: "ゼロ設定",
+          description: "フレームワークのルーティングをそのまま使用。複雑な設定なしにすぐに開始できます。",
+        },
+      },
+    },
+    // Code Example Section
+    codeExample: {
+      title: (
+        <>
+          驚くほど<span className="gradient-orange">シンプルなコード</span>
+        </>
+      ),
+      subtitle: "わずか数行でページトランジションアニメーションを実装",
+    },
+    // CTA Section
+    cta: {
+      title: "今すぐ始める",
+      subtitle: "必要なのは5分だけ。SSGOIでウェブにネイティブアプリ体験を追加しましょう。",
+      buttons: {
+        viewDocs: "ドキュメントを見る",
+        github: "GitHub",
+      },
+    },
+  },
+  metadata: {
+    title: "SSGOI - モダンウェブアプリのための美しいページトランジション",
+    description:
+      "SSGOIは、ウェブにネイティブアプリのようなアニメーションをもたらす強力なページトランジションライブラリです。すべてのフレームワークで状態保持を備えたスムーズなスプリングベースのトランジションを作成します。",
+    keywords: [
+      "ページトランジション",
+      "アニメーションライブラリ",
+      "reactトランジション",
+      "vueトランジション",
+      "svelteトランジション",
+      "スプリングアニメーション",
+      "ビュートランジション",
+      "ウェブアニメーション",
+      "ssgoi",
+    ],
+    og: {
+      title: "SSGOI - モダンウェブアプリのための美しいページトランジション",
+      description:
+        "SSGOIで素晴らしいページトランジションを作成。ネイティブアプリのようなアニメーション、状態保持、フレームワーク非依存設計。React、Vue、Svelteなどで動作します。",
+      siteName: "SSGOI",
+      imageAlt: "SSGOI - ページトランジションライブラリ",
+    },
+    twitter: {
+      title: "SSGOI - モダンウェブアプリのための美しいページトランジション",
+      description:
+        "SSGOIで素晴らしいページトランジションを作成。ネイティブアプリのようなアニメーション、状態保持、フレームワーク非依存設計。",
+      imageAlt: "SSGOI - ページトランジションライブラリ",
+    },
+  },
+  sidebar: {
+    categories: {
+      "getting-started": "はじめに",
+      "core-concepts": "コアコンセプト",
+      "view-transitions": "ビュートランジション",
+      "transitions": "トランジション",
+    },
+  },
+};
+
+export default ja;

--- a/apps/docs/src/i18n/supported-languages.ts
+++ b/apps/docs/src/i18n/supported-languages.ts
@@ -11,6 +11,10 @@ export const LANGUAGE_LIST = [
     title: "한국어",
     locale: "ko",
   },
+  {
+    title: "日本語",
+    locale: "ja",
+  },
 ];
 
 export const SUPPORTED_LANGUAGES = LANGUAGE_LIST.map(


### PR DESCRIPTION
## Summary
- Added Japanese language support to the documentation site
- Created complete Japanese translations for all existing documentation
- Added Japanese UI messages for navigation and home page

## Changes
- **Language Configuration**: Added Japanese (ja) to supported languages in `supported-languages.ts`
- **Documentation Translation**: Translated all documentation pages to Japanese
  - Getting Started section (introduction, quick start)
  - Core Concepts section (element transitions, page transitions)
- **UI Messages**: Added Japanese translations in `messages/ja.tsx` for:
  - Header navigation
  - Home page content
  - Sidebar categories
  - Metadata/SEO content

## Test Plan
- [ ] Verify language switcher shows Japanese option
- [ ] Check all Japanese documentation pages render correctly
- [ ] Confirm navigation and UI elements display in Japanese
- [ ] Test that code examples remain in English (as intended)
- [ ] Verify no broken links or missing translations

🤖 Generated with [Claude Code](https://claude.ai/code)