### PR TITLE
Fix incorrect animation cancellation strategy in page transitions

### DIFF
--- a/packages/core/src/lib/create-ssgoi-transition-context.ts
+++ b/packages/core/src/lib/create-ssgoi-transition-context.ts
@@ -5,6 +5,7 @@ import type {
   Transition,
 } from "./types";
 import { getScrollingElement } from "./utils/get-scrolling-element";
+import { TRANSITION_STRATEGY, createPageTransitionStrategy } from "./transition-strategy";
 
 /**
  * SSGOI Transition Context Operation Principles
@@ -228,6 +229,8 @@ export function createSggoiTransitionContext(
         const transitionConfig = await getTransition(path, "out");
         return transitionConfig(element);
       },
+      // Add page transition strategy for page-level transitions
+      [TRANSITION_STRATEGY]: createPageTransitionStrategy,
     };
   };
 }

--- a/packages/core/src/lib/transition-strategy.ts
+++ b/packages/core/src/lib/transition-strategy.ts
@@ -193,3 +193,77 @@ export const createDefaultStrategy = <TAnimationValue = number>(
     },
   };
 };
+
+/**
+ * Page transition strategy - Always starts fresh without checking current animations
+ * This is used for page-level transitions where each transition should be independent
+ */
+export const createPageTransitionStrategy = <TAnimationValue = number>(
+  _: StrategyContext<TAnimationValue>
+): TransitionStrategy<TAnimationValue> => {
+  return {
+    runIn: async (configs: TransitionConfigs<TAnimationValue>) => {
+      // Always start fresh for IN transition
+      const config = await configs.in;
+      if (!config) {
+        return {
+          state: {
+            position: 0 as TAnimationValue,
+            velocity: 0 as TAnimationValue extends number
+              ? number
+              : Record<string, number>,
+          },
+          from: 0 as TAnimationValue,
+          to: 1 as TAnimationValue,
+          direction: "forward",
+        };
+      }
+
+      const { from = 0 as TAnimationValue, to = 1 as TAnimationValue } = config;
+      return {
+        config,
+        state: {
+          position: from,
+          velocity: 0 as TAnimationValue extends number
+            ? number
+            : Record<string, number>,
+        },
+        from,
+        to,
+        direction: "forward",
+      };
+    },
+
+    runOut: async (configs: TransitionConfigs<TAnimationValue>) => {
+      // Always start fresh for OUT transition
+      const config = await configs.out;
+      if (!config) {
+        return {
+          state: {
+            position: 1 as TAnimationValue,
+            velocity: 0 as TAnimationValue extends number
+              ? number
+              : Record<string, number>,
+          },
+          from: 1 as TAnimationValue,
+          to: 0 as TAnimationValue,
+          direction: "forward",
+        };
+      }
+
+      const { from = 1 as TAnimationValue, to = 0 as TAnimationValue } = config;
+      return {
+        config,
+        state: {
+          position: from,
+          velocity: 0 as TAnimationValue extends number
+            ? number
+            : Record<string, number>,
+        },
+        from,
+        to,
+        direction: "forward",
+      };
+    },
+  };
+};


### PR DESCRIPTION
## Summary
- Fixed an issue where page transitions would intermittently fail to execute tick functions after prepare
- This resolves the problem where elements would get stuck in a transparent state during fade transitions

## Problem
The default transition strategy was incorrectly trying to reverse animations when switching between IN/OUT states during page navigation. This caused the tick function to sometimes not execute even though prepare was called, leaving elements stuck in their initial prepared state (e.g., opacity: 0).

## Solution
Created a dedicated `createPageTransitionStrategy` for page-level transitions that:
- Always starts fresh for each transition
- Uses the correct IN config for entrance animations
- Uses the correct OUT config for exit animations
- Never attempts to reverse or reuse animation states between pages

## Test plan
- [x] Test fade transitions between pages - elements should always animate properly
- [x] Test rapid navigation between pages - no stuck transparent elements
- [x] Verify prepare and tick functions always execute together
- [x] Check that page transitions complete successfully

🤖 Generated with [Claude Code](https://claude.ai/code)