### PR TITLE
build: optimize React package build by externalizing core submodules

### DIFF
--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -32,7 +32,14 @@ export default defineConfig({
       formats: ["es", "cjs"],
     },
     rollupOptions: {
-      external: ["react", "react-dom", "react/jsx-runtime", "@ssgoi/core"],
+      external: [
+        "react",
+        "react-dom",
+        "react/jsx-runtime",
+        "@ssgoi/core",
+        "@ssgoi/core/view-transitions",
+        "@ssgoi/core/transitions",
+      ],
       output: {
         preserveModules: false,
         exports: "named",


### PR DESCRIPTION
- Add @ssgoi/core/view-transitions and @ssgoi/core/transitions to external dependencies
- Prevents bundling of core transition modules into React package
- Reduces bundle size and avoids duplicate code

🤖 Generated with [Claude Code](https://claude.ai/code)