### PR TITLE
feat: add dynamic option controls to TransitionDemo component

### DIFF
--- a/apps/docs/src/components/mdx/mdx-components/transition-demo.tsx
+++ b/apps/docs/src/components/mdx/mdx-components/transition-demo.tsx
@@ -10,10 +10,53 @@ interface TransitionDemoProps {
   options?: Record<string, any>;
 }
 
+// Transition-specific option configurations
+const transitionOptions = {
+  scale: [
+    { name: 'start', type: 'range', min: 0, max: 2, step: 0.1, default: 0 },
+    { name: 'opacity', type: 'range', min: 0, max: 1, step: 0.1, default: 0 },
+    { name: 'axis', type: 'select', options: ['both', 'x', 'y'], default: 'both' }
+  ],
+  fade: [
+    { name: 'from', type: 'range', min: 0, max: 1, step: 0.1, default: 0 },
+    { name: 'to', type: 'range', min: 0, max: 1, step: 0.1, default: 1 }
+  ],
+  rotate: [
+    { name: 'degrees', type: 'range', min: 0, max: 720, step: 45, default: 360 },
+    { name: 'clockwise', type: 'toggle', default: true },
+    { name: 'scale', type: 'toggle', default: false },
+    { name: 'fade', type: 'toggle', default: true },
+    { name: 'axis', type: 'select', options: ['2d', 'x', 'y', 'z'], default: '2d' },
+    { name: 'perspective', type: 'range', min: 100, max: 2000, step: 100, default: 800 },
+    { name: 'origin', type: 'select', options: ['center', 'top', 'bottom', 'left', 'right', 'top left', 'top right', 'bottom left', 'bottom right'], default: 'center' }
+  ],
+  slide: [
+    { name: 'direction', type: 'select', options: ['left', 'right', 'up', 'down'], default: 'left' },
+    { name: 'distance', type: 'range', min: 0, max: 500, step: 10, default: 100 },
+    { name: 'opacity', type: 'range', min: 0, max: 1, step: 0.1, default: 0 },
+    { name: 'fade', type: 'toggle', default: true }
+  ],
+  bounce: [
+    { name: 'height', type: 'range', min: 0, max: 100, step: 5, default: 20 },
+    { name: 'bounces', type: 'range', min: 1, max: 10, step: 1, default: 3 },
+    { name: 'fade', type: 'toggle', default: true }
+  ],
+  blur: [
+    { name: 'amount', type: 'range', min: 0, max: 20, step: 1, default: 10 },
+    { name: 'opacity', type: 'range', min: 0, max: 1, step: 0.1, default: 0 }
+  ],
+  fly: [
+    { name: 'y', type: 'range', min: -500, max: 500, step: 10, default: -100 },
+    { name: 'x', type: 'range', min: -500, max: 500, step: 10, default: 0 },
+    { name: 'opacity', type: 'range', min: 0, max: 1, step: 0.1, default: 0 }
+  ]
+} as const;
+
 export function TransitionDemo({ type, options = {} }: TransitionDemoProps) {
   const [isVisible, setIsVisible] = useState(true);
   const [springPreset, setSpringPreset] =
     useState<keyof typeof springPresets>("default");
+  const [customOptions, setCustomOptions] = useState<Record<string, any>>({});
 
   // Get the transition function
   const transitionFn = transitions[type];
@@ -21,9 +64,12 @@ export function TransitionDemo({ type, options = {} }: TransitionDemoProps) {
     return <div>Unknown transition type: {type}</div>;
   }
 
+  // Merge default options with custom options
+  const mergedOptions = { ...options, ...customOptions };
+
   // Apply the transition with spring preset
   const transitionConfig = transitionFn({
-    ...options,
+    ...mergedOptions,
     spring: springPresets[springPreset],
   });
 
@@ -55,6 +101,79 @@ export function TransitionDemo({ type, options = {} }: TransitionDemoProps) {
           {isVisible ? "Hide" : "Show"}
         </button>
       </div>
+
+      {/* Transition-specific Options */}
+      {transitionOptions[type as keyof typeof transitionOptions] && (
+        <div className="space-y-3 p-4 bg-gray-950/50 rounded-lg border border-gray-800">
+          <h3 className="text-sm font-semibold text-gray-400 mb-2">Options</h3>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            {transitionOptions[type as keyof typeof transitionOptions].map((option) => {
+              const currentValue = customOptions[option.name] ?? option.default;
+              
+              return (
+                <div key={option.name} className="space-y-1">
+                  <label className="text-xs text-gray-500 capitalize">
+                    {option.name.replace(/([A-Z])/g, ' $1').trim()}
+                  </label>
+                  
+                  {option.type === 'range' && (
+                    <div className="flex items-center gap-2">
+                      <input
+                        type="range"
+                        min={option.min}
+                        max={option.max}
+                        step={option.step}
+                        value={currentValue}
+                        onChange={(e) => setCustomOptions({
+                          ...customOptions,
+                          [option.name]: parseFloat(e.target.value)
+                        })}
+                        className="flex-1 h-1 bg-gray-700 rounded-lg appearance-none cursor-pointer [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:h-3 [&::-webkit-slider-thumb]:bg-orange-500 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:cursor-pointer"
+                      />
+                      <span className="text-xs text-gray-400 w-12 text-right">
+                        {currentValue}
+                      </span>
+                    </div>
+                  )}
+                  
+                  {option.type === 'select' && (
+                    <select
+                      value={currentValue}
+                      onChange={(e) => setCustomOptions({
+                        ...customOptions,
+                        [option.name]: e.target.value
+                      })}
+                      className="w-full px-2 py-1 text-xs bg-gray-800 text-gray-300 rounded-md border border-gray-700 focus:border-orange-500 focus:outline-none"
+                    >
+                      {option.options.map((opt) => (
+                        <option key={opt} value={opt}>{opt}</option>
+                      ))}
+                    </select>
+                  )}
+                  
+                  {option.type === 'toggle' && (
+                    <button
+                      onClick={() => setCustomOptions({
+                        ...customOptions,
+                        [option.name]: !currentValue
+                      })}
+                      className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${
+                        currentValue ? 'bg-orange-500' : 'bg-gray-700'
+                      }`}
+                    >
+                      <span
+                        className={`inline-block h-3 w-3 transform rounded-full bg-white transition-transform ${
+                          currentValue ? 'translate-x-5' : 'translate-x-1'
+                        }`}
+                      />
+                    </button>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
 
       {/* Spring Preset Controls */}
       <div className="flex gap-2 flex-wrap justify-center">


### PR DESCRIPTION
## Summary
- Added dynamic option controls to the TransitionDemo component for documentation
- Each transition type (scale, fade, rotate, slide, etc.) now has its own specific configurable options
- Users can interactively adjust transition parameters in real-time

## Changes
- **TransitionDemo component**: Added transition-specific option configurations
- **UI Controls**: Implemented range sliders, select dropdowns, and toggle switches
- **Real-time updates**: Options immediately affect the animation preview

## Test plan
- [ ] Test scale transition with start, opacity, and axis options
- [ ] Test fade transition with from/to options
- [ ] Test rotate transition with degrees, axis, perspective options
- [ ] Test slide transition with direction and distance options
- [ ] Verify all controls update animations in real-time
- [ ] Check responsive layout on mobile devices

🤖 Generated with [Claude Code](https://claude.ai/code)