### PR TITLE
feat(docs): add smooth scroll transitions between documentation pages

### DIFF
--- a/apps/docs/src/app/[lang]/docs/[...path]/page.tsx
+++ b/apps/docs/src/app/[lang]/docs/[...path]/page.tsx
@@ -1,41 +1,44 @@
-import { notFound } from 'next/navigation'
-import { getPost, getNavigationData } from '@/lib/post'
-import { MDXContent } from './mdx-content'
-import { DocsNavigation } from '@/components/docs/docs-navigation'
-import { findNavigationLinks } from '@/lib/navigation-utils'
+import { notFound } from "next/navigation";
+import { getPost, getNavigationData } from "@/lib/post";
+import { MDXContent } from "./mdx-content";
+import { DocsNavigation } from "@/components/docs/docs-navigation";
+import { findNavigationLinks } from "@/lib/navigation-utils";
+import { SsgoiTransition } from "@/components/docs/ssgoi";
 
 interface DocsPageProps {
   params: Promise<{
-    lang: string
-    path: string[]
-  }>
+    lang: string;
+    path: string[];
+  }>;
 }
 
 export default async function DocsPage({ params }: DocsPageProps) {
-  const { lang, path } = await params
-  const postPath = path.join('/')
-  
+  const { lang, path } = await params;
+  const postPath = path.join("/");
+
   const [post, navigation] = await Promise.all([
     getPost(lang, postPath),
-    getNavigationData(lang)
-  ])
-  
+    getNavigationData(lang),
+  ]);
+
   if (!post) {
-    notFound()
+    notFound();
   }
-  
+
   // Find previous and next navigation links
-  const currentPath = `/${lang}/docs/${postPath}`
-  const { prev, next } = findNavigationLinks(navigation, currentPath, lang)
-  
+  const currentPath = `/${lang}/docs/${postPath}`;
+  const { prev, next } = findNavigationLinks(navigation, currentPath, lang);
+
   return (
-    <article className="max-w-none">
-      <h1 className="text-4xl font-bold mb-4 text-white">{post.title}</h1>
-      {post.description && (
-        <p className="text-xl text-gray-400 mb-8">{post.description}</p>
-      )}
-      {await MDXContent({ content: post.content })}
-      <DocsNavigation prev={prev} next={next} lang={lang} />
-    </article>
-  )
+    <SsgoiTransition id={postPath}>
+      <article className="max-w-none">
+        <h1 className="text-4xl font-bold mb-4 text-white">{post.title}</h1>
+        {post.description && (
+          <p className="text-xl text-gray-400 mb-8">{post.description}</p>
+        )}
+        {await MDXContent({ content: post.content })}
+        <DocsNavigation prev={prev} next={next} lang={lang} />
+      </article>
+    </SsgoiTransition>
+  );
 }

--- a/apps/docs/src/app/[lang]/docs/layout.tsx
+++ b/apps/docs/src/app/[lang]/docs/layout.tsx
@@ -1,6 +1,7 @@
 import { getNavigationData } from "@/lib/post";
 import { Sidebar } from "./sidebar";
 import { NavigationSetter } from "@/components/layout/navigation-setter";
