### PR TITLE
feat: Add mask transition effect

### DIFF
--- a/apps/docs/content/en/04.transitions/08-mask.mdx
+++ b/apps/docs/content/en/04.transitions/08-mask.mdx
@@ -1,0 +1,141 @@
+---
+title: "Mask Animation"
+description: "Stylish reveal and hide effects using clipping masks"
+nav-title: "Mask"
+---
+
+# Mask Animation
+
+The Mask animation uses clipping masks to create stylish reveal and hide effects where elements appear or disappear in circular, elliptical, or square shapes. It provides elegant transitions similar to Material Design's ripple effect.
+
+<TransitionDemo type="mask" />
+
+## Usage
+
+<Tabs items={[{ label: "React", value: "react" }, { label: "Svelte", value: "svelte" }, { label: "Vue", value: "vue" }]}>
+  <TabPanel value="react">
+    ```tsx
+    import { transition } from '@ssgoi/react';
+    import { mask } from '@ssgoi/react/transitions';
+
+    function Component() {
+      return (
+        <div ref={transition({
+          key: 'my-element',
+          ...mask()
+        })}>
+          Mask me!
+        </div>
+      );
+    }
+    ```
+  </TabPanel>
+  <TabPanel value="svelte">
+    ```svelte
+    <script>
+      import { transition } from '@ssgoi/svelte';
+      import { mask } from '@ssgoi/svelte/transitions';
+    </script>
+
+    <div use:transition={{
+      key: 'my-element',
+      ...mask()
+    }}>
+      Mask me!
+    </div>
+    ```
+  </TabPanel>
+  <TabPanel value="vue">
+    ```vue
+    <script setup>
+    import { mask } from '@ssgoi/vue/transitions';
+    </script>
+
+    <template>
+      <div v-transition="{
+        key: 'my-element',
+        ...mask()
+      }">
+        Mask me!
+      </div>
+    </template>
+    ```
+  </TabPanel>
+</Tabs>
+
+## Options
+
+```typescript
+interface MaskOptions {
+  shape?: 'circle' | 'ellipse' | 'square';  // Mask shape (default: 'circle')
+  origin?: 'center' | 'top' | 'bottom' | 'left' | 'right' | 
+           'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';  // Origin position (default: 'center')
+  scale?: number;     // Mask size scale (default: 1.5)
+  fade?: boolean;     // Apply fade effect simultaneously (default: false)
+  spring?: {
+    stiffness?: number;  // Spring stiffness (default: 300)
+    damping?: number;    // Damping ratio (default: 30)
+  };
+}
+```
+
+### Examples
+
+```tsx
+// Circular mask from center
+mask()
+
+// Circular mask from top-left
+mask({ origin: 'top-left' })
+
+// Elliptical mask
+mask({ shape: 'ellipse' })
+
+// Square mask
+mask({ shape: 'square', origin: 'center' })
+
+// With fade effect
+mask({ fade: true })
+
+// Larger mask range
+mask({ scale: 2 })
+
+// Smooth animation
+mask({ spring: { stiffness: 100, damping: 20 } })
+```
+
+## Use Cases
+
+### Card Ripple Effect
+
+```tsx
+// Ripple effect from click position
+mask({ 
+  origin: 'top-left',  // Set dynamically based on click position
+  scale: 2,
+  spring: { stiffness: 400, damping: 35 }
+})
+```
+
+### Modal Opening Effect
+
+```tsx
+// Modal expanding from button position
+mask({
+  origin: 'bottom-right',  // Button position
+  scale: 3,
+  fade: true
+})
+```
+
+### Gallery Image Transition
+
+```tsx
+// Expand from image center
+mask({
+  shape: 'circle',
+  origin: 'center',
+  scale: 1.5,
+  spring: { stiffness: 200, damping: 25 }
+})
+```

