### PR TITLE
feat: Add Spring Presets Similar to react-spring

### DIFF
--- a/apps/docs/content/en/02.core-concepts/03.spring-presets.mdx
+++ b/apps/docs/content/en/02.core-concepts/03.spring-presets.mdx
@@ -1,0 +1,130 @@
+---
+title: Spring Presets
+description: Pre-configured spring settings for different animation feels
+---
+
+# Spring Presets
+
+SSGOI provides pre-configured spring settings to easily create different animation feels without manually tuning physics values.
+
+## Usage
+
+You can import spring presets from the `presets` module:
+
+```typescript
+import { config } from '@ssgoi/react/presets';
+// or
+import { config } from '@ssgoi/svelte/presets';
+
+// Use in transitions
+transition({
+  spring: config.gentle,
+  tick: (progress) => {
+    // Your animation logic
+  }
+})
+```
+
+You can also import individual presets:
+
+```typescript
+import { gentle, wobbly, stiff } from '@ssgoi/react/presets';
+
+transition({
+  spring: gentle,
+  // ...
+})
+```
+
+## Available Presets
+
+### default
+A balanced animation suitable for most use cases.
+- **stiffness**: 170
+- **damping**: 26
+- **Use case**: General purpose transitions
+
+### gentle
+Smooth and calm transitions with subtle movement.
+- **stiffness**: 120
+- **damping**: 14
+- **Use case**: Elegant, professional interfaces
+
+### wobbly
+Bouncy and playful animations with noticeable spring effect.
+- **stiffness**: 180
+- **damping**: 12
+- **Use case**: Fun, interactive elements
+
+### stiff
+Quick and responsive animations with minimal overshoot.
+- **stiffness**: 210
+- **damping**: 20
+- **Use case**: Snappy UI responses, tooltips
+
+### slow
+Deliberate and measured animations.
+- **stiffness**: 280
+- **damping**: 60
+- **Use case**: Important state changes, reveals
+
+### molasses
+Very slow and viscous movement.
+- **stiffness**: 280
+- **damping**: 120
+- **Use case**: Dramatic effects, loading states
+
+## Custom Spring Configuration
+
+You can always create your own spring configuration:
+
+```typescript
+transition({
+  spring: {
+    stiffness: 150,
+    damping: 15
+  },
+  // ...
+})
+```
+
+## Physics Values Explained
+
+- **stiffness**: Controls the spring's tension. Higher values create faster animations.
+- **damping**: Controls the resistance. Higher values reduce oscillation and create smoother stops.
+
+## Examples
+
+### Using presets in view transitions
+
+```typescript
+import { Ssgoi } from '@ssgoi/react';
+import { config } from '@ssgoi/react/presets';
+import { fade } from '@ssgoi/react/view-transitions';
+
+const config = {
+  defaultTransition: fade({ spring: config.gentle }),
+  transitions: [
+    {
+      from: '/home',
+      to: '/about',
+      transition: slide({ spring: config.wobbly })
+    }
+  ]
+};
+```
+
+### Using presets in element transitions
+
+```typescript
+import { transition } from '@ssgoi/react';
+import { config } from '@ssgoi/react/presets';
+
+const fadeIn = transition({
+  spring: config.slow,
+  tick: (progress) => ({
+    opacity: progress,
+    transform: `translateY(${(1 - progress) * 20}px)`
+  })
+});
+```