+import { DocsSsgoi } from "@/components/docs/ssgoi";
 
 interface DocsLayoutProps {
   children: React.ReactNode;
@@ -30,7 +31,9 @@ export default async function DocsLayout({
             {/* Main content */}
             <main className="flex-1 min-w-0">
               <div className="py-8">
-                <div className="mx-auto max-w-4xl">{children}</div>
+                <div className="mx-auto max-w-4xl relative overflow-hidden">
+                  <DocsSsgoi navigation={navigation}>{children}</DocsSsgoi>
+                </div>
               </div>
             </main>
           </div>

--- a/apps/docs/src/components/docs/ssgoi.tsx
+++ b/apps/docs/src/components/docs/ssgoi.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+export { SsgoiTransition } from "@ssgoi/react";
+
+import { useMemo } from "react";
+import { NavigationItem } from "@/lib/post";
+import { Ssgoi as _Ssgoi } from "@ssgoi/react";
+import { scroll } from "@ssgoi/react/view-transitions";
+import { SsgoiConfig } from "@ssgoi/core";
+import { useMobile } from "@/lib/use-mobile";
+
+// Helper function to create transitions between adjacent pages
+function createAdjacentTransitions(
+  navigation: NavigationItem[]
+): SsgoiConfig["transitions"] {
+  // Extract leaf nodes
+  const leafNodes: NavigationItem[] = [];
+
+  function traverse(item: NavigationItem) {
+    if (!item.children || item.children.length === 0) {
+      leafNodes.push(item);
+    } else {
+      item.children.forEach(traverse);
+    }
+  }
+
+  navigation.forEach(traverse);
+
+  // Create transitions
+  const transitions: SsgoiConfig["transitions"] = [];
+
+  for (let i = 0; i < leafNodes.length - 1; i++) {
+    const current = leafNodes[i];
+    const next = leafNodes[i + 1];
+
+    // Forward transition (current -> next)
+    transitions.push({
+      from: current.path,
+      to: next.path,
+      transition: scroll({
+        direction: "up",
+        spring: { stiffness: 20, damping: 7 },
+      }),
+    });
+
+    // Backward transition (next -> current)
+    transitions.push({
+      from: next.path,
+      to: current.path,
+      transition: scroll({
+        direction: "down",
+        spring: { stiffness: 20, damping: 7 },
+      }),
+    });
+  }
+
+  return transitions;
+}
+
+export function DocsSsgoi({
+  children,
+  navigation,
+}: {
+  children: React.ReactNode;
+  navigation: NavigationItem[];
+}) {
+  const isMobile = useMobile();
+  const transitions = useMemo(
+    () => createAdjacentTransitions(navigation),
+    [navigation]
+  );
+
+  return (
+    <_Ssgoi
+      config={{
+        transitions: isMobile ? [] : transitions,
+      }}
+    >
+      {children}
+    </_Ssgoi>
+  );
+}

--- a/apps/docs/src/lib/post.ts
+++ b/apps/docs/src/lib/post.ts
@@ -19,7 +19,7 @@ import { getServerTranslations } from '@/i18n/get-server-translations'
  *       File extensions (.md, .mdx) are also handled automatically
  */
 
-interface NavigationItem {
+export interface NavigationItem {
   title: string
   navTitle: string
   description?: string

--- a/apps/docs/src/lib/use-mobile.ts
+++ b/apps/docs/src/lib/use-mobile.ts
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+
+const MOBILE_BREAKPOINT = 768;
+
+export function useMobile() {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    const checkMobile = () => {
+      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    };
+
+    // Check on mount
+    checkMobile();
+
+    // Add resize listener
+    window.addEventListener('resize', checkMobile);
+
+    // Cleanup
+    return () => {
+      window.removeEventListener('resize', checkMobile);
+    };
+  }, []);
+
+  return isMobile;
+}

--- a/packages/core/src/lib/view-transitions/index.ts
+++ b/packages/core/src/lib/view-transitions/index.ts
@@ -2,3 +2,4 @@ export * from "./fade";
 export * from "./hero";
 export * from "./pinterest";
 export * from "./ripple";
+export * from "./scroll";

--- a/packages/core/src/lib/view-transitions/scroll.ts
+++ b/packages/core/src/lib/view-transitions/scroll.ts
@@ -1,0 +1,39 @@
+import type { SpringConfig, SggoiTransition } from "../types";
+import { prepareOutgoing } from "../utils";
+
+interface ScrollOptions {
+  direction?: "up" | "down";
+  spring?: Partial<SpringConfig>;
+}
+
+export const scroll = (options: ScrollOptions = {}): SggoiTransition => {
+  const direction = options.direction ?? "up";
+  const spring: SpringConfig = {
+    stiffness: options.spring?.stiffness ?? 300,
+    damping: options.spring?.damping ?? 30,
+  };
+
+  const isUp = direction === "up";
+
+  return {
+    in: (element) => ({
+      spring,
+      tick: (progress) => {
+        const translateY = isUp
+          ? (1 - progress) * 100 // 100 → 0
+          : (1 - progress) * -100; // -100 → 0
+        element.style.transform = `translateY(${translateY}%)`;
+      },
+    }),
+    out: (element) => ({
+      spring,
+      tick: (progress) => {
+        const translateY = isUp
+          ? (1 - progress) * -100 // 0 → -100
+          : (1 - progress) * 100; // 0 → 100
+        element.style.transform = `translateY(${translateY}%)`;
+      },
+      prepare: prepareOutgoing,
+    }),
+  };
+};


### PR DESCRIPTION
## Summary
- Adds smooth scroll transitions when navigating between documentation pages
- Creates a new `scroll` view transition that slides pages up/down
- Implements `DocsSsgoi` component to manage transitions between adjacent docs

## Changes
1. **New scroll transition** (`packages/core/src/lib/view-transitions/scroll.ts`)
   - Supports `up` and `down` directions
   - Uses spring physics for natural motion
   - Properly handles IN (0→1) and OUT (1→0) progress values

2. **DocsSsgoi wrapper component** (`apps/docs/src/components/docs/ssgoi.tsx`)
   - Automatically extracts leaf nodes from navigation tree
   - Creates transitions only between adjacent pages
   - Forward navigation uses "up" scroll, backward uses "down"
   - Disabled on mobile for better performance

3. **Integration**
   - Added `SsgoiTransition` wrapper to individual doc pages
   - Exported NavigationItem type for type safety
   - Added `useMobile` hook for responsive behavior

## Test plan
- [x] Test navigation between adjacent docs pages
- [x] Verify smooth scroll animations
- [x] Check that non-adjacent pages have no transitions
- [x] Confirm mobile behavior (transitions disabled)
- [x] Test browser back/forward navigation

🤖 Generated with [Claude Code](https://claude.ai/code)