--- a/apps/docs/content/ja/04.transitions/08-mask.mdx
+++ b/apps/docs/content/ja/04.transitions/08-mask.mdx
@@ -1,0 +1,141 @@
+---
+title: "マスクアニメーション"
+description: "クリッピングマスクを使用したスタイリッシュな表示・非表示エフェクト"
+nav-title: "マスク"
+---
+
+# マスクアニメーション
+
+マスク（Mask）アニメーションは、クリッピングマスクを使用して、要素が円形、楕円形、または正方形の形状で表示または非表示になるスタイリッシュなエフェクトを作成します。Material Designのリップルエフェクトに似たエレガントなトランジションを提供します。
+
+<TransitionDemo type="mask" />
+
+## 使用方法
+
+<Tabs items={[{ label: "React", value: "react" }, { label: "Svelte", value: "svelte" }, { label: "Vue", value: "vue" }]}>
+  <TabPanel value="react">
+    ```tsx
+    import { transition } from '@ssgoi/react';
+    import { mask } from '@ssgoi/react/transitions';
+
+    function Component() {
+      return (
+        <div ref={transition({
+          key: 'my-element',
+          ...mask()
+        })}>
+          マスクエフェクト！
+        </div>
+      );
+    }
+    ```
+  </TabPanel>
+  <TabPanel value="svelte">
+    ```svelte
+    <script>
+      import { transition } from '@ssgoi/svelte';
+      import { mask } from '@ssgoi/svelte/transitions';
+    </script>
+
+    <div use:transition={{
+      key: 'my-element',
+      ...mask()
+    }}>
+      マスクエフェクト！
+    </div>
+    ```
+  </TabPanel>
+  <TabPanel value="vue">
+    ```vue
+    <script setup>
+    import { mask } from '@ssgoi/vue/transitions';
+    </script>
+
+    <template>
+      <div v-transition="{
+        key: 'my-element',
+        ...mask()
+      }">
+        マスクエフェクト！
+      </div>
+    </template>
+    ```
+  </TabPanel>
+</Tabs>
+
+## オプション
+
+```typescript
+interface MaskOptions {
+  shape?: 'circle' | 'ellipse' | 'square';  // マスクの形状（デフォルト：'circle'）
+  origin?: 'center' | 'top' | 'bottom' | 'left' | 'right' | 
+           'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';  // 開始位置（デフォルト：'center'）
+  scale?: number;     // マスクサイズの倍率（デフォルト：1.5）
+  fade?: boolean;     // フェード効果を同時に適用（デフォルト：false）
+  spring?: {
+    stiffness?: number;  // スプリングの剛性（デフォルト：300）
+    damping?: number;    // 減衰係数（デフォルト：30）
+  };
+}
+```
+
+### 使用例
+
+```tsx
+// 中央から始まる円形マスク
+mask()
+
+// 左上から始まる円形マスク
+mask({ origin: 'top-left' })
+
+// 楕円形マスク
+mask({ shape: 'ellipse' })
+
+// 正方形マスク
+mask({ shape: 'square', origin: 'center' })
+
+// フェード効果付き
+mask({ fade: true })
+
+// より大きな範囲のマスク
+mask({ scale: 2 })
+
+// スムーズなアニメーション
+mask({ spring: { stiffness: 100, damping: 20 } })
+```
+
+## 活用例
+
+### カードのリップルエフェクト
+
+```tsx
+// クリック位置から始まるリップルエフェクト
+mask({ 
+  origin: 'top-left',  // クリック位置に基づいて動的に設定
+  scale: 2,
+  spring: { stiffness: 400, damping: 35 }
+})
+```
+
+### モーダルオープンエフェクト
+
+```tsx
+// ボタン位置から展開するモーダル
+mask({
+  origin: 'bottom-right',  // ボタンの位置
+  scale: 3,
+  fade: true
+})
+```
+
+### ギャラリー画像のトランジション
+
+```tsx
+// 画像中央から展開
+mask({
+  shape: 'circle',
+  origin: 'center',
+  scale: 1.5,
+  spring: { stiffness: 200, damping: 25 }
+})
+```

