### PR TITLE
build: add rollup-plugin-preserve-directives to React package

### DIFF
--- a/apps/react-demo/app/item/[id]/page.tsx
+++ b/apps/react-demo/app/item/[id]/page.tsx
@@ -1,4 +1,4 @@
-import SsgoiTransition from "@/lib/ssgoi-transition";
+import { SsgoiTransition } from "@ssgoi/react";
 import styles from "./page.module.css";
 import Link from "next/link";
 

--- a/apps/react-demo/lib/ssgoi-transition.ts
+++ b/apps/react-demo/lib/ssgoi-transition.ts
@@ -1,5 +1,0 @@
-"use client";
-//TODO: "use client" directive on "@ssgoi/react" itself
-import { SsgoiTransition } from "@ssgoi/react";
-
-export default SsgoiTransition;

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -63,6 +63,7 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
+    "rollup-plugin-preserve-directives": "^0.4.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.35.1",
     "vite": "^7.0.4",

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import { resolve } from "path";
 import dts from "vite-plugin-dts";
+import preserveDirectives from "rollup-plugin-preserve-directives";
 
 export default defineConfig({
   plugins: [
@@ -41,7 +42,7 @@ export default defineConfig({
         "@ssgoi/core/transitions",
       ],
       output: {
-        preserveModules: false,
+        preserveModules: true,
         exports: "named",
         globals: {
           react: "React",
@@ -50,6 +51,7 @@ export default defineConfig({
           "@ssgoi/core": "@ssgoi/core",
         },
       },
+      plugins: [preserveDirectives()],
     },
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,6 +260,9 @@ importers:
       globals:
         specifier: ^16.3.0
         version: 16.3.0
+      rollup-plugin-preserve-directives:
+        specifier: ^0.4.0
+        version: 0.4.0(rollup@4.45.0)
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
@@ -3487,6 +3490,11 @@ packages:
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rollup-plugin-preserve-directives@0.4.0:
+    resolution: {integrity: sha512-gx4nBxYm5BysmEQS+e2tAMrtFxrGvk+Pe5ppafRibQi0zlW7VYAbEGk6IKDw9sJGPdFWgVTE0o4BU4cdG0Fylg==}
+    peerDependencies:
+      rollup: 2.x || 3.x || 4.x
 
   rollup@4.45.0:
     resolution: {integrity: sha512-WLjEcJRIo7i3WDDgOIJqVI2d+lAC3EwvOGy+Xfq6hs+GQuAA4Di/H72xmXkOhrIWFg2PFYSKZYfH0f4vfKXN4A==}
@@ -7813,6 +7821,12 @@ snapshots:
       supports-preserve-symlinks-flag: 1.0.0
 
   reusify@1.1.0: {}
+
+  rollup-plugin-preserve-directives@0.4.0(rollup@4.45.0):
+    dependencies:
+      '@rollup/pluginutils': 5.2.0(rollup@4.45.0)
+      magic-string: 0.30.17
+      rollup: 4.45.0
 
   rollup@4.45.0:
     dependencies:


### PR DESCRIPTION
## Summary
- Added `rollup-plugin-preserve-directives` to preserve "use client" directives in the React package build output
- Configured Vite with `preserveModules: true` to enable the plugin functionality
- Removed the workaround client-side wrapper file in react-demo app

## Test plan
- [x] Build the React package successfully
- [x] Verify that "use client" directives are preserved in the build output
- [x] Test the react-demo app to ensure it works correctly without the wrapper

🤖 Generated with [Claude Code](https://claude.ai/code)