### PR TITLE
feat: Add multilingual support for mobile menu

### DIFF
--- a/apps/docs/src/components/layout/mobile-drawer.tsx
+++ b/apps/docs/src/components/layout/mobile-drawer.tsx
@@ -9,6 +9,7 @@ import { useOutsideClick } from "@/lib/use-click-outside";
 import { LANGUAGE_LIST } from "@/i18n/supported-languages";
 import { SidebarContent } from "@/components/docs/sidebar-content";
 import { useNavigationStore } from "@/store/navigation";
+import { useTranslations } from "@/i18n/use-translations";
 
 interface MobileDrawerProps {
   isOpen: boolean;
@@ -23,6 +24,7 @@ export function MobileDrawer({ isOpen, onClose, lang }: MobileDrawerProps) {
   const { toggle: toggleSidebar } = useSidebarStore();
   const onOutsideClick = useOutsideClick();
   const navigation = useNavigationStore((state) => state.navigation);
+  const t = useTranslations("mobileMenu");
 
   // 탭 상태 관리 - 문서 페이지에서는 'docs'가 기본값
   const [activeTab, setActiveTab] = useState<"menu" | "docs">(
@@ -82,7 +84,7 @@ export function MobileDrawer({ isOpen, onClose, lang }: MobileDrawerProps) {
                     }`}
                   >
                     <BookOpen className="h-4 w-4" />
-                    문서 목차
+                    {t("documentToc")}
                   </button>
                 )}
                 <button
@@ -94,7 +96,7 @@ export function MobileDrawer({ isOpen, onClose, lang }: MobileDrawerProps) {
                   }`}
                 >
                   <Menu className="h-4 w-4" />
-                  메뉴
+                  {t("menu")}
                 </button>
               </div>
               <button
@@ -102,7 +104,7 @@ export function MobileDrawer({ isOpen, onClose, lang }: MobileDrawerProps) {
                 className="inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors hover:bg-zinc-800 h-9 w-9 text-gray-400 hover:text-white"
               >
                 <X className="h-5 w-5" />
-                <span className="sr-only">Close drawer</span>
+                <span className="sr-only">{t("closeDrawer")}</span>
               </button>
             </div>
             <div className="border-b border-zinc-800" />
@@ -125,7 +127,7 @@ export function MobileDrawer({ isOpen, onClose, lang }: MobileDrawerProps) {
             {activeTab === "docs" && !navigation && (
               <div className="text-center py-8">
                 <p className="text-sm text-gray-400">
-                  문서 페이지로 이동해주세요.
+                  {t("noDocumentPage")}
                 </p>
               </div>
             )}
@@ -136,7 +138,7 @@ export function MobileDrawer({ isOpen, onClose, lang }: MobileDrawerProps) {
                 {/* Navigation Section */}
                 <div>
                   <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">
-                    네비게이션
+                    {t("navigation")}
                   </h3>
                   <nav>
                     <ul className="space-y-2">
@@ -147,7 +149,7 @@ export function MobileDrawer({ isOpen, onClose, lang }: MobileDrawerProps) {
                           className="flex items-center gap-2 px-3 py-2 rounded-md text-sm text-gray-300 hover:text-white hover:bg-zinc-800 transition-colors"
                         >
                           <FileText className="h-4 w-4" />
-                          문서
+                          {t("documents")}
                         </Link>
                       </li>
                     </ul>
@@ -157,7 +159,7 @@ export function MobileDrawer({ isOpen, onClose, lang }: MobileDrawerProps) {
                 {/* Language Section */}
                 <div>
                   <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">
-                    언어 / Language
+                    {t("language")}
                   </h3>
                   <div className="space-y-2">
                     {LANGUAGE_LIST.map((language) => (

--- a/apps/docs/src/i18n/messages/en.tsx
+++ b/apps/docs/src/i18n/messages/en.tsx
@@ -12,6 +12,15 @@ const en: Messages = {
     openMenu: "Open menu",
     githubRepository: "GitHub Repository",
   },
+  mobileMenu: {
+    documentToc: "Table of Contents",
+    menu: "Menu",
+    closeDrawer: "Close drawer",
+    noDocumentPage: "Please navigate to a documentation page.",
+    navigation: "Navigation",
+    documents: "Documentation",
+    language: "Language",
+  },
   home: {
     title: "Beautiful page transitions\nfor modern web apps",
     getStarted: "Get Started",

--- a/apps/docs/src/i18n/messages/ja.tsx
+++ b/apps/docs/src/i18n/messages/ja.tsx
@@ -12,6 +12,15 @@ const ja: Messages = {
     openMenu: "メニューを開く",
     githubRepository: "GitHubリポジトリ",
   },
+  mobileMenu: {
+    documentToc: "目次",
+    menu: "メニュー",
+    closeDrawer: "閉じる",
+    noDocumentPage: "ドキュメントページに移動してください。",
+    navigation: "ナビゲーション",
+    documents: "ドキュメント",
+    language: "言語 / Language",
+  },
   home: {
     title: "モダンウェブアプリのための\n美しいページトランジション",
     getStarted: "はじめる",

--- a/apps/docs/src/i18n/messages/ko.tsx
+++ b/apps/docs/src/i18n/messages/ko.tsx
@@ -12,6 +12,15 @@ const ko: Messages = {
     openMenu: "메뉴 열기",
     githubRepository: "GitHub 저장소",
   },
+  mobileMenu: {
+    documentToc: "문서 목차",
+    menu: "메뉴",
+    closeDrawer: "닫기",
+    noDocumentPage: "문서 페이지로 이동해주세요.",
+    navigation: "네비게이션",
+    documents: "문서",
+    language: "언어 / Language",
+  },
   home: {
     title: "아름다운 페이지 전환\n모던 웹을 위한",
     getStarted: "시작하기",

--- a/apps/docs/src/i18n/messages/types.ts
+++ b/apps/docs/src/i18n/messages/types.ts
@@ -12,6 +12,15 @@ export type Messages = {
     openMenu: string;
     githubRepository: string;
   };
+  mobileMenu: {
+    documentToc: string;
+    menu: string;
+    closeDrawer: string;
+    noDocumentPage: string;
+    navigation: string;
+    documents: string;
+    language: string;
+  };
   home: {
     title: string;
     getStarted: string;

--- a/apps/docs/src/i18n/messages/zh.tsx
+++ b/apps/docs/src/i18n/messages/zh.tsx
@@ -12,6 +12,15 @@ const zh: Messages = {
     openMenu: "打开菜单",
     githubRepository: "GitHub仓库",
   },
+  mobileMenu: {
+    documentToc: "文档目录",
+    menu: "菜单",
+    closeDrawer: "关闭",
+    noDocumentPage: "请导航到文档页面。",
+    navigation: "导航",
+    documents: "文档",
+    language: "语言 / Language",
+  },
   home: {
     title: "为现代网页应用打造\n优美的页面过渡效果",
     getStarted: "开始使用",


### PR DESCRIPTION
## Summary
- Added multilingual support for mobile menu in documentation site
- Replaced hardcoded Korean text with proper translations

## Changes
- Added `mobileMenu` section to Messages type interface
- Added translations for all supported languages (ko, en, ja, zh)
- Updated MobileDrawer component to use useTranslations hook

## Related Issue
Resolves #SSG-60

## Test Plan
- [x] Mobile menu displays correctly in Korean
- [x] Mobile menu displays correctly in English
- [x] Mobile menu displays correctly in Japanese
- [x] Mobile menu displays correctly in Chinese
- [x] Language switching works properly in mobile menu

🤖 Generated with [Claude Code](https://claude.ai/code)