--- a/apps/docs/content/ko/04.transitions/08-mask.mdx
+++ b/apps/docs/content/ko/04.transitions/08-mask.mdx
@@ -1,0 +1,141 @@
+---
+title: "마스크 애니메이션"
+description: "클리핑 마스크를 사용한 스타일리시한 나타남/사라짐 효과"
+nav-title: "마스크"
+---
+
+# 마스크 애니메이션
+
+마스크(Mask) 애니메이션은 클리핑 마스크를 사용하여 요소가 원형, 타원형, 또는 사각형 모양으로 나타나거나 사라지는 효과를 만듭니다. Material Design의 리플 효과와 유사한 스타일리시한 전환을 제공합니다.
+
+<TransitionDemo type="mask" />
+
+## 사용법
+
+<Tabs items={[{ label: "React", value: "react" }, { label: "Svelte", value: "svelte" }, { label: "Vue", value: "vue" }]}>
+  <TabPanel value="react">
+    ```tsx
+    import { transition } from '@ssgoi/react';
+    import { mask } from '@ssgoi/react/transitions';
+
+    function Component() {
+      return (
+        <div ref={transition({
+          key: 'my-element',
+          ...mask()
+        })}>
+          Mask me!
+        </div>
+      );
+    }
+    ```
+  </TabPanel>
+  <TabPanel value="svelte">
+    ```svelte
+    <script>
+      import { transition } from '@ssgoi/svelte';
+      import { mask } from '@ssgoi/svelte/transitions';
+    </script>
+
+    <div use:transition={{
+      key: 'my-element',
+      ...mask()
+    }}>
+      Mask me!
+    </div>
+    ```
+  </TabPanel>
+  <TabPanel value="vue">
+    ```vue
+    <script setup>
+    import { mask } from '@ssgoi/vue/transitions';
+    </script>
+
+    <template>
+      <div v-transition="{
+        key: 'my-element',
+        ...mask()
+      }">
+        Mask me!
+      </div>
+    </template>
+    ```
+  </TabPanel>
+</Tabs>
+
+## 옵션
+
+```typescript
+interface MaskOptions {
+  shape?: 'circle' | 'ellipse' | 'square';  // 마스크 모양 (기본값: 'circle')
+  origin?: 'center' | 'top' | 'bottom' | 'left' | 'right' | 
+           'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';  // 시작 위치 (기본값: 'center')
+  scale?: number;     // 마스크 크기 배율 (기본값: 1.5)
+  fade?: boolean;     // 페이드 효과 동시 적용 (기본값: false)
+  spring?: {
+    stiffness?: number;  // 스프링 강도 (기본값: 300)
+    damping?: number;    // 감쇠 계수 (기본값: 30)
+  };
+}
+```
+
+### 사용 예시
+
+```tsx
+// 중앙에서 시작하는 원형 마스크
+mask()
+
+// 좌측 상단에서 시작하는 원형 마스크
+mask({ origin: 'top-left' })
+
+// 타원형 마스크
+mask({ shape: 'ellipse' })
+
+// 사각형 마스크
+mask({ shape: 'square', origin: 'center' })
+
+// 페이드와 함께 적용
+mask({ fade: true })
+
+// 더 큰 범위의 마스크
+mask({ scale: 2 })
+
+// 부드러운 애니메이션
+mask({ spring: { stiffness: 100, damping: 20 } })
+```
+
+## 활용 예시
+
+### 카드 리플 효과
+
+```tsx
+// 클릭 위치에서 시작하는 리플 효과
+mask({ 
+  origin: 'top-left',  // 클릭 위치에 따라 동적으로 설정
+  scale: 2,
+  spring: { stiffness: 400, damping: 35 }
+})
+```
+
+### 모달 오픈 효과
+
+```tsx
+// 버튼 위치에서 확장되는 모달
+mask({
+  origin: 'bottom-right',  // 버튼 위치
+  scale: 3,
+  fade: true
+})
+```
+
+### 갤러리 이미지 전환
+
+```tsx
+// 이미지 중앙에서 확장
+mask({
+  shape: 'circle',
+  origin: 'center',
+  scale: 1.5,
+  spring: { stiffness: 200, damping: 25 }
+})
+```