--- a/apps/docs/content/ja/02.core-concepts/03.spring-presets.mdx
+++ b/apps/docs/content/ja/02.core-concepts/03.spring-presets.mdx
@@ -1,0 +1,130 @@
+---
+title: スプリングプリセット
+description: 様々なアニメーション効果のための事前定義されたスプリング設定
+---
+
+# スプリングプリセット
+
+SSGOIは、物理値を手動で調整することなく、様々なアニメーション効果を簡単に作成できるよう、事前定義されたスプリング設定を提供しています。
+
+## 使用方法
+
+`presets`モジュールからスプリングプリセットをインポートできます：
+
+```typescript
+import { config } from '@ssgoi/react/presets';
+// または
+import { config } from '@ssgoi/svelte/presets';
+
+// トランジションで使用
+transition({
+  spring: config.gentle,
+  tick: (progress) => {
+    // アニメーションロジック
+  }
+})
+```
+
+個別のプリセットをインポートすることもできます：
+
+```typescript
+import { gentle, wobbly, stiff } from '@ssgoi/react/presets';
+
+transition({
+  spring: gentle,
+  // ...
+})
+```
+
+## 利用可能なプリセット
+
+### default
+ほとんどのユースケースに適したバランスの取れたアニメーション。
+- **stiffness**: 170
+- **damping**: 26
+- **ユースケース**: 汎用的なトランジション
+
+### gentle
+微妙な動きを持つ滑らかで落ち着いたトランジション。
+- **stiffness**: 120
+- **damping**: 14
+- **ユースケース**: エレガントでプロフェッショナルなインターフェース
+
+### wobbly
+顕著なスプリング効果を持つ弾力的で遊び心のあるアニメーション。
+- **stiffness**: 180
+- **damping**: 12
+- **ユースケース**: 楽しくインタラクティブな要素
+
+### stiff
+最小限のオーバーシュートで素早く反応するアニメーション。
+- **stiffness**: 210
+- **damping**: 20
+- **ユースケース**: 素早いUIレスポンス、ツールチップ
+
+### slow
+慎重で計測されたアニメーション。
+- **stiffness**: 280
+- **damping**: 60
+- **ユースケース**: 重要な状態変更、リビール効果
+
+### molasses
+非常に遅く粘性のある動き。
+- **stiffness**: 280
+- **damping**: 120
+- **ユースケース**: ドラマチックな効果、ローディング状態
+
+## カスタムスプリング設定
+
+独自のスプリング設定を作成することも可能です：
+
+```typescript
+transition({
+  spring: {
+    stiffness: 150,
+    damping: 15
+  },
+  // ...
+})
+```
+
+## 物理値の説明
+
+- **stiffness**: スプリングの張力を制御します。値が高いほど速いアニメーションになります。
+- **damping**: 抵抗を制御します。値が高いほど振動が減少し、より滑らかに停止します。
+
+## 例
+
+### ビュートランジションでのプリセット使用
+
+```typescript
+import { Ssgoi } from '@ssgoi/react';
+import { config } from '@ssgoi/react/presets';
+import { fade } from '@ssgoi/react/view-transitions';
+
+const config = {
+  defaultTransition: fade({ spring: config.gentle }),
+  transitions: [
+    {
+      from: '/home',
+      to: '/about',
+      transition: slide({ spring: config.wobbly })
+    }
+  ]
+};
+```
+
+### 要素トランジションでのプリセット使用
+
+```typescript
+import { transition } from '@ssgoi/react';
+import { config } from '@ssgoi/react/presets';
+
+const fadeIn = transition({
+  spring: config.slow,
+  tick: (progress) => ({
+    opacity: progress,
+    transform: `translateY(${(1 - progress) * 20}px)`
+  })
+});
+```

--- a/apps/docs/content/ko/02.core-concepts/03.spring-presets.mdx
+++ b/apps/docs/content/ko/02.core-concepts/03.spring-presets.mdx
@@ -1,0 +1,130 @@
+---
+title: 스프링 프리셋
+description: 다양한 애니메이션 느낌을 위한 사전 정의된 스프링 설정
+---
+
+# 스프링 프리셋
+
+SSGOI는 물리 값을 수동으로 조정하지 않고도 다양한 애니메이션 느낌을 쉽게 만들 수 있도록 사전 정의된 스프링 설정을 제공합니다.
+
+## 사용법
+
+`presets` 모듈에서 스프링 프리셋을 가져올 수 있습니다:
+
+```typescript
+import { config } from '@ssgoi/react/presets';
+// 또는
+import { config } from '@ssgoi/svelte/presets';
+
+// 트랜지션에서 사용
+transition({
+  spring: config.gentle,
+  tick: (progress) => {
+    // 애니메이션 로직
+  }
+})
+```
+
+개별 프리셋을 가져올 수도 있습니다:
+
+```typescript
+import { gentle, wobbly, stiff } from '@ssgoi/react/presets';
+
+transition({
+  spring: gentle,
+  // ...
+})
+```
+
+## 사용 가능한 프리셋
+
+### default
+대부분의 사용 사례에 적합한 균형 잡힌 애니메이션입니다.
+- **stiffness**: 170
+- **damping**: 26
+- **사용 사례**: 범용 트랜지션
+
+### gentle
+미묘한 움직임을 가진 부드럽고 차분한 전환입니다.
+- **stiffness**: 120
+- **damping**: 14
+- **사용 사례**: 우아하고 전문적인 인터페이스
+
+### wobbly
+눈에 띄는 스프링 효과를 가진 탄력 있고 재미있는 애니메이션입니다.
+- **stiffness**: 180
+- **damping**: 12
+- **사용 사례**: 재미있고 인터랙티브한 요소
+
+### stiff
+최소한의 오버슛으로 빠르고 반응이 빠른 애니메이션입니다.
+- **stiffness**: 210
+- **damping**: 20
+- **사용 사례**: 빠른 UI 응답, 툴팁
+
+### slow
+신중하고 측정된 애니메이션입니다.
+- **stiffness**: 280
+- **damping**: 60
+- **사용 사례**: 중요한 상태 변경, 공개 효과
+
+### molasses
+매우 느리고 점성이 있는 움직임입니다.
+- **stiffness**: 280
+- **damping**: 120
+- **사용 사례**: 극적인 효과, 로딩 상태
+
+## 커스텀 스프링 설정
+
+언제든지 자신만의 스프링 구성을 만들 수 있습니다:
+
+```typescript
+transition({
+  spring: {
+    stiffness: 150,
+    damping: 15
+  },
+  // ...
+})
+```
+
+## 물리 값 설명
+
+- **stiffness**: 스프링의 장력을 제어합니다. 값이 높을수록 더 빠른 애니메이션이 생성됩니다.
+- **damping**: 저항을 제어합니다. 값이 높을수록 진동이 줄어들고 더 부드럽게 멈춥니다.
+
+## 예제
+
+### 뷰 트랜지션에서 프리셋 사용
+
+```typescript
+import { Ssgoi } from '@ssgoi/react';
+import { config } from '@ssgoi/react/presets';
+import { fade } from '@ssgoi/react/view-transitions';
+
+const config = {
+  defaultTransition: fade({ spring: config.gentle }),
+  transitions: [
+    {
+      from: '/home',
+      to: '/about',
+      transition: slide({ spring: config.wobbly })
+    }
+  ]
+};
+```
+
+### 요소 트랜지션에서 프리셋 사용
+
+```typescript
+import { transition } from '@ssgoi/react';
+import { config } from '@ssgoi/react/presets';
+
+const fadeIn = transition({
+  spring: config.slow,
+  tick: (progress) => ({
+    opacity: progress,
+    transform: `translateY(${(1 - progress) * 20}px)`
+  })
+});
+```

