### PR TITLE
fix(docs): github api 호출 시 에러 처리

### DIFF
--- a/apps/docs/src/components/layout/header.tsx
+++ b/apps/docs/src/components/layout/header.tsx
@@ -18,7 +18,11 @@ export function Header() {
 
   useEffect(() => {
     fetch("https://api.github.com/repos/meursyphus/ssgoi")
-      .then((res) => res.json())
+      .then((res) => {
+        if (!res.ok) throw new Error("Failed to fetch");
+
+        return res.json();
+      })
       .then((data) => {
         setStars(data.stargazers_count);
         setIsLoadingStars(false);


### PR DESCRIPTION
현재 API rate limit이 발생하여 `stars.toLocaleString`에서 `Uncaught TypeError: Cannot read properties of undefined (reading 'toLocaleString')` 에러가 발생하고 있습니다.

Star 갯수를 표시하기 위해 github repo 정보를 가져올 때 fetch 실패 시의 에러 핸들링이 누락되어 추가했습니다.