--- a/apps/docs/content/zh/04.transitions/08-mask.mdx
+++ b/apps/docs/content/zh/04.transitions/08-mask.mdx
@@ -1,0 +1,141 @@
+---
+title: "遮罩动画"
+description: "使用剪切遮罩实现时尚的显示和隐藏效果"
+nav-title: "遮罩"
+---
+
+# 遮罩动画
+
+遮罩（Mask）动画使用剪切遮罩创建时尚的显示和隐藏效果，元素以圆形、椭圆形或方形的形状出现或消失。它提供了类似 Material Design 涟漪效果的优雅过渡。
+
+<TransitionDemo type="mask" />
+
+## 使用方法
+
+<Tabs items={[{ label: "React", value: "react" }, { label: "Svelte", value: "svelte" }, { label: "Vue", value: "vue" }]}>
+  <TabPanel value="react">
+    ```tsx
+    import { transition } from '@ssgoi/react';
+    import { mask } from '@ssgoi/react/transitions';
+
+    function Component() {
+      return (
+        <div ref={transition({
+          key: 'my-element',
+          ...mask()
+        })}>
+          遮罩效果！
+        </div>
+      );
+    }
+    ```
+  </TabPanel>
+  <TabPanel value="svelte">
+    ```svelte
+    <script>
+      import { transition } from '@ssgoi/svelte';
+      import { mask } from '@ssgoi/svelte/transitions';
+    </script>
+
+    <div use:transition={{
+      key: 'my-element',
+      ...mask()
+    }}>
+      遮罩效果！
+    </div>
+    ```
+  </TabPanel>
+  <TabPanel value="vue">
+    ```vue
+    <script setup>
+    import { mask } from '@ssgoi/vue/transitions';
+    </script>
+
+    <template>
+      <div v-transition="{
+        key: 'my-element',
+        ...mask()
+      }">
+        遮罩效果！
+      </div>
+    </template>
+    ```
+  </TabPanel>
+</Tabs>
+
+## 选项
+
+```typescript
+interface MaskOptions {
+  shape?: 'circle' | 'ellipse' | 'square';  // 遮罩形状（默认：'circle'）
+  origin?: 'center' | 'top' | 'bottom' | 'left' | 'right' | 
+           'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';  // 起始位置（默认：'center'）
+  scale?: number;     // 遮罩大小比例（默认：1.5）
+  fade?: boolean;     // 同时应用淡入淡出效果（默认：false）
+  spring?: {
+    stiffness?: number;  // 弹簧刚度（默认：300）
+    damping?: number;    // 阻尼系数（默认：30）
+  };
+}
+```
+
+### 使用示例
+
+```tsx
+// 从中心开始的圆形遮罩
+mask()
+
+// 从左上角开始的圆形遮罩
+mask({ origin: 'top-left' })
+
+// 椭圆形遮罩
+mask({ shape: 'ellipse' })
+
+// 方形遮罩
+mask({ shape: 'square', origin: 'center' })
+
+// 带淡入淡出效果
+mask({ fade: true })
+
+// 更大范围的遮罩
+mask({ scale: 2 })
+
+// 平滑动画
+mask({ spring: { stiffness: 100, damping: 20 } })
+```
+
+## 应用场景
+
+### 卡片涟漪效果
+
+```tsx
+// 从点击位置开始的涟漪效果
+mask({ 
+  origin: 'top-left',  // 根据点击位置动态设置
+  scale: 2,
+  spring: { stiffness: 400, damping: 35 }
+})
+```
+
+### 模态窗口打开效果
+
+```tsx
+// 从按钮位置展开的模态窗口
+mask({
+  origin: 'bottom-right',  // 按钮位置
+  scale: 3,
+  fade: true
+})
+```
+
+### 画廊图片过渡
+
+```tsx
+// 从图片中心展开
+mask({
+  shape: 'circle',
+  origin: 'center',
+  scale: 1.5,
+  spring: { stiffness: 200, damping: 25 }
+})
+```

--- a/apps/docs/src/components/mdx/mdx-components/transition-demo.tsx
+++ b/apps/docs/src/components/mdx/mdx-components/transition-demo.tsx
@@ -49,6 +49,12 @@ const transitionOptions = {
     { name: 'y', type: 'range', min: -500, max: 500, step: 10, default: -100 },
     { name: 'x', type: 'range', min: -500, max: 500, step: 10, default: 0 },
     { name: 'opacity', type: 'range', min: 0, max: 1, step: 0.1, default: 0 }
+  ],
+  mask: [
+    { name: 'shape', type: 'select', options: ['circle', 'ellipse', 'square'], default: 'circle' },
+    { name: 'origin', type: 'select', options: ['center', 'top', 'bottom', 'left', 'right', 'top-left', 'top-right', 'bottom-left', 'bottom-right'], default: 'center' },
+    { name: 'scale', type: 'range', min: 0.5, max: 3, step: 0.1, default: 1.5 },
+    { name: 'fade', type: 'toggle', default: false }
   ]
 } as const;
 