--- a/apps/docs/content/zh/02.core-concepts/03.spring-presets.mdx
+++ b/apps/docs/content/zh/02.core-concepts/03.spring-presets.mdx
@@ -1,0 +1,130 @@
+---
+title: 弹簧预设
+description: 为不同动画效果预定义的弹簧设置
+---
+
+# 弹簧预设
+
+SSGOI 提供预定义的弹簧设置，让您无需手动调整物理值即可轻松创建不同的动画效果。
+
+## 使用方法
+
+您可以从 `presets` 模块导入弹簧预设：
+
+```typescript
+import { config } from '@ssgoi/react/presets';
+// 或
+import { config } from '@ssgoi/svelte/presets';
+
+// 在过渡中使用
+transition({
+  spring: config.gentle,
+  tick: (progress) => {
+    // 您的动画逻辑
+  }
+})
+```
+
+您也可以导入单独的预设：
+
+```typescript
+import { gentle, wobbly, stiff } from '@ssgoi/react/presets';
+
+transition({
+  spring: gentle,
+  // ...
+})
+```
+
+## 可用预设
+
+### default
+适合大多数用例的平衡动画。
+- **stiffness**: 170
+- **damping**: 26
+- **用例**: 通用过渡
+
+### gentle
+具有细微动作的平滑、平静的过渡。
+- **stiffness**: 120
+- **damping**: 14
+- **用例**: 优雅、专业的界面
+
+### wobbly
+具有明显弹簧效果的弹性、活泼的动画。
+- **stiffness**: 180
+- **damping**: 12
+- **用例**: 有趣、互动的元素
+
+### stiff
+超调最小的快速响应动画。
+- **stiffness**: 210
+- **damping**: 20
+- **用例**: 快速 UI 响应、工具提示
+
+### slow
+谨慎而有节制的动画。
+- **stiffness**: 280
+- **damping**: 60
+- **用例**: 重要状态更改、展示效果
+
+### molasses
+非常缓慢和粘稠的运动。
+- **stiffness**: 280
+- **damping**: 120
+- **用例**: 戏剧性效果、加载状态
+
+## 自定义弹簧配置
+
+您随时可以创建自己的弹簧配置：
+
+```typescript
+transition({
+  spring: {
+    stiffness: 150,
+    damping: 15
+  },
+  // ...
+})
+```
+
+## 物理值说明
+
+- **stiffness**: 控制弹簧的张力。值越高，动画速度越快。
+- **damping**: 控制阻力。值越高，振荡越少，停止越平滑。
+
+## 示例
+
+### 在视图过渡中使用预设
+
+```typescript
+import { Ssgoi } from '@ssgoi/react';
+import { config } from '@ssgoi/react/presets';
+import { fade } from '@ssgoi/react/view-transitions';
+
+const config = {
+  defaultTransition: fade({ spring: config.gentle }),
+  transitions: [
+    {
+      from: '/home',
+      to: '/about',
+      transition: slide({ spring: config.wobbly })
+    }
+  ]
+};
+```
+
+### 在元素过渡中使用预设
+
+```typescript
+import { transition } from '@ssgoi/react';
+import { config } from '@ssgoi/react/presets';
+
+const fadeIn = transition({
+  spring: config.slow,
+  tick: (progress) => ({
+    opacity: progress,
+    transform: `translateY(${(1 - progress) * 20}px)`
+  })
+});
+```

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -31,6 +31,12 @@
       "import": "./dist/types.js",
       "require": "./dist/types.cjs",
       "default": "./dist/types.js"
