### PR TITLE
docs(quick-start): Add RSC limitations note and update examples across locales

### DIFF
--- a/apps/docs/content/en/01.getting-started/02.quick-start.mdx
+++ b/apps/docs/content/en/01.getting-started/02.quick-start.mdx
@@ -34,6 +34,9 @@ nav-title: "Quick Start"
 
 <Tabs items={[{ label: "React", value: "react" }, { label: "Svelte", value: "svelte" }, { label: "Vue", value: "vue" }]}>
   <TabPanel value="react">
+    > **📝 Note: RSC (React Server Components) Limitations**
+    > RSC cannot pass functions as props, so the `config` attribute cannot be used. Set default transition effects using the `transition` attribute of the `SsgoiTransition` component on each page.
+
     ### 1. Root Layout Setup (Next.js App Router)
 
     ```tsx
@@ -49,7 +52,7 @@ nav-title: "Quick Start"
       return (
         <html>
           <body>
-            <Ssgoi config={{ defaultTransition: fade() }}>
+            <Ssgoi>
               {/* ⚠️ Important: position: relative is required! */}
               <div style={{ position: "relative", minHeight: "100vh" }}>
                 {children}

--- a/apps/docs/content/ja/01.getting-started/02.quick-start.mdx
+++ b/apps/docs/content/ja/01.getting-started/02.quick-start.mdx
@@ -34,6 +34,8 @@ nav-title: "クイックスタート"
 
 <Tabs items={[{ label: "React", value: "react" }, { label: "Svelte", value: "svelte" }, { label: "Vue", value: "vue" }]}>
   <TabPanel value="react">
+  > **📝 注記: RSC（React Server Components）の制限事項**
+    > RSCでは関数をpropsとして渡すことができないため、`config`属性を使用できません。デフォルトのトランジション効果設定は、各ページで`SsgoiTransition`コンポーネントの`transition`属性を使用して指定してください。
     ### 1. ルートレイアウトの設定 (Next.js App Router)
 
     ```tsx
@@ -49,7 +51,7 @@ nav-title: "クイックスタート"
       return (
         <html>
           <body>
-            <Ssgoi config={{ defaultTransition: fade() }}>
+            <Ssgoi>
               {/* ⚠️ 重要: position: relativeが必要です！ */}
               <div style={{ position: "relative", minHeight: "100vh" }}>
                 {children}

--- a/apps/docs/content/ko/01.getting-started/02.quick-start.mdx
+++ b/apps/docs/content/ko/01.getting-started/02.quick-start.mdx
@@ -34,11 +34,13 @@ nav-title: "빠른 시작"
 
 <Tabs items={[{ label: "React", value: "react" }, { label: "Svelte", value: "svelte" }, { label: "Vue", value: "vue" }]}>
   <TabPanel value="react">
+    > **📝 참고: RSC(React Server Components) 제한사항**
+    > RSC에서는 함수를 props로 전달할 수 없어 `config` 속성을 사용할 수 없습니다. 기본 전환 효과 설정은 각 페이지에서 `SsgoiTransition` 컴포넌트의 `transition` 속성으로 지정하세요.
+
     ### 1. 루트 레이아웃 설정 (Next.js App Router)
     ```tsx
     // app/layout.tsx
     import { Ssgoi } from "@ssgoi/react";
-    import { fade } from "@ssgoi/react/view-transitions";
 
     export default function RootLayout({
       children,
@@ -48,7 +50,7 @@ nav-title: "빠른 시작"
       return (
         <html>
           <body>
-            <Ssgoi config={{ defaultTransition: fade() }}>
+            <Ssgoi>
               {/* ⚠️ 중요: position: relative 필수! */}
               <div style={{ position: "relative", minHeight: "100vh" }}>
                 {children}
@@ -59,7 +61,6 @@ nav-title: "빠른 시작"
       );
     }
     ```
-    
     > **왜 position: relative가 필요한가요?**
     > 페이지가 out 애니메이션될 때 `position: absolute`가 적용됩니다. 상위 요소에 `position: relative`가 없으면 페이지가 잘못된 위치로 이동할 수 있습니다.
     

--- a/apps/docs/content/zh/01.getting-started/02.quick-start.mdx
+++ b/apps/docs/content/zh/01.getting-started/02.quick-start.mdx
@@ -34,6 +34,9 @@ nav-title: "快速入门"
 
 <Tabs items={[{ label: "React", value: "react" }, { label: "Svelte", value: "svelte" }, { label: "Vue", value: "vue" }]}>
   <TabPanel value="react">
+    > **📝 注意: RSC（React Server Components）限制**
+    > RSC无法将函数作为props传递，因此无法使用`config`属性。请在每个页面使用`SsgoiTransition`组件的`transition`属性来设置默认过渡效果。
+
     ### 1. 根布局设置 (Next.js App Router)
 
     ```tsx
@@ -49,7 +52,7 @@ nav-title: "快速入门"
       return (
         <html>
           <body>
-            <Ssgoi config={{ defaultTransition: fade() }}>
+            <Ssgoi>
               {/* ⚠️ 重要：必须设置position: relative！ */}
               <div style={{ position: "relative", minHeight: "100vh" }}>
                 {children}


### PR DESCRIPTION
### Summary
Add a "Note: RSC (React Server Components) limitations" callout to the React Quick Start tab and update examples to avoid passing functions via props in RSC. This ensures the documentation aligns with RSC constraints and prevents invalid usage in Next.js App Router.

### Changes
- Add an explicit note explaining that RSC cannot pass functions as props, so the `config` attribute cannot be used.
- Update examples to remove `config` from `<Ssgoi>` usage.
- Instruct users to set default transitions per page via the `transition` prop on `SsgoiTransition`.
- Apply the same update across locales

### Rationale
- In RSC, functions cannot be passed as props. Since `config` requires a function (e.g., `fade()`), the previous example could not work in RSC contexts. This update documents the limitation and provides a clear, supported usage pattern.