--- a/packages/core/src/lib/transitions/index.ts
+++ b/packages/core/src/lib/transitions/index.ts
@@ -5,4 +5,5 @@ export * from './rotate';
 export * from './bounce';
 export * from './blur';
 export * from './fly';
+export * from './mask';
 export * from './none';

--- a/packages/core/src/lib/transitions/mask.ts
+++ b/packages/core/src/lib/transitions/mask.ts
@@ -1,0 +1,83 @@
+import type { TransitionKey } from '../types';
+
+interface MaskOptions {
+  shape?: 'circle' | 'ellipse' | 'square';
+  origin?: 'center' | 'top' | 'bottom' | 'left' | 'right' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+  scale?: number;
+  fade?: boolean;
+  spring?: {
+    stiffness?: number;
+    damping?: number;
+  };
+  key?: TransitionKey;
+}
+
+export const mask = (options: MaskOptions = {}) => {
+  const {
+    shape = 'circle',
+    origin = 'center',
+    scale = 1.5,
+    fade = false,
+    spring = { stiffness: 300, damping: 30 },
+    key
+  } = options;
+
+  const getOriginPosition = (): string => {
+    switch (origin) {
+      case 'top': return '50% 0%';
+      case 'bottom': return '50% 100%';
+      case 'left': return '0% 50%';
+      case 'right': return '100% 50%';
+      case 'top-left': return '0% 0%';
+      case 'top-right': return '100% 0%';
+      case 'bottom-left': return '0% 100%';
+      case 'bottom-right': return '100% 100%';
+      case 'center':
+      default: return '50% 50%';
+    }
+  };
+
+  const getClipPath = (progress: number): string => {
+    const size = progress * scale * 100;
+    const position = getOriginPosition();
+    
+    switch (shape) {
+      case 'ellipse':
+        return `ellipse(${size}% ${size * 0.75}% at ${position})`;
+      case 'square':
+        const squareSize = progress * scale * 100;
+        const [x, y] = position.split(' ');
+        const xVal = parseFloat(x || '50');
+        const yVal = parseFloat(y || '50');
+        const halfSize = squareSize / 2;
+        return `polygon(${xVal - halfSize}% ${yVal - halfSize}%, ${xVal + halfSize}% ${yVal - halfSize}%, ${xVal + halfSize}% ${yVal + halfSize}%, ${xVal - halfSize}% ${yVal + halfSize}%)`;
+      case 'circle':
+      default:
+        return `circle(${size}% at ${position})`;
+    }
+  };
+
+  return {
+    in: (element: HTMLElement) => ({
+      spring,
+      tick: (progress: number) => {
+        element.style.clipPath = getClipPath(progress);
+        
+        if (fade) {
+          element.style.opacity = progress.toString();
+        }
+      }
+    }),
+    out: (element: HTMLElement) => ({
+      spring,
+      tick: (progress: number) => {
+        element.style.clipPath = getClipPath(progress);
+        
+        if (fade) {
+          element.style.opacity = progress.toString();
+        }
+      }
+    }),
+    ...(key && { key })
+  };
+};

