### PR TITLE
feat: add drill transition

### DIFF
--- a/apps/docs/src/components/demo/layout.tsx
+++ b/apps/docs/src/components/demo/layout.tsx
@@ -3,7 +3,7 @@
 import React, { useMemo, useRef, useEffect, useLayoutEffect } from "react";
 import { useDemoRouter } from "./router-provider";
 import { Ssgoi, SsgoiConfig } from "@ssgoi/react";
-import { hero, pinterest, fade } from "@ssgoi/react/view-transitions";
+import { drill, hero, pinterest, fade } from "@ssgoi/react/view-transitions";
 import styles from "./layout.module.css";
 
 interface DemoLayoutProps {
@@ -61,7 +61,7 @@ export default function DemoLayout({ children }: DemoLayoutProps) {
         {
           from: "/demo/pinterest/*",
           to: "/demo/pinterest",
-          transition: pinterest({spring: {stiffness: 150, damping: 20}}),
+          transition: pinterest({ spring: { stiffness: 150, damping: 20 } }),
           symmetric: true,
         },
         // Products transitions - hero
@@ -71,72 +71,12 @@ export default function DemoLayout({ children }: DemoLayoutProps) {
           transition: hero(),
           symmetric: true,
         },
-        // Posts transitions - slide with parallax effect
+        // Posts transitions - drill effect
         {
           from: "/demo/posts",
           to: "/demo/posts/*",
-          transition: {
-            in: (node) => ({
-              spring: {
-                stiffness: 150,
-                damping: 20,
-              },
-              prepare: (node) => {
-                node.style.zIndex = "100";
-              },
-              tick: (t) => {
-                node.style.zIndex = "100";
-                node.style.transform = `translateX(${(1 - t) * 100}%)`;
-              },
-            }),
-            out: (node) => ({
-              spring: {
-                stiffness: 150,
-                damping: 20,
-              },
-              prepare: (node) => {
-                node.style.position = "absolute";
-                node.style.left = "0";
-                node.style.top = "0";
-                node.style.width = "100%";
-                node.style.zIndex = "-1";
-              },
-              tick: (t) => {
-                node.style.transform = `translateX(${-(1 - t) * 20}%)`;
-              },
-            }),
-          },
-        },
-        {
-          from: "/demo/posts/*",
-          to: "/demo/posts",
-          transition: {
-            in: (node) => ({
-              spring: {
-                stiffness: 100,
-                damping: 20,
-              },
-              tick: (t) => {
-                node.style.transform = `translateX(${-(1 - t) * 20}%)`;
-              },
-            }),
-            out: (node) => ({
-              spring: {
-                stiffness: 50,
-                damping: 20,
-              },
-              prepare: (node) => {
-                node.style.position = "absolute";
-                node.style.left = "0";
-                node.style.top = "0";
-                node.style.width = "auto";
-                node.style.zIndex = "100";
-              },
-              tick: (t) => {
-                node.style.transform = `translateX(${(1 - t) * 100}%)`;
-              },
-            }),
-          },
+          transition: drill({ direction: "enter" }),
+          symmetric: true,
         },
       ],
     }),

--- a/apps/docs/src/components/demo/layout.tsx
+++ b/apps/docs/src/components/demo/layout.tsx
@@ -76,7 +76,11 @@ export default function DemoLayout({ children }: DemoLayoutProps) {
           from: "/demo/posts",
           to: "/demo/posts/*",
           transition: drill({ direction: "enter" }),
-          symmetric: true,
+        },
+        {
+          from: "/demo/posts/*",
+          to: "/demo/posts",
+          transition: drill({ direction: "exit" }),
         },
       ],
     }),