+    },
+    "./presets": {
+      "types": "./dist/presets/index.d.ts",
+      "import": "./dist/presets/index.js",
+      "require": "./dist/presets/index.cjs",
+      "default": "./dist/presets/index.js"
     }
   },
   "files": [

--- a/packages/core/src/lib/presets/index.ts
+++ b/packages/core/src/lib/presets/index.ts
@@ -1,0 +1,40 @@
+import type { SpringConfig } from "../types";
+
+export const defaultSpring: SpringConfig = {
+  stiffness: 170,
+  damping: 26,
+};
+
+export const gentle: SpringConfig = {
+  stiffness: 120,
+  damping: 14,
+};
+
+export const wobbly: SpringConfig = {
+  stiffness: 180,
+  damping: 12,
+};
+
+export const stiff: SpringConfig = {
+  stiffness: 210,
+  damping: 20,
+};
+
+export const slow: SpringConfig = {
+  stiffness: 280,
+  damping: 60,
+};
+
+export const molasses: SpringConfig = {
+  stiffness: 280,
+  damping: 120,
+};
+
+export const config = {
+  default: defaultSpring,
+  gentle,
+  wobbly,
+  stiff,
+  slow,
+  molasses,
+} as const;

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -36,6 +36,12 @@
       "import": "./dist/types.js",
       "require": "./dist/types.cjs",
       "default": "./dist/types.js"
+    },
+    "./presets": {
+      "types": "./dist/presets/index.d.ts",
+      "import": "./dist/presets/index.js",
+      "require": "./dist/presets/index.cjs",
+      "default": "./dist/presets/index.js"
     }
   },
   "scripts": {

--- a/packages/react/src/lib/presets/index.ts
+++ b/packages/react/src/lib/presets/index.ts
@@ -1,0 +1,1 @@
+export * from "@ssgoi/core/presets";

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -29,6 +29,7 @@ export default defineConfig({
           "src/lib/view-transitions/index.ts"
         ),
         types: resolve(__dirname, "src/lib/types.ts"),
+        "presets/index": resolve(__dirname, "src/lib/presets/index.ts"),
       },
       formats: ["es", "cjs"],
     },
@@ -40,6 +41,7 @@ export default defineConfig({
         "@ssgoi/core",
         "@ssgoi/core/view-transitions",
         "@ssgoi/core/transitions",
+        "@ssgoi/core/presets",
       ],
       output: {
         preserveModules: true,

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -86,6 +86,10 @@
 		"./types": {
 			"types": "./dist/types.d.ts",
 			"import": "./dist/types.js"
+		},
+		"./presets": {
+			"types": "./dist/presets/index.d.ts",
+			"import": "./dist/presets/index.js"
 		}
 	}
 }

--- a/packages/svelte/src/lib/presets/index.ts
+++ b/packages/svelte/src/lib/presets/index.ts
@@ -1,0 +1,1 @@
+export * from "@ssgoi/core/presets";


### PR DESCRIPTION
## Summary
- Added spring animation presets for easier configuration
- Provides pre-defined spring settings similar to react-spring

## Changes
- Added spring presets in `packages/core/src/lib/presets/index.ts`
- Exported presets from React and Svelte packages
- Included presets: default, gentle, wobbly, stiff, slow, molasses

## Spring Preset Values
```typescript
export const defaultSpring = { stiffness: 170, damping: 26 };
export const gentle = { stiffness: 120, damping: 14 };
export const wobbly = { stiffness: 180, damping: 12 };
export const stiff = { stiffness: 210, damping: 20 };
export const slow = { stiffness: 280, damping: 60 };
export const molasses = { stiffness: 280, damping: 120 };
```

## Usage Example
```typescript
import { config } from '@ssgoi/core/presets';

transition({
  key: 'my-animation',
  in: (element) => ({
    spring: config.wobbly,
    tick: (progress) => {
      element.style.opacity = progress.toString();
    }
  })
});
```

## Related Issue
Resolves #SSG-58

## Test Plan
- [ ] Spring presets work correctly with core package
- [ ] Presets are properly exported from React package
- [ ] Presets are properly exported from Svelte package
- [ ] Animation behavior matches expected spring physics

🤖 Generated with [Claude Code](https://claude.ai/code)