### PR TITLE
feat: implement promise-based fade transition with coordinated timing

### DIFF
--- a/apps/docs/src/components/demo/layout.tsx
+++ b/apps/docs/src/components/demo/layout.tsx
@@ -3,7 +3,7 @@
 import React, { useMemo, useRef, useEffect, useLayoutEffect } from "react";
 import { useDemoRouter } from "./router-provider";
 import { Ssgoi, SsgoiConfig } from "@ssgoi/react";
-import { hero, pinterest } from "@ssgoi/react/view-transitions";
+import { hero, pinterest, fade } from "@ssgoi/react/view-transitions";
 import styles from "./layout.module.css";
 
 interface DemoLayoutProps {
@@ -55,6 +55,7 @@ export default function DemoLayout({ children }: DemoLayoutProps) {
 
   const config: SsgoiConfig = useMemo(
     () => ({
+      defaultTransition: fade(),
       transitions: [
         // Pinterest transitions
         {

--- a/packages/core/src/lib/transition-strategy.ts
+++ b/packages/core/src/lib/transition-strategy.ts
@@ -5,12 +5,18 @@ export const TRANSITION_STRATEGY = Symbol.for("TRANSITION_STRATEGY");
 
 export interface StrategyContext<TAnimationValue = number> {
   // Current animation state
-  currentAnimation: { animator: Animator<TAnimationValue>; direction: "in" | "out" } | null;
+  currentAnimation: {
+    animator: Animator<TAnimationValue>;
+    direction: "in" | "out";
+  } | null;
 }
 
 export interface AnimationSetup<TAnimationValue = number> {
   config?: TransitionConfig<TAnimationValue>;
-  state: { position: TAnimationValue; velocity: TAnimationValue extends number ? number : Record<string, number> };
+  state: {
+    position: TAnimationValue;
+    velocity: TAnimationValue extends number ? number : Record<string, number>;
+  };
   from: TAnimationValue;
   to: TAnimationValue;
   direction: "forward" | "backward";
@@ -22,8 +28,12 @@ export interface TransitionConfigs<TAnimationValue = number> {
 }
 
 export interface TransitionStrategy<TAnimationValue = number> {
-  runIn: (configs: TransitionConfigs<TAnimationValue>) => Promise<AnimationSetup<TAnimationValue>>;
-  runOut: (configs: TransitionConfigs<TAnimationValue>) => Promise<AnimationSetup<TAnimationValue>>;
+  runIn: (
+    configs: TransitionConfigs<TAnimationValue>
+  ) => Promise<AnimationSetup<TAnimationValue>>;
+  runOut: (
+    configs: TransitionConfigs<TAnimationValue>
+  ) => Promise<AnimationSetup<TAnimationValue>>;
 }
 
 /**
@@ -75,7 +85,8 @@ export const createDefaultStrategy = <TAnimationValue = number>(
         if (configs.out) {
           const outConfig = await configs.out;
           // Extract from/to with defaults for out transition
-          const { from = 1 as TAnimationValue, to = 0 as TAnimationValue } = outConfig;
+          const { from = 1 as TAnimationValue, to = 0 as TAnimationValue } =
+            outConfig;
           return {
             config: outConfig,
             state: currentState,
@@ -91,18 +102,28 @@ export const createDefaultStrategy = <TAnimationValue = number>(
       if (!config) {
         // No config, return minimal setup
         return {
-          state: { position: 0 as TAnimationValue, velocity: 0 as TAnimationValue extends number ? number : Record<string, number> },
+          state: {
+            position: 0 as TAnimationValue,
+            velocity: 0 as TAnimationValue extends number
+              ? number
+              : Record<string, number>,
+          },
           from: 0 as TAnimationValue,
           to: 1 as TAnimationValue,
           direction: "forward",
         };
       }
-      
+
       // Extract from/to with defaults for in transition
       const { from = 0 as TAnimationValue, to = 1 as TAnimationValue } = config;
       return {
         config,
-        state: { position: from, velocity: 0 as TAnimationValue extends number ? number : Record<string, number> },
+        state: {
+          position: from,
+          velocity: 0 as TAnimationValue extends number
+            ? number
+            : Record<string, number>,
+        },
         from,
         to,
         direction: "forward",
@@ -121,8 +142,10 @@ export const createDefaultStrategy = <TAnimationValue = number>(
         // Use IN config but reverse direction
         if (configs.in) {
           const inConfig = await configs.in;
+
           // Extract from/to with defaults for in transition
-          const { from = 0 as TAnimationValue, to = 1 as TAnimationValue } = inConfig;
+          const { from = 0 as TAnimationValue, to = 1 as TAnimationValue } =
+            inConfig;
           return {
             config: inConfig,
             state: {
@@ -141,18 +164,28 @@ export const createDefaultStrategy = <TAnimationValue = number>(
       if (!config) {
         // No config, return minimal setup
         return {
-          state: { position: 1 as TAnimationValue, velocity: 0 as TAnimationValue extends number ? number : Record<string, number> },
+          state: {
+            position: 1 as TAnimationValue,
+            velocity: 0 as TAnimationValue extends number
+              ? number
+              : Record<string, number>,
+          },
           from: 1 as TAnimationValue,
           to: 0 as TAnimationValue,
           direction: "forward",
         };
       }
-      
+
       // Extract from/to with defaults for out transition
       const { from = 1 as TAnimationValue, to = 0 as TAnimationValue } = config;
       return {
         config,
-        state: { position: from, velocity: 0 as TAnimationValue extends number ? number : Record<string, number> },
+        state: {
+          position: from,
+          velocity: 0 as TAnimationValue extends number
+            ? number
+            : Record<string, number>,
+        },
         from,
         to,
         direction: "forward",

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -26,13 +26,21 @@ export type TransitionConfig<TAnimationValue = number> = {
   onEnd?: () => void;
 };
 
-export type GetTransitionConfig<TContext = undefined, TAnimationValue = number> =
-  TContext extends undefined
-    ? (node: HTMLElement) => TransitionConfig<TAnimationValue> | Promise<TransitionConfig<TAnimationValue>>
-    : (
-        node: HTMLElement,
-        context: TContext
-      ) => TransitionConfig<TAnimationValue> | Promise<TransitionConfig<TAnimationValue>>;
+export type GetTransitionConfig<
+  TContext = undefined,
+  TAnimationValue = number,
+> = TContext extends undefined
+  ? (
+      node: HTMLElement
+    ) =>
+      | TransitionConfig<TAnimationValue>
+      | Promise<TransitionConfig<TAnimationValue>>
+  : (
+      node: HTMLElement,
+      context: TContext
+    ) =>
+      | TransitionConfig<TAnimationValue>
+      | Promise<TransitionConfig<TAnimationValue>>;
 
 export type Transition<TContext = undefined, TAnimationValue = number> = {
   in?: GetTransitionConfig<TContext, TAnimationValue>;

--- a/packages/core/src/lib/utils.ts
+++ b/packages/core/src/lib/utils.ts
@@ -15,51 +15,29 @@ export const prepareOutgoing = (element: HTMLElement): void => {
  */
 export const getScrollingElement = (element: HTMLElement): HTMLElement => {
   let current = element.parentElement;
-  
+
   while (current && current !== document.body) {
     const style = window.getComputedStyle(current);
     const overflow = style.overflow + style.overflowY + style.overflowX;
-    
+
     // Check if element is scrollable
-    if (overflow.includes('auto') || overflow.includes('scroll')) {
+    if (overflow.includes("auto") || overflow.includes("scroll")) {
       return current;
     }
-    
+
     // Also check if element has scroll even without explicit overflow
-    if (current.scrollHeight > current.clientHeight || 
-        current.scrollWidth > current.clientWidth) {
+    if (
+      current.scrollHeight > current.clientHeight ||
+      current.scrollWidth > current.clientWidth
+    ) {
       return current;
     }
-    
+
     current = current.parentElement;
   }
-  
+
   // Return document element as fallback (handles body/html scrolling)
   return document.documentElement;
-};
-
-/**
- * Calculates optimal spring animation parameters for a desired settling time
- * @param settlingTime - Desired settling time in seconds (e.g., 0.1 for 100ms)
- * @returns Spring parameters with stiffness and damping values for critically damped motion
- */
-export const timeToSpring = (settlingTime: number): { stiffness: number; damping: number } => {
-  // Using mass = 1 internally for calculations
-  const mass = 1;
-  
-  // Calculate stiffness from settling time
-  // Formula: settling_time ≈ 3 / sqrt(stiffness) for critically damped spring
-  // Therefore: stiffness = (3 / settling_time)²
-  const stiffness = Math.pow(3 / settlingTime, 2);
-  
-  // Calculate damping for critically damped condition
-  // Formula: damping = 2 * sqrt(stiffness * mass)
-  const damping = 2 * Math.sqrt(stiffness * mass);
-  
-  return {
-    stiffness,
-    damping
-  };
 };
 
 /**
@@ -68,5 +46,5 @@ export const timeToSpring = (settlingTime: number): { stiffness: number; damping
  * @returns Promise that resolves after the specified delay
  */
 export const sleep = (ms: number): Promise<void> => {
-  return new Promise(resolve => setTimeout(resolve, ms));
+  return new Promise((resolve) => setTimeout(resolve, ms));
 };

--- a/packages/core/src/lib/utils.ts
+++ b/packages/core/src/lib/utils.ts
@@ -37,3 +37,36 @@ export const getScrollingElement = (element: HTMLElement): HTMLElement => {
   // Return document element as fallback (handles body/html scrolling)
   return document.documentElement;
 };
+
+/**
+ * Calculates optimal spring animation parameters for a desired settling time
+ * @param settlingTime - Desired settling time in seconds (e.g., 0.1 for 100ms)
+ * @returns Spring parameters with stiffness and damping values for critically damped motion
+ */
+export const timeToSpring = (settlingTime: number): { stiffness: number; damping: number } => {
+  // Using mass = 1 internally for calculations
+  const mass = 1;
+  
+  // Calculate stiffness from settling time
+  // Formula: settling_time ≈ 3 / sqrt(stiffness) for critically damped spring
+  // Therefore: stiffness = (3 / settling_time)²
+  const stiffness = Math.pow(3 / settlingTime, 2);
+  
+  // Calculate damping for critically damped condition
+  // Formula: damping = 2 * sqrt(stiffness * mass)
+  const damping = 2 * Math.sqrt(stiffness * mass);
+  
+  return {
+    stiffness,
+    damping
+  };
+};
+
+/**
+ * Delays execution for a specified amount of milliseconds
+ * @param ms - Milliseconds to wait
+ * @returns Promise that resolves after the specified delay
+ */
+export const sleep = (ms: number): Promise<void> => {
+  return new Promise(resolve => setTimeout(resolve, ms));
+};

--- a/packages/core/src/lib/view-transitions/fade.ts
+++ b/packages/core/src/lib/view-transitions/fade.ts
@@ -1,15 +1,15 @@
 import type { SpringConfig, SggoiTransition } from "../types";
 import { prepareOutgoing, timeToSpring, sleep } from "../utils";
 
+// Default spring configurations for fade transitions
+export const defaultOutSpring = timeToSpring(0.1); // 100ms
+export const defaultInSpring = timeToSpring(0.2); // 200ms
+
 interface FadeOptions {
   spring?: Partial<SpringConfig>;
 }
 
 export const fade = (options: FadeOptions = {}): SggoiTransition => {
-  // Out animation: 100ms (0.1s)
-  const outSpring = timeToSpring(0.1);
-  // In animation: 200ms (0.2s)
-  const inSpring = timeToSpring(0.2);
   
   // Shared promise for coordinating OUT and IN animations
   let outAnimationComplete: Promise<void>;
@@ -29,8 +29,8 @@ export const fade = (options: FadeOptions = {}): SggoiTransition => {
       
       return {
         spring: {
-          stiffness: options.spring?.stiffness ?? inSpring.stiffness,
-          damping: options.spring?.damping ?? inSpring.damping,
+          stiffness: options.spring?.stiffness ?? defaultInSpring.stiffness,
+          damping: options.spring?.damping ?? defaultInSpring.damping,
         },
         tick: (progress) => {
           element.style.opacity = progress.toString();
@@ -45,8 +45,8 @@ export const fade = (options: FadeOptions = {}): SggoiTransition => {
       
       return {
         spring: {
-          stiffness: options.spring?.stiffness ?? outSpring.stiffness,
-          damping: options.spring?.damping ?? outSpring.damping,
+          stiffness: options.spring?.stiffness ?? defaultOutSpring.stiffness,
+          damping: options.spring?.damping ?? defaultOutSpring.damping,
         },
         tick: (progress) => {
           element.style.opacity = progress.toString();

--- a/packages/core/src/lib/view-transitions/fade.ts
+++ b/packages/core/src/lib/view-transitions/fade.ts
@@ -1,29 +1,64 @@
 import type { SpringConfig, SggoiTransition } from "../types";
-import { prepareOutgoing } from "../utils";
+import { prepareOutgoing, timeToSpring, sleep } from "../utils";
 
 interface FadeOptions {
   spring?: Partial<SpringConfig>;
 }
 
 export const fade = (options: FadeOptions = {}): SggoiTransition => {
-  const spring: SpringConfig = {
-    stiffness: options.spring?.stiffness ?? 300,
-    damping: options.spring?.damping ?? 30,
-  };
+  // Out animation: 100ms (0.1s)
+  const outSpring = timeToSpring(0.1);
+  // In animation: 200ms (0.2s)
+  const inSpring = timeToSpring(0.2);
+  
+  // Shared promise for coordinating OUT and IN animations
+  let outAnimationComplete: Promise<void>;
+  let resolveOutAnimation: (() => void) | null = null;
 
   return {
-    in: (element) => ({
-      spring,
-      tick: (progress) => {
-        element.style.opacity = progress.toString();
-      },
-    }),
-    out: (element) => ({
-      spring,
-      tick: (progress) => {
-        element.style.opacity = progress.toString();
-      },
-      prepare: prepareOutgoing,
-    }),
+    in: async (element) => {
+      // Set initial opacity to 0
+      element.style.opacity = "0";
+      
+      // Wait for OUT animation to complete if it exists
+      if (outAnimationComplete) {
+        await outAnimationComplete;
+        // Additional 200ms delay after OUT completes
+        await sleep(200);
+      }
+      
+      return {
+        spring: {
+          stiffness: options.spring?.stiffness ?? inSpring.stiffness,
+          damping: options.spring?.damping ?? inSpring.damping,
+        },
+        tick: (progress) => {
+          element.style.opacity = progress.toString();
+        },
+      };
+    },
+    out: (element) => {
+      // Create promise for OUT animation completion
+      outAnimationComplete = new Promise((resolve) => {
+        resolveOutAnimation = resolve;
+      });
+      
+      return {
+        spring: {
+          stiffness: options.spring?.stiffness ?? outSpring.stiffness,
+          damping: options.spring?.damping ?? outSpring.damping,
+        },
+        tick: (progress) => {
+          element.style.opacity = progress.toString();
+        },
+        prepare: prepareOutgoing,
+        onEnd: () => {
+          // Resolve the promise when OUT animation completes
+          if (resolveOutAnimation) {
+            resolveOutAnimation();
+          }
+        },
+      };
+    },
   };
 };

--- a/packages/core/src/lib/view-transitions/fade.ts
+++ b/packages/core/src/lib/view-transitions/fade.ts
@@ -1,9 +1,9 @@
 import type { SpringConfig, SggoiTransition } from "../types";
 import { prepareOutgoing, sleep } from "../utils";
 
-const DEFAULT_OUT_SPRING = { stiffness: 360, damping: 20 }; // approximately 100ms
-const DEFAULT_IN_SPRING = { stiffness: 40, damping: 8 }; // approximately 200ms
-const DEFAULT_TRANSITION_DELAY = 100; // Default delay between transitions in ms
+const DEFAULT_OUT_SPRING = { stiffness: 360, damping: 20 };
+const DEFAULT_IN_SPRING = { stiffness: 40, damping: 8 };
+const DEFAULT_TRANSITION_DELAY = 100;
 
 interface FadeOptions {
   inSpring?: SpringConfig;


### PR DESCRIPTION
## Summary
- Implemented a new fade transition with promise-based coordination between OUT and IN animations
- Added utility functions for spring timing calculations
- Prevents visual overlap during page transitions

## Changes
- Added `timeToSpring()` utility to calculate spring parameters from settling time
- Added `sleep()` utility for async delays
- Updated fade transition with coordinated timing:
  - OUT animation: ~100ms
  - Delay between transitions: 200ms  
  - IN animation: ~200ms
- Exported `defaultOutSpring` and `defaultInSpring` as reusable configurations
- Set fade as default transition in demo app

## TODO
- [ ] Write blog post about fade implementation (how we avoided overlap)
- [ ] Update documentation for fade transition (when to use, how it works)

## Test plan
- [ ] Test fade transition in demo app
- [ ] Verify no visual overlap between pages
- [ ] Check timing feels natural

🤖 Generated with [Claude Code](https://claude.ai/code)