--- a/packages/core/src/lib/create-transition-callback.ts
+++ b/packages/core/src/lib/create-transition-callback.ts
@@ -50,6 +50,11 @@ export function createTransitionCallback<TAnimationValue = number>(
 
     setup.config.prepare?.(element);
 
+    // Wait if configured
+    if (setup.config.wait) {
+      await setup.config.wait();
+    }
+
     const animator = Animator.fromState(setup.state, {
       from: setup.from,
       to: setup.to,
@@ -89,6 +94,11 @@ export function createTransitionCallback<TAnimationValue = number>(
     setup.config.prepare?.(element);
 
     insertClone();
+
+    // Wait if configured
+    if (setup.config.wait) {
+      await setup.config.wait();
+    }
 
     const animator = Animator.fromState(setup.state, {
       from: setup.from,

--- a/packages/core/src/lib/transition.ts
+++ b/packages/core/src/lib/transition.ts
@@ -68,9 +68,56 @@ function unregisterTransition(key: TransitionKey): void {
 
 /**
  * Framework-agnostic transition function that can be used as a ref
- * Usage: <div ref={transition({ key: 'fade', in, out })} />
+ * 
+ * @description
+ * Creates a transition that can be attached to DOM elements via ref.
+ * Manages entrance and exit animations with a complete lifecycle system.
+ * 
+ * **IN Animation Lifecycle (Element Entering):**
+ * 1. `prepare` - Setup element's initial state (e.g., opacity: 0)
+ * 2. `wait` - Optional async delay before animation starts
+ * 3. `onStart` - Called when animation begins
+ * 4. `tick` - Called on each animation frame with progress value (0 → 1)
+ * 5. `onEnd` - Called when animation completes
+ * 
+ * **OUT Animation Lifecycle (Element Exiting):**
+ * 1. `prepare` - Setup element's initial state for exit
+ * 2. `wait` - Optional async delay before animation starts
+ * 3. `onStart` - Called when animation begins
+ * 4. `tick` - Called on each animation frame with progress value (1 → 0)
+ * 5. `onEnd` - Called when animation completes and element is removed
+ * 
+ * The `key` parameter is crucial for transition management - it uniquely identifies
+ * each transition instance, allowing the system to track, cleanup, and prevent
+ * conflicts between multiple transitions on the same element.
+ * 
+ * @param {object} options - Configuration object
+ * @param {TransitionKey} options.key - Unique identifier for this transition instance.
+ *                                      Can be string or symbol. Used to manage and cleanup
+ *                                      transitions internally.
+ * @param {Function} options.in - Configuration for entrance animation.
+ *                                Returns TransitionConfig with lifecycle hooks.
+ * @param {Function} options.out - Configuration for exit animation.
+ *                                 Returns TransitionConfig with lifecycle hooks.
  * 
  * @template TAnimationValue - The type of value being animated (number | object)
+ * 
+ * @returns {TransitionCallback} A callback function to be used as a ref
+ * 
+ * @example
+ * ```tsx
+ * // Simple fade transition
+ * <div ref={transition({
+ *   key: 'hero-fade',
+ *   in: (element) => ({
+ *     prepare: (el) => el.style.opacity = '0',
+ *     tick: (progress) => el.style.opacity = progress.toString(),
+ *   }),
+ *   out: (element) => ({
+ *     tick: (progress) => el.style.opacity = progress.toString(),
+ *   })
+ * })} />
+ * ```
  */
 export function transition<TAnimationValue = number>(options: {
   key: TransitionKey;

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -19,6 +19,9 @@ export type TransitionConfig<TAnimationValue = number> = {
   // Prepare element before animation (typically for out transitions)
   prepare?: (element: HTMLElement) => void;
 
+  // Wait before starting the animation
+  wait?: () => Promise<void>;
+
   // Called when animation starts
   onStart?: () => void;
 

--- a/packages/core/src/lib/view-transitions/drill.ts
+++ b/packages/core/src/lib/view-transitions/drill.ts
@@ -1,0 +1,83 @@
+import type { SpringConfig, SggoiTransition } from "../types";
+import { prepareOutgoing } from "../utils";
+
+interface DrillOptions {
+  opacity?: boolean;
+  direction?: "enter" | "exit";
+  spring?: Partial<SpringConfig>;
+}
+
+export const drill = (options: DrillOptions = {}): SggoiTransition => {
+  const { opacity = false, direction = "enter" } = options;
+  const spring: SpringConfig = {
+    stiffness: options.spring?.stiffness ?? 150,
+    damping: options.spring?.damping ?? 20,
+  };
+
+  if (direction === "enter") {
+    return {
+      in: (element) => ({
+        spring,
+        prepare: (element) => {
+          element.style.zIndex = "100";
+        },
+        tick: (progress) => {
+          element.style.zIndex = "100";
+          element.style.transform = `translateX(${(1 - progress) * 100}%)`;
+          if (opacity) {
+            // TODO: Apply opacity only to content, not the whole element
+            element.style.opacity = progress.toString();
+          }
+        },
+      }),
+      out: (element) => ({
+        spring,
+        prepare: (element) => {
+          prepareOutgoing(element);
+          element.style.zIndex = "-1";
+        },
+        tick: (progress) => {
+          element.style.transform = `translateX(${-(1 - progress) * 20}%)`;
+          if (opacity) {
+            // TODO: Apply opacity only to content, not the whole element
+            element.style.opacity = progress.toString();
+          }
+        },
+      }),
+    };
+  } else {
+    // direction === "exit"
+    return {
+      in: (element) => ({
+        spring: {
+          stiffness: 100,
+          damping: 20,
+        },
+        tick: (progress) => {
+          element.style.transform = `translateX(${-(1 - progress) * 20}%)`;
+          if (opacity) {
+            // TODO: Apply opacity only to content, not the whole element
+            element.style.opacity = progress.toString();
+          }
+        },
+      }),
+      out: (element) => ({
+        spring: {
+          stiffness: 50,
+          damping: 20,
+        },
+        prepare: (element) => {
+          prepareOutgoing(element);
+          element.style.zIndex = "100";
+        },
+        tick: (progress) => {
+          element.style.transform = `translateX(${(1 - progress) * 100}%)`;
+          if (opacity) {
+            // TODO: Apply opacity only to content, not the whole element
+            element.style.opacity = progress.toString();
+          }
+        },
+      }),
+    };
+  }
+};

--- a/packages/core/src/lib/view-transitions/drill.ts
+++ b/packages/core/src/lib/view-transitions/drill.ts
@@ -18,11 +18,7 @@ export const drill = (options: DrillOptions = {}): SggoiTransition => {
     return {
       in: (element) => ({
         spring,
-        prepare: (element) => {
-          element.style.zIndex = "100";
-        },
         tick: (progress) => {
-          element.style.zIndex = "100";
           element.style.transform = `translateX(${(1 - progress) * 100}%)`;
           if (opacity) {
             // TODO: Apply opacity only to content, not the whole element
@@ -72,6 +68,7 @@ export const drill = (options: DrillOptions = {}): SggoiTransition => {
         },
         tick: (progress) => {
           element.style.transform = `translateX(${(1 - progress) * 100}%)`;
+
           if (opacity) {
             // TODO: Apply opacity only to content, not the whole element
             element.style.opacity = progress.toString();

--- a/packages/core/src/lib/view-transitions/drill.ts
+++ b/packages/core/src/lib/view-transitions/drill.ts
@@ -59,7 +59,7 @@ export const drill = (options: DrillOptions = {}): SggoiTransition => {
       }),
       out: (element) => ({
         spring: {
-          stiffness: 50,
+          stiffness: 100,
           damping: 20,
         },
         prepare: (element) => {

--- a/packages/core/src/lib/view-transitions/fade.ts
+++ b/packages/core/src/lib/view-transitions/fade.ts
@@ -1,7 +1,7 @@
 import type { SpringConfig, SggoiTransition } from "../types";
 import { prepareOutgoing, sleep } from "../utils";
 
-const DEFAULT_OUT_SPRING = { stiffness: 360, damping: 20 };
+const DEFAULT_OUT_SPRING = { stiffness: 400, damping: 20 };
 const DEFAULT_IN_SPRING = { stiffness: 40, damping: 8 };
 const DEFAULT_TRANSITION_DELAY = 100;
 
@@ -22,19 +22,20 @@ export const fade = (options: FadeOptions = {}): SggoiTransition => {
   let resolveOutAnimation: (() => void) | null = null;
 
   return {
-    in: async (element) => {
-      // Set initial opacity to 0
-      element.style.opacity = "0";
-
-      // Wait for OUT animation to complete if it exists
-      if (outAnimationComplete) {
-        await outAnimationComplete;
-        // Configurable delay after OUT completes
-        await sleep(transitionDelay);
-      }
-
+    in: (element) => {
       return {
         spring: inSpring,
+        prepare: (element) => {
+          element.style.opacity = "0";
+        },
+        wait: async () => {
+          // Wait for OUT animation to complete if it exists
+          if (outAnimationComplete) {
+            await outAnimationComplete;
+            // Configurable delay after OUT completes
+            await sleep(transitionDelay);
+          }
+        },
         tick: (progress) => {
           element.style.opacity = progress.toString();
         },

--- a/packages/core/src/lib/view-transitions/index.ts
+++ b/packages/core/src/lib/view-transitions/index.ts
@@ -1,3 +1,4 @@
+export * from "./drill";
 export * from "./fade";
 export * from "./hero";
 export * from "./pinterest";


### PR DESCRIPTION
## Summary
- Added new `drill` transition to the core view-transitions library
- Implemented configurable `opacity` and `direction` options for the drill transition
- Updated demo posts page to use the new drill transition

## Details
The drill transition provides a parallax-like effect with customizable direction:
- `direction: "enter"` - Slides in from right with parallax on the previous page
- `direction: "exit"` - Slides out to right with parallax on the incoming page
- `opacity` option (default: false) - For future implementation of content-only opacity

## TODOs
- [ ] Add documentation for the drill transition
- [ ] Write blog post about the drill transition implementation
- [ ] Implement content-only opacity feature (currently marked as TODO in code)

🤖 Generated with [Claude Code](https://claude.ai/code)