--- a/packages/core/src/lib/transitions/mask.ts
+++ b/packages/core/src/lib/transitions/mask.ts
@@ -1,8 +1,17 @@
-import type { TransitionKey } from '../types';
+import type { TransitionKey } from "../types";
 
 interface MaskOptions {
-  shape?: 'circle' | 'ellipse' | 'square';
-  origin?: 'center' | 'top' | 'bottom' | 'left' | 'right' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+  shape?: "circle" | "ellipse" | "square";
+  origin?:
+    | "center"
+    | "top"
+    | "bottom"
+    | "left"
+    | "right"
+    | "top-left"
+    | "top-right"
+    | "bottom-left"
+    | "bottom-right";
   scale?: number;
   fade?: boolean;
   spring?: {
@@ -14,44 +23,57 @@ interface MaskOptions {
 
 export const mask = (options: MaskOptions = {}) => {
   const {
-    shape = 'circle',
-    origin = 'center',
+    shape = "circle",
+    origin = "center",
     scale = 1.5,
     fade = false,
     spring = { stiffness: 300, damping: 30 },
-    key
+    key,
   } = options;
 
   const getOriginPosition = (): string => {
     switch (origin) {
-      case 'top': return '50% 0%';
-      case 'bottom': return '50% 100%';
-      case 'left': return '0% 50%';
-      case 'right': return '100% 50%';
-      case 'top-left': return '0% 0%';
-      case 'top-right': return '100% 0%';
-      case 'bottom-left': return '0% 100%';
-      case 'bottom-right': return '100% 100%';
-      case 'center':
-      default: return '50% 50%';
+      case "top":
+        return "50% 0%";
+      case "bottom":
+        return "50% 100%";
+      case "left":
+        return "0% 50%";
+      case "right":
+        return "100% 50%";
+      case "top-left":
+        return "0% 0%";
+      case "top-right":
+        return "100% 0%";
+      case "bottom-left":
+        return "0% 100%";
+      case "bottom-right":
+        return "100% 100%";
+      case "center":
+      default:
+        return "50% 50%";
     }
   };
 
   const getClipPath = (progress: number): string => {
     const size = progress * scale * 100;
     const position = getOriginPosition();
-    
+
     switch (shape) {
-      case 'ellipse':
+      case "ellipse":
         return `ellipse(${size}% ${size * 0.75}% at ${position})`;
-      case 'square':
+      case "square":
         const squareSize = progress * scale * 100;
-        const [x, y] = position.split(' ');
-        const xVal = parseFloat(x || '50');
-        const yVal = parseFloat(y || '50');
+        const [x, y] = position.split(" ");
+        const xVal = parseFloat(x!);
+        const yVal = parseFloat(y!);
         const halfSize = squareSize / 2;
-        return `polygon(${xVal - halfSize}% ${yVal - halfSize}%, ${xVal + halfSize}% ${yVal - halfSize}%, ${xVal + halfSize}% ${yVal + halfSize}%, ${xVal - halfSize}% ${yVal + halfSize}%)`;
-      case 'circle':
+        return `polygon(${xVal - halfSize}% ${yVal - halfSize}%, ${
+          xVal + halfSize
+        }% ${yVal - halfSize}%, ${xVal + halfSize}% ${yVal + halfSize}%, ${
+          xVal - halfSize
+        }% ${yVal + halfSize}%)`;
+      case "circle":
       default:
         return `circle(${size}% at ${position})`;
     }
@@ -62,22 +84,22 @@ export const mask = (options: MaskOptions = {}) => {
       spring,
       tick: (progress: number) => {
         element.style.clipPath = getClipPath(progress);
-        
+
         if (fade) {
           element.style.opacity = progress.toString();
         }
-      }
+      },
     }),
     out: (element: HTMLElement) => ({
       spring,
       tick: (progress: number) => {
         element.style.clipPath = getClipPath(progress);
-        
+
         if (fade) {
           element.style.opacity = progress.toString();
         }
-      }
+      },
     }),
-    ...(key && { key })
+    ...(key && { key }),
   };
 };


### PR DESCRIPTION
## Summary
- Added a new mask transition effect using CSS clip-path for stylish reveal/hide animations
- Provides Material Design-like ripple effects with customizable shapes and origins
- Includes comprehensive documentation in 4 languages

## Changes
- **New transition**: `mask` transition with circle, ellipse, and square shapes
- **Configurable options**: 9 origin positions, scale factor, and optional fade effect
- **Documentation**: Added documentation in English, Korean, Chinese, and Japanese
- **Demo support**: Updated transition demo component to showcase mask options

## Features
- 🎭 Three mask shapes: circle, ellipse, square
- 📍 9 origin positions for flexible animation starting points
- 🎨 Optional fade effect that can be combined with mask
- ⚡ Performance-optimized using CSS clip-path
- 🌍 Full internationalization support

## Test plan
- [ ] Build all packages successfully
- [ ] Test mask transition in React demo app
- [ ] Test mask transition in Svelte demo app
- [ ] Verify all shape options work correctly
- [ ] Verify all origin positions work as expected
- [ ] Check documentation renders correctly in all languages

🤖 Generated with [Claude Code](https://claude.ai/code)