### PR TITLE
feat: Apply film transition to non-demo pages with mobile optimization

### DIFF
--- a/apps/docs/src/app/[lang]/demo/demo-wrapper.tsx
+++ b/apps/docs/src/app/[lang]/demo/demo-wrapper.tsx
@@ -22,8 +22,8 @@ export default function DemoWrapper({
     },
   };
   return (
-    <div className="h-[calc(100svh-4rem)] flex items-center justify-center bg-gray-100">
-      <div className="w-full  h-full lg:w-[390px] lg:h-[844px] lg:rounded-[3rem] lg:overflow-hidden lg:border-8 lg:border-gray-900 lg:shadow-2xl">
+    <div className="min-h-full flex items-center justify-center bg-gray-100 py-10">
+      <div className="w-full h-full lg:w-[390px] lg:h-[844px] lg:rounded-[3rem] lg:overflow-hidden lg:border-8 lg:border-gray-900 lg:shadow-2xl">
         <RouterProvider
           currentPath={pathname.replace(`/${lang}`, "")}
           customRouter={customRouter}

--- a/apps/docs/src/components/demo/layout.tsx
+++ b/apps/docs/src/components/demo/layout.tsx
@@ -88,7 +88,7 @@ export default function DemoLayout({ children }: DemoLayoutProps) {
     [],
   );
   return (
-    <div className="h-full bg-gray-900 flex">
+    <div className="h-full bg-gray-900 flex z-0">
       {/* Mobile Frame */}
       <div className="w-full bg-black flex flex-col overflow-hidden relative">
         {/* Main Content Area */}

--- a/apps/docs/src/components/demo/posts/index.tsx
+++ b/apps/docs/src/components/demo/posts/index.tsx
@@ -18,7 +18,7 @@ export default function PostsDemo() {
 
   return (
     <SsgoiTransition id="/demo/posts">
-      <div className="min-h-screen bg-gray-950 px-4 py-8">
+      <div className="min-h-full bg-gray-950 px-4 py-8">
         {/* Header */}
         <div className="mb-8">
           <h1 className="text-3xl font-bold text-white mb-2">Latest Posts</h1>

--- a/apps/docs/src/components/layout/ssgoi.tsx
+++ b/apps/docs/src/components/layout/ssgoi.tsx
@@ -1,7 +1,8 @@
 "use client";
 
+import { useMobile } from "@/lib/use-mobile";
 import { Ssgoi, type SsgoiConfig } from "@ssgoi/react";
-import { fade } from "@ssgoi/react/view-transitions";
+import { fade, film } from "@ssgoi/react/view-transitions";
 import { useMemo } from "react";
 
 interface SsgoiProviderProps {
@@ -9,12 +10,31 @@ interface SsgoiProviderProps {
 }
 
 export function SsgoiProvider({ children }: SsgoiProviderProps) {
+  const isMobile = useMobile();
   const config = useMemo<SsgoiConfig>(
     () => ({
-      transitions: [],
-      defaultTransition: fade(),
+      transitions: isMobile
+        ? []
+        : [
+            // Apply film transition to non-demo pages
+            {
+              from: "/non-demo/*",
+              to: "/non-demo/*",
+              transition: film(),
+            },
+          ],
+      defaultTransition: isMobile ? undefined : fade(),
+      middleware(from, to) {
+        // Transform paths: non-demo routes get prefixed with /non-demo
+        const isDemoRoute = (path: string) => path.includes("/demo");
+
+        const transformedFrom = isDemoRoute(from) ? from : `/non-demo${from}`;
+        const transformedTo = isDemoRoute(to) ? to : `/non-demo${to}`;
+
+        return { from: transformedFrom, to: transformedTo };
+      },
     }),
-    [],
+    [isMobile],
   );
 
   return <Ssgoi config={config}>{children}</Ssgoi>;


### PR DESCRIPTION
## Summary
- Configure film transition for all documentation pages except demo routes
- Add mobile detection to disable transitions on mobile devices for better performance
- Use middleware to transform paths for selective transition matching

## Changes
- Apply film transition to non-demo pages using path transformation middleware
- Disable all transitions (film and fade) on mobile devices
- Set fade as default transition for demo pages (desktop only)
- Transform non-demo routes with `/non-demo` prefix for transition matching

## Why this change?
Film transition provides a more engaging user experience for documentation navigation on desktop, while mobile users benefit from instant page transitions without animation overhead.

## Test plan
- [ ] Navigate between documentation pages - should see film transition (desktop)
- [ ] Navigate to/from demo pages - should see fade transition (desktop)  
- [ ] Test on mobile device - no transitions should be applied
- [ ] Verify middleware correctly transforms paths for non-demo routes
- [ ] Test browser back/forward navigation
- [ ] Verify performance on mobile devices

🤖 Generated with [Claude Code](https://claude.ai/code)