### PR TITLE
feat: Add cookie-based language preference system

### DIFF
--- a/apps/docs/src/components/layout/language-switcher.tsx
+++ b/apps/docs/src/components/layout/language-switcher.tsx
@@ -1,40 +1,45 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
-import { usePathname, useRouter } from "next/navigation";
+import { useState, useTransition } from "react";
+import { usePathname } from "next/navigation";
 import { ChevronDown, Globe } from "lucide-react";
 import { LANGUAGE_LIST } from "@/i18n/supported-languages";
 import { useCurrentLanguage } from "@/i18n/use-current-language";
 import { useOutsideClick } from "@/lib/use-click-outside";
+import { setLanguagePreference } from "@/i18n/actions";
 
 export function LanguageSwitcher() {
   const [isOpen, setIsOpen] = useState(false);
-  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
   const pathname = usePathname();
   const currentLang = useCurrentLanguage();
   const onOutsideClick = useOutsideClick();
 
-  const currentLanguage = LANGUAGE_LIST.find((lang) => lang.locale === currentLang);
+  const currentLanguage = LANGUAGE_LIST.find(
+    (lang) => lang.locale === currentLang
+  );
 
   const handleLanguageChange = (locale: string) => {
-    // 현재 경로에서 언어 부분만 교체
-    const pathSegments = pathname.split("/");
-    pathSegments[1] = locale; // /ko/docs -> /en/docs
-    const newPath = pathSegments.join("/");
-    
-    router.push(newPath);
     setIsOpen(false);
+
+    // Use server action to set cookie and redirect
+    startTransition(async () => {
+      await setLanguagePreference(locale, pathname);
+    });
   };
 
   return (
     <div className="relative">
       <button
         onClick={() => setIsOpen(!isOpen)}
-        className="flex items-center gap-2 px-3 py-2 text-sm font-medium text-gray-300 transition-colors hover:bg-zinc-800 hover:text-white rounded-md"
+        disabled={isPending}
+        className="flex items-center gap-2 px-3 py-2 text-sm font-medium text-gray-300 transition-colors hover:bg-zinc-800 hover:text-white rounded-md disabled:opacity-50 disabled:cursor-not-allowed"
       >
         <Globe className="h-4 w-4" />
         <span className="hidden sm:inline">{currentLanguage?.title}</span>
-        <ChevronDown className={`h-4 w-4 transition-transform ${isOpen ? "rotate-180" : ""}`} />
+        <ChevronDown
+          className={`h-4 w-4 transition-transform ${isOpen ? "rotate-180" : ""}`}
+        />
       </button>
 
       {isOpen && (
@@ -46,15 +51,18 @@ export function LanguageSwitcher() {
             <button
               key={lang.locale}
               onClick={() => handleLanguageChange(lang.locale)}
+              disabled={isPending}
               className={`
                 w-full px-4 py-2 text-sm text-left transition-colors
-                ${currentLang === lang.locale 
-                  ? "bg-zinc-700 text-white" 
-                  : "text-gray-300 hover:bg-zinc-700 hover:text-white"
+                ${
+                  currentLang === lang.locale
+                    ? "bg-zinc-700 text-white"
+                    : "text-gray-300 hover:bg-zinc-700 hover:text-white"
                 }
+                disabled:opacity-50 disabled:cursor-not-allowed
               `}
             >
-              {lang.title}
+              {isPending ? "..." : lang.title}
             </button>
           ))}
         </div>

--- a/apps/docs/src/i18n/actions.ts
+++ b/apps/docs/src/i18n/actions.ts
@@ -1,0 +1,39 @@
+"use server";
+
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { SUPPORTED_LANGUAGES } from "./supported-languages";
+
+const LANGUAGE_COOKIE_NAME = "preferred-language";
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // 1 year
+
+export async function setLanguagePreference(locale: string, currentPath: string) {
+  // Validate the locale
+  if (!SUPPORTED_LANGUAGES.includes(locale)) {
+    throw new Error(`Unsupported language: ${locale}`);
+  }
+
+  // Set the cookie
+  const cookieStore = await cookies();
+  cookieStore.set(LANGUAGE_COOKIE_NAME, locale, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === "production",
+    sameSite: "lax",
+    maxAge: COOKIE_MAX_AGE,
+    path: "/",
+  });
+
+  // Update the path with the new locale
+  const pathSegments = currentPath.split("/");
+  pathSegments[1] = locale;
+  const newPath = pathSegments.join("/");
+
+  // Redirect to the new path
+  redirect(newPath);
+}
+
+export async function getLanguagePreference(): Promise<string | null> {
+  const cookieStore = await cookies();
+  const cookie = cookieStore.get(LANGUAGE_COOKIE_NAME);
+  return cookie?.value || null;
+}

--- a/apps/docs/src/i18n/get-preferred-language.ts
+++ b/apps/docs/src/i18n/get-preferred-language.ts
@@ -1,16 +1,27 @@
 import { NextRequest } from "next/server";
 import { DEFAULT_LANGUAGE, SUPPORTED_LANGUAGES } from "./supported-languages";
 
-export function getPreferredLanguage(request: NextRequest): string {
-  const acceptLanguage = request.headers.get("accept-language");
-  if (!acceptLanguage) return DEFAULT_LANGUAGE;
+const LANGUAGE_COOKIE_NAME = "preferred-language";
 
-  const langs = acceptLanguage.split(",").map((lang) => lang.split(";")[0]);
-  for (const lang of langs) {
-    const shortLang = lang.slice(0, 2).toLowerCase();
-    if (SUPPORTED_LANGUAGES.includes(shortLang)) {
-      return shortLang;
+export function getPreferredLanguage(request: NextRequest): string {
+  // 1. First check for cookie preference
+  const cookieValue = request.cookies.get(LANGUAGE_COOKIE_NAME)?.value;
+  if (cookieValue && SUPPORTED_LANGUAGES.includes(cookieValue)) {
+    return cookieValue;
+  }
+
+  // 2. Then check browser's Accept-Language header
+  const acceptLanguage = request.headers.get("accept-language");
+  if (acceptLanguage) {
+    const langs = acceptLanguage.split(",").map((lang) => lang.split(";")[0]);
+    for (const lang of langs) {
+      const shortLang = lang.slice(0, 2).toLowerCase();
+      if (SUPPORTED_LANGUAGES.includes(shortLang)) {
+        return shortLang;
+      }
     }
   }
+
+  // 3. Finally fallback to default language
   return DEFAULT_LANGUAGE;
 }


### PR DESCRIPTION
## Summary
- Implement persistent language preference using cookies
- Users' language selection is now remembered across browser sessions
- Improves UX by maintaining consistent language settings

## Changes
- Added server action (`setLanguagePreference`) to manage language preference cookies with 1-year expiry
- Updated language detection priority: 
  1. Cookie preference (`preferred-language`)
  2. Browser Accept-Language header
  3. Default language fallback
- Enhanced LanguageSwitcher component with server action integration and loading states

## Test Plan
- [x] Language selection persists after page refresh
- [x] Cookie is properly set with correct expiry (1 year)
- [x] Language preference works across different pages
- [x] Loading state displays during language change
- [x] Fallback to browser language works when no cookie is set

🤖 Generated with [Claude Code](https://claude.ai/code)