### PR TITLE
fix: Add demo name prefixes to SsgoiTransition IDs

### DIFF
--- a/apps/docs/src/components/mdx/mdx-components/view-transition-demo/blind-demo.tsx
+++ b/apps/docs/src/components/mdx/mdx-components/view-transition-demo/blind-demo.tsx
@@ -13,7 +13,7 @@ function TheaterPage() {
 
   return (
     <DemoPage
-      path="/"
+      path="/blind"
       className="bg-gradient-to-br from-gray-900 via-red-950 to-gray-900 min-h-full"
     >
       <div
@@ -82,7 +82,7 @@ function Act1Page() {
 
   return (
     <DemoPage
-      path="/act1"
+      path="/blind/act1"
       className="bg-gradient-to-br from-gray-900 via-purple-950 to-gray-900 min-h-full"
     >
       <div
@@ -157,7 +157,7 @@ function Act2Page() {
 
   return (
     <DemoPage
-      path="/act2"
+      path="/blind/act2"
       className="bg-gradient-to-br from-gray-900 via-blue-950 to-gray-900 min-h-full"
     >
       <div
@@ -248,7 +248,7 @@ function FinalePage() {
 
   return (
     <DemoPage
-      path="/finale"
+      path="/blind/finale"
       className="bg-gradient-to-br from-gray-900 via-yellow-950 to-gray-900 min-h-full"
     >
       <div
@@ -323,10 +323,10 @@ function FinalePage() {
 
 // Route configuration
 const blindRoutes: RouteConfig[] = [
-  { path: "/", component: TheaterPage, label: "Opening" },
-  { path: "/act1", component: Act1Page, label: "Act I" },
-  { path: "/act2", component: Act2Page, label: "Act II" },
-  { path: "/finale", component: FinalePage, label: "Finale" },
+  { path: "/blind", component: TheaterPage, label: "Opening" },
+  { path: "/blind/act1", component: Act1Page, label: "Act I" },
+  { path: "/blind/act2", component: Act2Page, label: "Act II" },
+  { path: "/blind/finale", component: FinalePage, label: "Finale" },
 ];
 
 // Header Actions Component

--- a/apps/docs/src/components/mdx/mdx-components/view-transition-demo/drill-demo.tsx
+++ b/apps/docs/src/components/mdx/mdx-components/view-transition-demo/drill-demo.tsx
@@ -281,7 +281,7 @@ function PostDetailPage({ post }: { post: (typeof blogPosts)[0] }) {
         <div className="sticky top-0 z-10 bg-gray-950/80 backdrop-blur-md border-b border-gray-800">
           <div className="max-w-4xl mx-auto p-4">
             <DemoLink
-              to="/posts"
+              to="/drill/posts"
               className="inline-flex items-center gap-2 text-gray-400 hover:text-white transition-colors no-underline"
             >
               <svg
@@ -353,7 +353,7 @@ function PostDetailPage({ post }: { post: (typeof blogPosts)[0] }) {
           {/* Footer */}
           <footer className="mt-12 pt-8 border-t border-gray-800">
             <DemoLink
-              to="/posts"
+              to="/drill/posts"
               className="inline-flex items-center gap-2 px-6 py-3 bg-gray-800 hover:bg-gray-700 rounded-lg text-white transition-colors no-underline"
             >
               <svg

--- a/apps/docs/src/components/mdx/mdx-components/view-transition-demo/fade-demo.tsx
+++ b/apps/docs/src/components/mdx/mdx-components/view-transition-demo/fade-demo.tsx
@@ -13,7 +13,7 @@ function HomePage() {
 
   return (
     <DemoPage
-      path="/"
+      path="/fade"
       className="bg-gradient-to-br from-gray-900 to-gray-800 min-h-full"
     >
       <div
@@ -96,7 +96,7 @@ function FeaturesPage() {
 
   return (
     <DemoPage
-      path="/features"
+      path="/fade/features"
       className="bg-gradient-to-br from-gray-900 to-gray-800 min-h-full"
     >
       <div
@@ -201,7 +201,7 @@ function ExamplesPage() {
 
   return (
     <DemoPage
-      path="/examples"
+      path="/fade/examples"
       className="bg-gradient-to-br from-gray-900 to-gray-800 min-h-full"
     >
       <div
@@ -258,7 +258,7 @@ function GettingStartedPage() {
 
   return (
     <DemoPage
-      path="/start"
+      path="/fade/start"
       className="bg-gradient-to-br from-gray-900 to-gray-800 min-h-full"
     >
       <div
@@ -350,10 +350,10 @@ export default function HomePage() {
 
 // Route configuration
 const fadeRoutes: RouteConfig[] = [
-  { path: "/", component: HomePage, label: "Home" },
-  { path: "/features", component: FeaturesPage, label: "Features" },
-  { path: "/examples", component: ExamplesPage, label: "Examples" },
-  { path: "/start", component: GettingStartedPage, label: "Start" },
+  { path: "/fade", component: HomePage, label: "Home" },
+  { path: "/fade/features", component: FeaturesPage, label: "Features" },
+  { path: "/fade/examples", component: ExamplesPage, label: "Examples" },
+  { path: "/fade/start", component: GettingStartedPage, label: "Start" },
 ];
 
 // Header Actions Component

--- a/apps/docs/src/components/mdx/mdx-components/view-transition-demo/hero-demo.tsx
+++ b/apps/docs/src/components/mdx/mdx-components/view-transition-demo/hero-demo.tsx
@@ -172,7 +172,7 @@ function GalleryDetailPage({ item }: { item: (typeof galleryItems)[0] }) {
           <div className="absolute top-0 left-0 right-0 z-20 bg-gradient-to-b from-black/60 to-transparent p-4">
             <div className="flex items-center justify-between max-w-6xl mx-auto">
               <DemoLink
-                to="/gallery"
+                to="/hero/gallery"
                 className="flex items-center gap-2 px-4 py-2 bg-white/20 backdrop-blur-md rounded-lg text-white hover:bg-white/30 transition-all transform hover:scale-105 no-underline"
               >
                 <svg
@@ -194,7 +194,7 @@ function GalleryDetailPage({ item }: { item: (typeof galleryItems)[0] }) {
                   Press ESC
                 </span>
                 <DemoLink
-                  to="/gallery"
+                  to="/hero/gallery"
                   className="p-2 bg-white/20 backdrop-blur-md rounded-full text-white hover:bg-white/30 transition-all transform hover:scale-105 no-underline"
                   aria-label="Close"
                 >

--- a/apps/docs/src/components/mdx/mdx-components/view-transition-demo/pinterest-demo.tsx
+++ b/apps/docs/src/components/mdx/mdx-components/view-transition-demo/pinterest-demo.tsx
@@ -107,7 +107,7 @@ const pinterestItems = [
 // Pinterest Grid Page Component
 function PinterestGridPage() {
   return (
-    <DemoPage path="/pinterest">
+    <DemoPage path="/pinterest/gallery">
       <div className="min-h-screen p-4">
         {/* Header */}
         <div className="mb-6 text-center">
@@ -122,7 +122,7 @@ function PinterestGridPage() {
           {pinterestItems.map((item) => (
             <DemoLink
               key={item.id}
-              to={`/pinterest/${item.id}`}
+              to={`/pinterest/gallery/${item.id}`}
               className="break-inside-avoid block no-underline"
             >
               <article className="relative group cursor-pointer">
@@ -185,7 +185,7 @@ function PinterestDetailPage({ item }: { item: (typeof pinterestItems)[0] }) {
   useEffect(() => {
     const handleKeyPress = (e: KeyboardEvent) => {
       if (e.key === "Escape") {
-        navigate("/pinterest");
+        navigate("/pinterest/gallery");
       }
     };
 
@@ -194,7 +194,7 @@ function PinterestDetailPage({ item }: { item: (typeof pinterestItems)[0] }) {
   }, [navigate]);
 
   return (
-    <DemoPage path={`/pinterest/${item.id}`}>
+    <DemoPage path={`/pinterest/gallery/${item.id}`}>
       <div className="min-h-screen">
         {/* Content */}
         <div>
@@ -209,7 +209,7 @@ function PinterestDetailPage({ item }: { item: (typeof pinterestItems)[0] }) {
             
             {/* Back button overlay */}
             <DemoLink
-              to="/pinterest"
+              to="/pinterest/gallery"
               className="absolute top-3 left-3 p-2 bg-black/60 backdrop-blur-sm hover:bg-black/80 rounded-full transition-colors no-underline"
             >
               <svg
@@ -319,14 +319,14 @@ function PinterestDetailPage({ item }: { item: (typeof pinterestItems)[0] }) {
 
 // Create route configuration for detail pages
 const detailPages = pinterestItems.map((item) => ({
-  path: `/pinterest/${item.id}`,
+  path: `/pinterest/gallery/${item.id}`,
   component: () => <PinterestDetailPage item={item} />,
   label: item.title,
 }));
 
 // Route configuration
 const pinterestRoutes: RouteConfig[] = [
-  { path: "/pinterest", component: PinterestGridPage, label: "Pinterest" },
+  { path: "/pinterest/gallery", component: PinterestGridPage, label: "Pinterest" },
   ...detailPages,
 ];
 
@@ -349,8 +349,8 @@ export function PinterestDemo() {
   const config = {
     transitions: [
       {
-        from: "/pinterest",
-        to: "/pinterest/*",
+        from: "/pinterest/gallery",
+        to: "/pinterest/gallery/*",
         transition: pinterest({ spring: { stiffness: 150, damping: 20 } }),
         symmetric: true,
       },
@@ -362,7 +362,7 @@ export function PinterestDemo() {
       routes={pinterestRoutes}
       config={config}
       layout={PinterestLayout}
-      initialPath="/pinterest"
+      initialPath="/pinterest/gallery"
     />
   );
 }

--- a/apps/docs/src/components/mdx/mdx-components/view-transition-demo/scroll-demo.tsx
+++ b/apps/docs/src/components/mdx/mdx-components/view-transition-demo/scroll-demo.tsx
@@ -13,7 +13,7 @@ import type { RouteConfig } from "../browser-mockup";
 // Intro Section Page
 function IntroPage() {
   return (
-    <DemoPage path="/intro">
+    <DemoPage path="/scroll/intro">
       <div className="p-4 md:p-8 max-w-3xl mx-auto">
         <div className="mb-3 md:mb-6 text-2xl md:text-4xl">📝</div>
 
@@ -83,7 +83,7 @@ function IntroPage() {
 // Features Section Page
 function FeaturesPage() {
   return (
-    <DemoPage path="/features">
+    <DemoPage path="/scroll/features">
       <div className="p-4 md:p-8 max-w-3xl mx-auto">
         <div className="mb-3 md:mb-6 text-2xl md:text-4xl">✨</div>
 
@@ -151,7 +151,7 @@ function FeaturesPage() {
 // Usage Section Page
 function UsagePage() {
   return (
-    <DemoPage path="/usage">
+    <DemoPage path="/scroll/usage">
       <div className="p-4 md:p-8 max-w-3xl mx-auto">
         <div className="mb-3 md:mb-6 text-2xl md:text-4xl">🚀</div>
 
@@ -219,7 +219,7 @@ function UsagePage() {
 // Examples Section Page
 function ExamplesPage() {
   return (
-    <DemoPage path="/examples">
+    <DemoPage path="/scroll/examples">
       <div className="p-4 md:p-8 max-w-3xl mx-auto">
         <div className="mb-3 md:mb-6 text-2xl md:text-4xl">💡</div>
 
@@ -288,10 +288,10 @@ function ExamplesPage() {
 
 // Route configuration with sidebar navigation
 const scrollRoutes: RouteConfig[] = [
-  { path: "/intro", component: IntroPage, label: "📝 Introduction" },
-  { path: "/features", component: FeaturesPage, label: "✨ Features" },
-  { path: "/usage", component: UsagePage, label: "🚀 Usage" },
-  { path: "/examples", component: ExamplesPage, label: "💡 Examples" },
+  { path: "/scroll/intro", component: IntroPage, label: "📝 Introduction" },
+  { path: "/scroll/features", component: FeaturesPage, label: "✨ Features" },
+  { path: "/scroll/usage", component: UsagePage, label: "🚀 Usage" },
+  { path: "/scroll/examples", component: ExamplesPage, label: "💡 Examples" },
 ];
 
 // Custom layout with sidebar navigation

--- a/apps/docs/src/components/mdx/mdx-components/view-transition-demo/slide-demo.tsx
+++ b/apps/docs/src/components/mdx/mdx-components/view-transition-demo/slide-demo.tsx
@@ -23,7 +23,7 @@ function ClothingPage() {
   ];
 
   return (
-    <DemoPage path="/clothing">
+    <DemoPage path="/slide/clothing">
       <div className="h-full bg-white">
         <div className="p-4 md:p-6">
           <div className="flex items-center justify-between mb-4">
@@ -62,7 +62,7 @@ function ShoesPage() {
   ];
 
   return (
-    <DemoPage path="/shoes">
+    <DemoPage path="/slide/shoes">
       <div className="h-full bg-white">
         <div className="p-4 md:p-6">
           <div className="flex items-center justify-between mb-4">
@@ -108,7 +108,7 @@ function AccessoriesPage() {
   ];
 
   return (
-    <DemoPage path="/accessories">
+    <DemoPage path="/slide/accessories">
       <div className="h-full bg-white">
         <div className="p-4 md:p-6">
           <div className="flex items-center justify-between mb-4">
@@ -142,9 +142,9 @@ function AccessoriesPage() {
 
 // Route configuration with tab navigation
 const slideRoutes: RouteConfig[] = [
-  { path: "/clothing", component: ClothingPage, label: "Clothing" },
-  { path: "/shoes", component: ShoesPage, label: "Shoes" },
-  { path: "/accessories", component: AccessoriesPage, label: "Accessories" },
+  { path: "/slide/clothing", component: ClothingPage, label: "Clothing" },
+  { path: "/slide/shoes", component: ShoesPage, label: "Shoes" },
+  { path: "/slide/accessories", component: AccessoriesPage, label: "Accessories" },
 ];
 
 // Custom layout with tab navigation


### PR DESCRIPTION
## Summary
- Added demo name prefixes to all SsgoiTransition IDs in view-transition-demo components
- Prevents route conflicts between different demos when multiple are displayed on the same page

## Changes
Updated path prefixes for all demo components:
- fade-demo: `/fade` prefix
- blind-demo: `/blind` prefix  
- drill-demo: `/drill` prefix
- hero-demo: `/hero` prefix
- pinterest-demo: `/pinterest` prefix
- scroll-demo: `/scroll` prefix
- slide-demo: `/slide` prefix

## Test plan
- [x] All demo components render correctly
- [x] Navigation within each demo works as expected
- [x] No route conflicts between different demos

🤖 Generated with [Claude Code](https://claude.ai/code)