### PR TITLE
fix: Resolve unused variables and empty blocks in core package

### DIFF
--- a/packages/core/src/lib/animator.ts
+++ b/packages/core/src/lib/animator.ts
@@ -72,7 +72,7 @@ export class Animator<TAnimationValue = number> {
 
     // Handle object animations differently
     if (typeof this.currentValue === "object" && this.currentValue !== null) {
-      this.animateObject(target as any, reverse);
+      this.animateObject(target as any);
       return;
     }
 
@@ -157,7 +157,7 @@ export class Animator<TAnimationValue = number> {
     });
   };
 
-  private animateObject = (target: any, _reverse: boolean) => {
+  private animateObject = (target: any) => {
     const from = this.currentValue as any;
     const keys = Object.keys(from);
 

--- a/packages/core/src/lib/transition-strategy.ts
+++ b/packages/core/src/lib/transition-strategy.ts
@@ -198,9 +198,9 @@ export const createDefaultStrategy = <TAnimationValue = number>(
  * Page transition strategy - Always starts fresh without checking current animations
  * This is used for page-level transitions where each transition should be independent
  */
-export const createPageTransitionStrategy = <TAnimationValue = number>(
-  _: StrategyContext<TAnimationValue>,
-): TransitionStrategy<TAnimationValue> => {
+export const createPageTransitionStrategy = <
+  TAnimationValue = number,
+>(): TransitionStrategy<TAnimationValue> => {
   return {
     runIn: async (configs: TransitionConfigs<TAnimationValue>) => {
       // Always start fresh for IN transition

--- a/packages/core/src/lib/transition.ts
+++ b/packages/core/src/lib/transition.ts
@@ -97,7 +97,9 @@ const __cleanupRegistry = FinalizationRegistryCtor
   ? (new (FinalizationRegistryCtor as any)((key: TransitionKey) => {
       try {
         unregisterTransition(key);
-      } catch {}
+      } catch {
+        // Ignore cleanup errors
+      }
     }) as { register: (target: object, heldValue: TransitionKey) => void })
   : undefined;
 
@@ -167,7 +169,9 @@ export function transition<TAnimationValue = number>(
   if (options.ref && __cleanupRegistry) {
     try {
       __cleanupRegistry.register(options.ref, resolvedKey);
-    } catch {}
+    } catch {
+      // Ignore registration errors
+    }
   }
 
   return registerTransition(

--- a/packages/core/src/lib/transitions/mask.ts
+++ b/packages/core/src/lib/transitions/mask.ts
@@ -62,7 +62,7 @@ export const mask = (options: MaskOptions = {}) => {
     switch (shape) {
       case "ellipse":
         return `ellipse(${size}% ${size * 0.75}% at ${position})`;
-      case "square":
+      case "square": {
         const squareSize = progress * scale * 100;
         const [x, y] = position.split(" ");
         const xVal = parseFloat(x!);
@@ -73,6 +73,7 @@ export const mask = (options: MaskOptions = {}) => {
         }% ${yVal - halfSize}%, ${xVal + halfSize}% ${yVal + halfSize}%, ${
           xVal - halfSize
         }% ${yVal + halfSize}%)`;
+      }
       case "circle":
       default:
         return `circle(${size}% at ${position})`;

--- a/packages/core/src/lib/transitions/none.ts
+++ b/packages/core/src/lib/transitions/none.ts
@@ -12,15 +12,15 @@ export const none = (options: NoneOptions = {}) => {
   const { spring = { stiffness: 1000, damping: 100 }, key } = options;
 
   return {
-    in: (_element: HTMLElement) => ({
+    in: () => ({
       spring,
-      tick: (_progress: number) => {
+      tick: () => {
         // No animation, just instantly show
       },
     }),
-    out: (_element: HTMLElement) => ({
+    out: () => ({
       spring,
-      tick: (_progress: number) => {
+      tick: () => {
         // No animation, just instantly hide
       },
     }),


### PR DESCRIPTION
## Summary

Partially resolves #133 by fixing ESLint errors related to unused variables and empty block statements in the core package.

### Changes Made

- **animator.ts**: Removed unused `reverse` parameter from `animateObject` method
  - The `reverse` logic is already handled at line 71 where `target` is calculated based on the reverse flag
  - Object animations use this pre-calculated `target`, making the reverse parameter redundant
  - Removed from both method call (line 75) and method definition (line 160)

- **none.ts**: Removed unused parameters `_element` and `_progress` from transition callbacks
  - These parameters are not needed since `none()` performs no actual animation

- **transition-strategy.ts**: Removed unused context parameter from `createPageTransitionStrategy`
  - The strategy function doesn't use the context parameter

- **transition.ts**: Added explicit comments to empty catch blocks
  - Clarifies intentional error ignoring for cleanup and registration operations

- **mask.ts**: Wrapped case block variables in braces to create proper scope
  - Prevents ESLint `no-case-declarations` errors by isolating variable declarations

### ESLint Errors Resolved

✅ Fixed **1** unused variable error
✅ Fixed **4** unused parameter errors  
✅ Fixed **1** unused parameter error
✅ Fixed **2** empty block statement errors
✅ Fixed **5** case declaration errors

**Total: 13 ESLint errors resolved**

### Remaining Work

This PR addresses unused variables and empty blocks. The remaining `@typescript-eslint/no-explicit-any` errors (16 total) will be handled in a separate PR as they require more careful type analysis.

## Test Plan

- [x] Core package builds successfully
- [x] ESLint errors for unused variables and empty blocks are resolved
- [x] Pre-commit hooks pass
- [x] No functional changes - all animation behavior remains identical