### PR TITLE
feat: Add strip view transition

### DIFF
--- a/apps/docs/content/en/03.view-transitions/09-strip.mdx
+++ b/apps/docs/content/en/03.view-transitions/09-strip.mdx
@@ -1,0 +1,221 @@
+---
+title: "Strip Transition"
+description: "Smooth transition effect flowing along a 3D curve like a film strip"
+nav-title: "Strip"
+---
+
+# Strip Transition
+
+The Strip transition creates a 3D curved transition effect reminiscent of film strips passing through a projector. The current screen curves out to the right, while the new screen enters from the left along the same curve, creating a continuous flow that naturally expresses content progression.
+
+## Demo
+
+<ViewTransitionDemo type="strip" />
+
+## UX Principles
+
+### When to Use
+
+Strip transitions are used for **Premium Brand Experiences**.
+
+#### Content Relationship Suitability
+
+<SuitabilityTable
+  items={[
+    {
+      label: "Unrelated Content",
+      suitable: "yes",
+      description: "Premium transitions between independent sections (Home → Services)",
+    },
+    {
+      label: "Sibling Relationship",
+      suitable: "no",
+      description: "Use slide transitions for same-level content",
+    },
+    {
+      label: "Hierarchical Relationship",
+      suitable: "no",
+      description: "Use drill or hero for parent-child structures",
+    },
+  ]}
+/>
+
+#### Key Use Cases
+
+- **Brand Experience**: Default transition for premium landing pages
+- **Top-level Navigation**: Moving between major sections via header menu
+- **Showcase Sites**: Portfolio or product introduction pages
+- **Cinematic Effects**: Brand sites requiring a film-like feel
+
+### Why It Works This Way
+
+1. **Physical Metaphor**: Digitally recreates the movement of actual film strips
+2. **Continuous Expression**: Provides a feeling of uninterrupted content flow
+3. **Spatial Perception**: 3D curves convey depth and premium feel
+4. **Natural Flow**: Curved motion provides smooth visual experience
+
+### Motion Design
+
+```
+Exiting Screen: Center → Right curve (3D transform + fade)
+Entering Screen: Left curve → Center (3D transform + fade)
+Curve Effect: Film strip effect using perspective and rotateY
+```
+
+This sequence provides users with the mental model that "content continues on a continuous strip."
+
+## Basic Usage
+
+<Tabs items={[{ label: "React", value: "react" }, { label: "Svelte", value: "svelte" }]}>
+  <TabPanel value="react">
+    ```tsx
+    import { Ssgoi } from '@ssgoi/react';
+    import { strip } from '@ssgoi/react/view-transitions';
+
+    const config = {
+      defaultTransition: strip()
+    };
+
+    export default function App() {
+      return (
+        <Ssgoi config={config}>
+          {/* App content */}
+        </Ssgoi>
+      );
+    }
+    ```
+
+  </TabPanel>
+  <TabPanel value="svelte">
+    ```svelte
+    <script>
+      import { Ssgoi } from '@ssgoi/svelte';
+      import { strip } from '@ssgoi/svelte/view-transitions';
+
+      const config = {
+        defaultTransition: strip()
+      };
+    </script>
+
+    <Ssgoi {config}>
+      <slot />
+    </Ssgoi>
+    ```
+
+  </TabPanel>
+</Tabs>
+
+## Practical Examples
+
+### Basic Usage (Recommended)
+
+It's recommended to use strip transitions with default values:
+
+<Tabs items={[{ label: "React", value: "react" }, { label: "Svelte", value: "svelte" }]}>
+  <TabPanel value="react">
+    ```tsx
+    const config = {
+      defaultTransition: strip()  // Recommended to use defaults
+    };
+    ```
+  </TabPanel>
+  <TabPanel value="svelte">
+    ```svelte
+    <script>
+      const config = {
+        defaultTransition: strip()  // Recommended to use defaults
+      };
+    </script>
+    ```
+  </TabPanel>
+</Tabs>
+
+### Apply to Specific Routes
+
+Apply to top-level navigation:
+
+<Tabs items={[{ label: "React", value: "react" }, { label: "Svelte", value: "svelte" }]}>
+  <TabPanel value="react">
+    ```tsx
+    const config = {
+      transitions: [
+        {
+          from: '/home',
+          to: '/about',
+          transition: strip(),
+          symmetric: true
+        },
+        {
+          from: '/home',
+          to: '/services',
+          transition: strip(),
+          symmetric: true
+        }
+      ]
+    };
+    ```
+  </TabPanel>
+  <TabPanel value="svelte">
+    ```svelte
+    <script>
+      const config = {
+        transitions: [
+          {
+            from: '/home',
+            to: '/about',
+            transition: strip(),
+            symmetric: true
+          },
+          {
+            from: '/home',
+            to: '/services',
+            transition: strip(),
+            symmetric: true
+          }
+        ]
+      };
+    </script>
+    ```
+  </TabPanel>
+</Tabs>
+
+## Accessibility
+
+- Automatically minimizes 3D effects when `prefers-reduced-motion` is set
+- Screen readers correctly recognize content changes during transitions
+- Fully compatible with keyboard navigation
+
+## Best Practices
+
+### ✅ DO
+
+- Use as default transition for landing pages
+- Apply to top-level navigation (header menus)
+- When providing premium brand experiences
+- Portfolio or showcase sites
+- **Set page backgrounds to transparent** (transition effects appear more beautiful)
+
+### ❌ DON'T
+
+- Use slide transitions for sibling content
+- Use drill or hero for hierarchical navigation
+- Not suitable for gallery internal navigation (slide recommended)
+- Prefer defaults over option adjustments
+
+## 💡 Design Tips
+
+For the best visual effects when using Strip transitions:
+
+```css
+/* Set each page's background to transparent */
+.page-content {
+  background: transparent;
+}
+
+/* Apply unified background to layout component */
+.layout-wrapper {
+  background: linear-gradient(to bottom right, #fef3e9, #fce7f3);
+}
+```
+
+This makes the film strip movement effect appear more natural and smooth during page transitions.

--- a/apps/docs/content/ja/03.view-transitions/09-strip.mdx
+++ b/apps/docs/content/ja/03.view-transitions/09-strip.mdx
@@ -1,0 +1,221 @@
+---
+title: "ストリップトランジション"
+description: "フィルムストリップのように3D曲面に沿って流れる滑らかな遷移効果"
+nav-title: "ストリップ"
+---
+
+# ストリップトランジション
+
+ストリップ（Strip）トランジションは、フィルムストリップが映写機を通過するような3D曲面の遷移効果を作り出します。現在の画面が右に曲がりながら退場し、新しい画面が左から同じ曲線に沿って入場し、連続的な流れを作り出して自然にコンテンツの進行を表現します。
+
+## デモ
+
+<ViewTransitionDemo type="strip" />
+
+## UX原則
+
+### いつ使うか
+
+ストリップトランジションは**プレミアムブランド体験**で使用されます。
+
+#### コンテンツ関係の適合性
+
+<SuitabilityTable
+  items={[
+    {
+      label: "無関係なコンテンツ",
+      suitable: "yes",
+      description: "独立したセクション間のプレミアムな遷移（ホーム → サービス）",
+    },
+    {
+      label: "兄弟関係",
+      suitable: "no",
+      description: "同レベルのコンテンツにはスライドトランジションを推奨",
+    },
+    {
+      label: "階層関係",
+      suitable: "no",
+      description: "親子構造にはドリルやヒーローを推奨",
+    },
+  ]}
+/>
+
+#### 主な使用ケース
+
+- **ブランド体験**：プレミアムランディングページのデフォルト遷移
+- **トップレベルナビゲーション**：ヘッダーメニューによる主要セクション間の移動
+- **ショーケースサイト**：ポートフォリオや製品紹介ページ
+- **シネマティック効果**：映画的な感覚が必要なブランドサイト
+
+### なぜこのように動作するのか
+
+1. **物理的メタファー**：実際のフィルムストリップの動きをデジタルで再現
+2. **連続性の表現**：コンテンツが途切れずに続く感覚を提供
+3. **空間的知覚**：3D曲面が深さとプレミアム感を伝える
+4. **自然な流れ**：曲線の動きが滑らかな視覚体験を提供
+
+### モーションデザイン
+
+```
+退出画面：中央 → 右曲面（3D変形 + フェード）
+進入画面：左曲面 → 中央（3D変形 + フェード）
+曲面効果：perspectiveとrotateYを使用したフィルムストリップ効果
+```
+
+このシーケンスは「コンテンツが連続したストリップ上に続いている」というメンタルモデルをユーザーに提供します。
+
+## 基本的な使い方
+
+<Tabs items={[{ label: "React", value: "react" }, { label: "Svelte", value: "svelte" }]}>
+  <TabPanel value="react">
+    ```tsx
+    import { Ssgoi } from '@ssgoi/react';
+    import { strip } from '@ssgoi/react/view-transitions';
+
+    const config = {
+      defaultTransition: strip()
+    };
+
+    export default function App() {
+      return (
+        <Ssgoi config={config}>
+          {/* アプリコンテンツ */}
+        </Ssgoi>
+      );
+    }
+    ```
+
+  </TabPanel>
+  <TabPanel value="svelte">
+    ```svelte
+    <script>
+      import { Ssgoi } from '@ssgoi/svelte';
+      import { strip } from '@ssgoi/svelte/view-transitions';
+
+      const config = {
+        defaultTransition: strip()
+      };
+    </script>
+
+    <Ssgoi {config}>
+      <slot />
+    </Ssgoi>
+    ```
+
+  </TabPanel>
+</Tabs>
+
+## 実践的な例
+
+### 基本的な使い方（推奨）
+
+ストリップトランジションはデフォルト値での使用を推奨します：
+
+<Tabs items={[{ label: "React", value: "react" }, { label: "Svelte", value: "svelte" }]}>
+  <TabPanel value="react">
+    ```tsx
+    const config = {
+      defaultTransition: strip()  // デフォルト値の使用を推奨
+    };
+    ```
+  </TabPanel>
+  <TabPanel value="svelte">
+    ```svelte
+    <script>
+      const config = {
+        defaultTransition: strip()  // デフォルト値の使用を推奨
+      };
+    </script>
+    ```
+  </TabPanel>
+</Tabs>
+
+### 特定ルートへの適用
+
+トップレベルナビゲーションに適用：
+
+<Tabs items={[{ label: "React", value: "react" }, { label: "Svelte", value: "svelte" }]}>
+  <TabPanel value="react">
+    ```tsx
+    const config = {
+      transitions: [
+        {
+          from: '/home',
+          to: '/about',
+          transition: strip(),
+          symmetric: true
+        },
+        {
+          from: '/home',
+          to: '/services',
+          transition: strip(),
+          symmetric: true
+        }
+      ]
+    };
+    ```
+  </TabPanel>
+  <TabPanel value="svelte">
+    ```svelte
+    <script>
+      const config = {
+        transitions: [
+          {
+            from: '/home',
+            to: '/about',
+            transition: strip(),
+            symmetric: true
+          },
+          {
+            from: '/home',
+            to: '/services',
+            transition: strip(),
+            symmetric: true
+          }
+        ]
+      };
+    </script>
+    ```
+  </TabPanel>
+</Tabs>
+
+## アクセシビリティ
+
+- `prefers-reduced-motion`設定時に自動的に3D効果を最小化
+- スクリーンリーダーは遷移中もコンテンツの変更を正しく認識
+- キーボードナビゲーションと完全に互換
+
+## ベストプラクティス
+
+### ✅ すべきこと
+
+- ランディングページのデフォルトトランジションとして使用
+- トップレベルナビゲーション（ヘッダーメニュー）に適用
+- プレミアムブランド体験を提供する時
+- ポートフォリオやショーケースサイト
+- **ページ背景を透明に設定**（遷移効果がより美しく表現される）
+
+### ❌ すべきでないこと
+
+- 兄弟コンテンツにはスライドトランジションを使用
+- 階層ナビゲーションにはドリルやヒーローを使用
+- ギャラリー内部のナビゲーションには不適切（スライド推奨）
+- オプション調整よりデフォルト値の使用を推奨
+
+## 💡 デザインのヒント
+
+ストリップトランジションで最高の視覚効果を得るために：
+
+```css
+/* 各ページの背景を透明に設定 */
+.page-content {
+  background: transparent;
+}
+
+/* レイアウトコンポーネントに統一背景を適用 */
+.layout-wrapper {
+  background: linear-gradient(to bottom right, #fef3e9, #fce7f3);
+}
+```
+
+このようにすることで、ページ遷移時にフィルムストリップが動くような効果がより自然で滑らかに表現されます。

--- a/apps/docs/content/ko/03.view-transitions/09-strip.mdx
+++ b/apps/docs/content/ko/03.view-transitions/09-strip.mdx
@@ -1,0 +1,222 @@
+---
+title: "스트립 전환"
+description: "필름 스트립처럼 3D 곡면을 따라 흐르는 부드러운 전환 효과"
+nav-title: "스트립"
+---
+
+# 스트립 전환
+
+스트립 전환은 필름 스트립이 영사기를 통과하는 듯한 3D 곡면 전환 효과입니다. 현재 화면이 오른쪽으로 휘어지며 나가고, 새 화면이 왼쪽에서 같은 곡선을 따라 들어오며, 연속적인 흐름을 만들어 자연스러운 콘텐츠 진행을 표현합니다.
+
+## 데모
+
+<ViewTransitionDemo type="strip" />
+
+## UX 원칙
+
+### 언제 사용하나요?
+
+스트립 전환은 **순차적 진행(Sequential Progress)** 시 사용됩니다.
+
+#### 콘텐츠 관계별 적합성
+
+<SuitabilityTable
+  items={[
+    {
+      label: "관련 없는 콘텐츠",
+      suitable: "yes",
+      description: "독립적인 섹션 간 프리미엄 전환 (홈 → 서비스)",
+    },
+    {
+      label: "형제 관계",
+      suitable: "no",
+      description: "동일 레벨의 콘텐츠는 슬라이드 사용 권장",
+    },
+    {
+      label: "계층 관계",
+      suitable: "no",
+      description: "부모-자식 구조는 드릴이나 히어로 사용 권장",
+    },
+  ]}
+/>
+
+#### 주요 사용 케이스
+
+- **브랜드 경험**: 프리미엄 랜딩 페이지의 기본 전환
+- **최상위 네비게이션**: 헤더 메뉴를 통한 주요 섹션 간 이동
+- **쇼케이스 사이트**: 포트폴리오나 제품 소개 페이지
+- **시네마틱 효과**: 영화적인 느낌이 필요한 브랜드 사이트
+
+### 왜 이렇게 동작하나요?
+
+1. **물리적 은유**: 실제 필름 스트립의 움직임을 디지털로 재현
+2. **연속성 표현**: 콘텐츠가 끊기지 않고 이어진다는 느낌 제공
+3. **공간적 인지**: 3D 곡면으로 깊이감과 프리미엄 느낌 전달
+4. **자연스러운 흐름**: 곡선 움직임으로 부드러운 시각적 경험
+
+### 모션 디자인
+
+```
+나가는 화면: 중앙 → 오른쪽 곡면 (3D 변형 + 페이드)
+들어오는 화면: 왼쪽 곡면 → 중앙 (3D 변형 + 페이드)
+곡면 효과: perspective와 rotateY로 필름 스트립 효과
+```
+
+이 시퀀스는 사용자에게 "콘텐츠가 연속된 스트립으로 이어져 있다"는 멘탈 모델을 제공합니다.
+
+## 기본 사용법
+
+<Tabs items={[{ label: "React", value: "react" }, { label: "Svelte", value: "svelte" }]}>
+  <TabPanel value="react">
+    ```tsx
+    import { Ssgoi } from '@ssgoi/react';
+    import { strip } from '@ssgoi/react/view-transitions';
+
+    const config = {
+      defaultTransition: strip()
+    };
+
+    export default function App() {
+      return (
+        <Ssgoi config={config}>
+          {/* 앱 내용 */}
+        </Ssgoi>
+      );
+    }
+    ```
+
+  </TabPanel>
+  <TabPanel value="svelte">
+    ```svelte
+    <script>
+      import { Ssgoi } from '@ssgoi/svelte';
+      import { strip } from '@ssgoi/svelte/view-transitions';
+
+      const config = {
+        defaultTransition: strip()
+      };
+    </script>
+
+    <Ssgoi {config}>
+      <slot />
+    </Ssgoi>
+    ```
+
+  </TabPanel>
+</Tabs>
+
+## 실전 활용 예시
+
+### 기본 사용법 (권장)
+
+strip 전환은 기본값으로 사용하는 것을 권장합니다:
+
+<Tabs items={[{ label: "React", value: "react" }, { label: "Svelte", value: "svelte" }]}>
+  <TabPanel value="react">
+    ```tsx
+    const config = {
+      defaultTransition: strip()  // 기본값 사용 권장
+    };
+    ```
+  </TabPanel>
+  <TabPanel value="svelte">
+    ```svelte
+    <script>
+      const config = {
+        defaultTransition: strip()  // 기본값 사용 권장
+      };
+    </script>
+    ```
+  </TabPanel>
+</Tabs>
+
+### 특정 라우트 적용
+
+최상위 네비게이션에 적용:
+
+<Tabs items={[{ label: "React", value: "react" }, { label: "Svelte", value: "svelte" }]}>
+  <TabPanel value="react">
+    ```tsx
+    const config = {
+      transitions: [
+        {
+          from: '/home',
+          to: '/about',
+          transition: strip(),
+          symmetric: true
+        },
+        {
+          from: '/home',
+          to: '/services',
+          transition: strip(),
+          symmetric: true
+        }
+      ]
+    };
+    ```
+  </TabPanel>
+  <TabPanel value="svelte">
+    ```svelte
+    <script>
+      const config = {
+        transitions: [
+          {
+            from: '/home',
+            to: '/about',
+            transition: strip(),
+            symmetric: true
+          },
+          {
+            from: '/home',
+            to: '/services',
+            transition: strip(),
+            symmetric: true
+          }
+        ]
+      };
+    </script>
+    ```
+  </TabPanel>
+</Tabs>
+
+
+## 접근성
+
+- `prefers-reduced-motion` 설정 시 자동으로 3D 효과 최소화
+- 스크린 리더는 전환 중에도 콘텐츠 변경을 올바르게 인식
+- 키보드 네비게이션과 완벽하게 호환
+
+## 모범 사례
+
+### ✅ DO
+
+- 랜딩 페이지의 기본 전환으로 사용
+- 최상위 네비게이션 (헤더 메뉴)에 적용
+- 프리미엄 브랜드 경험 제공 시
+- 포트폴리오나 쇼케이스 사이트
+- **페이지 배경을 투명하게 설정** (전환 효과가 더 아름답게 표현됨)
+
+### ❌ DON'T
+
+- 형제 관계 콘텐츠에는 슬라이드 전환 사용
+- 계층 구조 네비게이션에는 드릴이나 히어로 사용
+- 갤러리 내부 탐색에는 적합하지 않음 (슬라이드 권장)
+- 옵션 조정보다는 기본값 사용을 권장
+
+## 💡 디자인 팁
+
+Strip 전환을 사용할 때 최상의 시각적 효과를 위해:
+
+```css
+/* 각 페이지의 배경을 투명하게 설정 */
+.page-content {
+  background: transparent;
+}
+
+/* 레이아웃 컴포넌트에 통일된 배경 적용 */
+.layout-wrapper {
+  background: linear-gradient(to bottom right, #fef3e9, #fce7f3);
+}
+```
+
+이렇게 하면 페이지 전환 시 필름 스트립이 움직이는 듯한 효과가 더욱 자연스럽고 부드럽게 표현됩니다.

--- a/apps/docs/content/zh/03.view-transitions/09-strip.mdx
+++ b/apps/docs/content/zh/03.view-transitions/09-strip.mdx
@@ -1,0 +1,221 @@
+---
+title: "胶片过渡"
+description: "如胶片般沿着3D曲面流动的顺滑过渡效果"
+nav-title: "胶片"
+---
+
+# 胶片过渡
+
+胶片（Strip）过渡创建了类似胶片通过放映机的3D曲面过渡效果。当前画面向右弯曲退出，新画面从左侧沿着相同曲线进入，创造连续的流动感，自然地表现内容的推进。
+
+## 演示
+
+<ViewTransitionDemo type="strip" />
+
+## UX原则
+
+### 何时使用
+
+胶片过渡用于**高端品牌体验**。
+
+#### 内容关系适用性
+
+<SuitabilityTable
+  items={[
+    {
+      label: "无关内容",
+      suitable: "yes",
+      description: "独立板块间的高端过渡（首页 → 服务）",
+    },
+    {
+      label: "兄弟关系",
+      suitable: "no",
+      description: "同级内容建议使用滑动过渡",
+    },
+    {
+      label: "层级关系",
+      suitable: "no",
+      description: "父子结构建议使用钻入或英雄过渡",
+    },
+  ]}
+/>
+
+#### 主要使用场景
+
+- **品牌体验**：高端着陆页的默认过渡
+- **顶层导航**：通过头部菜单在主要板块间移动
+- **展示网站**：作品集或产品介绍页面
+- **电影效果**：需要电影质感的品牌网站
+
+### 为什么这样运作
+
+1. **物理隐喻**：数字化重现真实胶片的运动
+2. **连续性表达**：提供内容不间断的感觉
+3. **空间感知**：3D曲面传达深度和高端感
+4. **自然流畅**：曲线运动提供顺滑的视觉体验
+
+### 动效设计
+
+```
+退出画面：中心 → 右侧曲面（3D变形 + 淡出）
+进入画面：左侧曲面 → 中心（3D变形 + 淡入）
+曲面效果：使用perspective和rotateY实现胶片效果
+```
+
+这个序列给用户提供"内容在连续的胶片上延续"的心理模型。
+
+## 基本用法
+
+<Tabs items={[{ label: "React", value: "react" }, { label: "Svelte", value: "svelte" }]}>
+  <TabPanel value="react">
+    ```tsx
+    import { Ssgoi } from '@ssgoi/react';
+    import { strip } from '@ssgoi/react/view-transitions';
+
+    const config = {
+      defaultTransition: strip()
+    };
+
+    export default function App() {
+      return (
+        <Ssgoi config={config}>
+          {/* 应用内容 */}
+        </Ssgoi>
+      );
+    }
+    ```
+
+  </TabPanel>
+  <TabPanel value="svelte">
+    ```svelte
+    <script>
+      import { Ssgoi } from '@ssgoi/svelte';
+      import { strip } from '@ssgoi/svelte/view-transitions';
+
+      const config = {
+        defaultTransition: strip()
+      };
+    </script>
+
+    <Ssgoi {config}>
+      <slot />
+    </Ssgoi>
+    ```
+
+  </TabPanel>
+</Tabs>
+
+## 实战示例
+
+### 基本用法（推荐）
+
+建议使用默认值的胶片过渡：
+
+<Tabs items={[{ label: "React", value: "react" }, { label: "Svelte", value: "svelte" }]}>
+  <TabPanel value="react">
+    ```tsx
+    const config = {
+      defaultTransition: strip()  // 建议使用默认值
+    };
+    ```
+  </TabPanel>
+  <TabPanel value="svelte">
+    ```svelte
+    <script>
+      const config = {
+        defaultTransition: strip()  // 建议使用默认值
+      };
+    </script>
+    ```
+  </TabPanel>
+</Tabs>
+
+### 应用于特定路由
+
+应用于顶层导航：
+
+<Tabs items={[{ label: "React", value: "react" }, { label: "Svelte", value: "svelte" }]}>
+  <TabPanel value="react">
+    ```tsx
+    const config = {
+      transitions: [
+        {
+          from: '/home',
+          to: '/about',
+          transition: strip(),
+          symmetric: true
+        },
+        {
+          from: '/home',
+          to: '/services',
+          transition: strip(),
+          symmetric: true
+        }
+      ]
+    };
+    ```
+  </TabPanel>
+  <TabPanel value="svelte">
+    ```svelte
+    <script>
+      const config = {
+        transitions: [
+          {
+            from: '/home',
+            to: '/about',
+            transition: strip(),
+            symmetric: true
+          },
+          {
+            from: '/home',
+            to: '/services',
+            transition: strip(),
+            symmetric: true
+          }
+        ]
+      };
+    </script>
+    ```
+  </TabPanel>
+</Tabs>
+
+## 无障碍访问
+
+- 设置`prefers-reduced-motion`时自动最小化3D效果
+- 屏幕阅读器在过渡期间正确识别内容变化
+- 完全兼容键盘导航
+
+## 最佳实践
+
+### ✅ 应该
+
+- 作为着陆页的默认过渡
+- 应用于顶层导航（头部菜单）
+- 提供高端品牌体验时
+- 作品集或展示网站
+- **将页面背景设为透明**（过渡效果更加美观）
+
+### ❌ 不应该
+
+- 兄弟内容使用滑动过渡
+- 层级导航使用钻入或英雄过渡
+- 不适合画廊内部导航（建议使用滑动）
+- 优先使用默认值而非调整选项
+
+## 💡 设计技巧
+
+使用胶片过渡时获得最佳视觉效果：
+
+```css
+/* 将每个页面的背景设为透明 */
+.page-content {
+  background: transparent;
+}
+
+/* 在布局组件应用统一背景 */
+.layout-wrapper {
+  background: linear-gradient(to bottom right, #fef3e9, #fce7f3);
+}
+```
+
+这样在页面过渡时，胶片移动的效果会更加自然流畅。

--- a/apps/docs/src/components/mdx/mdx-components/view-transition-demo/index.tsx
+++ b/apps/docs/src/components/mdx/mdx-components/view-transition-demo/index.tsx
@@ -26,9 +26,12 @@ const SlideDemo = lazy(() =>
 const BlindDemo = lazy(() =>
   import("./blind-demo").then((m) => ({ default: m.BlindDemo })),
 );
+const StripDemo = lazy(() =>
+  import("./strip-demo").then((m) => ({ default: m.StripDemo })),
+);
 
 export interface ViewTransitionDemoProps {
-  type: "fade" | "hero" | "pinterest" | "scroll" | "drill" | "slide" | "blind";
+  type: "fade" | "hero" | "pinterest" | "scroll" | "drill" | "slide" | "blind" | "strip";
 }
 
 // Loading component
@@ -60,6 +63,8 @@ export function ViewTransitionDemo({ type }: ViewTransitionDemoProps) {
         return <SlideDemo />;
       case "blind":
         return <BlindDemo />;
+      case "strip":
+        return <StripDemo />;
       default:
         return null;
     }

--- a/apps/docs/src/components/mdx/mdx-components/view-transition-demo/index.tsx
+++ b/apps/docs/src/components/mdx/mdx-components/view-transition-demo/index.tsx
@@ -31,7 +31,15 @@ const StripDemo = lazy(() =>
 );
 
 export interface ViewTransitionDemoProps {
-  type: "fade" | "hero" | "pinterest" | "scroll" | "drill" | "slide" | "blind" | "strip";
+  type:
+    | "fade"
+    | "hero"
+    | "pinterest"
+    | "scroll"
+    | "drill"
+    | "slide"
+    | "blind"
+    | "strip";
 }
 
 // Loading component

--- a/apps/docs/src/components/mdx/mdx-components/view-transition-demo/strip-demo.tsx
+++ b/apps/docs/src/components/mdx/mdx-components/view-transition-demo/strip-demo.tsx
@@ -253,7 +253,9 @@ const StripLayout = memo(({ children }: { children: React.ReactNode }) => {
       </header>
 
       {/* Main Content */}
-      <main className="flex-1 overflow-y-scroll overflow-x-hidden relative z-0">{children}</main>
+      <main className="flex-1 overflow-y-scroll overflow-x-hidden relative z-0">
+        {children}
+      </main>
     </div>
   );
 });

--- a/apps/docs/src/components/mdx/mdx-components/view-transition-demo/strip-demo.tsx
+++ b/apps/docs/src/components/mdx/mdx-components/view-transition-demo/strip-demo.tsx
@@ -12,10 +12,7 @@ function SpeakingPage() {
   const isMobile = useMobile();
 
   return (
-    <DemoPage
-      path="/strip"
-      className="min-h-full"
-    >
+    <DemoPage path="/strip" className="min-h-full">
       <div
         className={cn(
           "mx-auto flex flex-col justify-center min-h-full",
@@ -27,7 +24,7 @@ function SpeakingPage() {
             className={cn(
               "font-black leading-none",
               isMobile ? "text-6xl" : "text-[10rem]",
-              "text-orange-500 tracking-tight"
+              "text-orange-500 tracking-tight",
             )}
           >
             SPEAKING
@@ -38,7 +35,8 @@ function SpeakingPage() {
               isMobile ? "text-lg max-w-sm" : "text-2xl max-w-2xl",
             )}
           >
-            Transform your ideas into powerful narratives that captivate and inspire.
+            Transform your ideas into powerful narratives that captivate and
+            inspire.
           </p>
           <div className="flex gap-4 pt-4">
             <button className="px-6 py-3 bg-orange-500 text-white rounded-full font-semibold hover:bg-orange-600 transition-colors">
@@ -59,10 +57,7 @@ function CreatingPage() {
   const isMobile = useMobile();
 
   return (
-    <DemoPage
-      path="/strip/creating"
-      className="min-h-full"
-    >
+    <DemoPage path="/strip/creating" className="min-h-full">
       <div
         className={cn(
           "mx-auto flex items-center justify-center min-h-full",
@@ -76,7 +71,7 @@ function CreatingPage() {
                 "font-black",
                 isMobile ? "text-5xl" : "text-[8rem]",
                 "text-transparent bg-clip-text bg-gradient-to-r from-purple-600 to-blue-600",
-                "tracking-tight leading-none"
+                "tracking-tight leading-none",
               )}
             >
               CREATING
@@ -86,7 +81,7 @@ function CreatingPage() {
                 "font-black absolute inset-0 blur-3xl opacity-30",
                 isMobile ? "text-5xl" : "text-[8rem]",
                 "text-purple-600",
-                "tracking-tight leading-none"
+                "tracking-tight leading-none",
               )}
             >
               CREATING
@@ -114,7 +109,8 @@ function CreatingPage() {
               isMobile ? "text-base" : "text-xl",
             )}
           >
-            Where imagination meets execution. Build something extraordinary today.
+            Where imagination meets execution. Build something extraordinary
+            today.
           </p>
         </div>
       </div>
@@ -127,10 +123,7 @@ function ImpactPage() {
   const isMobile = useMobile();
 
   return (
-    <DemoPage
-      path="/strip/impact"
-      className="min-h-full"
-    >
+    <DemoPage path="/strip/impact" className="min-h-full">
       <div
         className={cn(
           "mx-auto flex flex-col justify-center min-h-full relative",
@@ -146,7 +139,7 @@ function ImpactPage() {
               className={cn(
                 "font-black",
                 isMobile ? "text-5xl" : "text-[7rem]",
-                "text-gray-900 leading-none tracking-tight"
+                "text-gray-900 leading-none tracking-tight",
               )}
             >
               IMPACT
@@ -171,7 +164,7 @@ function ImpactPage() {
           <div
             className={cn(
               "absolute bottom-8 right-8",
-              isMobile ? "hidden" : "block"
+              isMobile ? "hidden" : "block",
             )}
           >
             <div className="w-32 h-32 rounded-full bg-orange-400 opacity-20 blur-3xl"></div>
@@ -188,7 +181,6 @@ const stripRoutes: RouteConfig[] = [
   { path: "/strip/creating", component: CreatingPage, label: "Creating" },
   { path: "/strip/impact", component: ImpactPage, label: "Impact" },
 ];
-
 
 // Custom Layout Component
 const StripLayout = memo(({ children }: { children: React.ReactNode }) => {
@@ -241,8 +233,18 @@ const StripLayout = memo(({ children }: { children: React.ReactNode }) => {
             {/* Mobile menu button */}
             {isMobile && (
               <button className="text-gray-600 hover:text-gray-900">
-                <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+                <svg
+                  className="w-6 h-6"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M4 6h16M4 12h16M4 18h16"
+                  />
                 </svg>
               </button>
             )}
@@ -264,10 +266,6 @@ export function StripDemo() {
   };
 
   return (
-    <BrowserMockup
-      routes={stripRoutes}
-      config={config}
-      layout={StripLayout}
-    />
+    <BrowserMockup routes={stripRoutes} config={config} layout={StripLayout} />
   );
 }

--- a/apps/docs/src/components/mdx/mdx-components/view-transition-demo/strip-demo.tsx
+++ b/apps/docs/src/components/mdx/mdx-components/view-transition-demo/strip-demo.tsx
@@ -253,7 +253,7 @@ const StripLayout = memo(({ children }: { children: React.ReactNode }) => {
       </header>
 
       {/* Main Content */}
-      <main className="flex-1 overflow-auto relative z-0">{children}</main>
+      <main className="flex-1 overflow-y-scroll overflow-x-hidden relative z-0">{children}</main>
     </div>
   );
 });

--- a/apps/docs/src/components/mdx/mdx-components/view-transition-demo/strip-demo.tsx
+++ b/apps/docs/src/components/mdx/mdx-components/view-transition-demo/strip-demo.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import React, { memo } from "react";
+import { strip } from "@ssgoi/react/view-transitions";
+import { BrowserContext, BrowserMockup, DemoPage } from "../browser-mockup";
+import type { RouteConfig } from "../browser-mockup";
+import { cn } from "../../../../lib/utils";
+import { useMobile } from "../../../../lib/use-mobile";
+
+// Page 1 - Bold Typography
+function SpeakingPage() {
+  const isMobile = useMobile();
+
+  return (
+    <DemoPage
+      path="/strip"
+      className="min-h-full"
+    >
+      <div
+        className={cn(
+          "mx-auto flex flex-col justify-center min-h-full",
+          isMobile ? "px-6 py-12" : "max-w-6xl px-8 py-20",
+        )}
+      >
+        <div className="space-y-8">
+          <h1
+            className={cn(
+              "font-black leading-none",
+              isMobile ? "text-6xl" : "text-[10rem]",
+              "text-orange-500 tracking-tight"
+            )}
+          >
+            SPEAKING
+          </h1>
+          <p
+            className={cn(
+              "font-medium text-gray-700",
+              isMobile ? "text-lg max-w-sm" : "text-2xl max-w-2xl",
+            )}
+          >
+            Transform your ideas into powerful narratives that captivate and inspire.
+          </p>
+          <div className="flex gap-4 pt-4">
+            <button className="px-6 py-3 bg-orange-500 text-white rounded-full font-semibold hover:bg-orange-600 transition-colors">
+              Start Now
+            </button>
+            <button className="px-6 py-3 bg-white text-orange-500 border-2 border-orange-500 rounded-full font-semibold hover:bg-orange-50 transition-colors">
+              Learn More
+            </button>
+          </div>
+        </div>
+      </div>
+    </DemoPage>
+  );
+}
+
+// Page 2 - Creative Layout
+function CreatingPage() {
+  const isMobile = useMobile();
+
+  return (
+    <DemoPage
+      path="/strip/creating"
+      className="min-h-full"
+    >
+      <div
+        className={cn(
+          "mx-auto flex items-center justify-center min-h-full",
+          isMobile ? "px-6 py-12" : "px-8 py-20",
+        )}
+      >
+        <div className="text-center space-y-12">
+          <div className="relative">
+            <h1
+              className={cn(
+                "font-black",
+                isMobile ? "text-5xl" : "text-[8rem]",
+                "text-transparent bg-clip-text bg-gradient-to-r from-purple-600 to-blue-600",
+                "tracking-tight leading-none"
+              )}
+            >
+              CREATING
+            </h1>
+            <div
+              className={cn(
+                "font-black absolute inset-0 blur-3xl opacity-30",
+                isMobile ? "text-5xl" : "text-[8rem]",
+                "text-purple-600",
+                "tracking-tight leading-none"
+              )}
+            >
+              CREATING
+            </div>
+          </div>
+
+          <div className="grid grid-cols-3 gap-8 max-w-3xl mx-auto">
+            <div className="text-center">
+              <div className="text-4xl mb-2">✨</div>
+              <p className="text-gray-700 font-medium">Innovate</p>
+            </div>
+            <div className="text-center">
+              <div className="text-4xl mb-2">🎯</div>
+              <p className="text-gray-700 font-medium">Execute</p>
+            </div>
+            <div className="text-center">
+              <div className="text-4xl mb-2">🚀</div>
+              <p className="text-gray-700 font-medium">Launch</p>
+            </div>
+          </div>
+
+          <p
+            className={cn(
+              "font-medium text-gray-700 max-w-xl mx-auto",
+              isMobile ? "text-base" : "text-xl",
+            )}
+          >
+            Where imagination meets execution. Build something extraordinary today.
+          </p>
+        </div>
+      </div>
+    </DemoPage>
+  );
+}
+
+// Page 3 - Minimal Impact
+function ImpactPage() {
+  const isMobile = useMobile();
+
+  return (
+    <DemoPage
+      path="/strip/impact"
+      className="min-h-full"
+    >
+      <div
+        className={cn(
+          "mx-auto flex flex-col justify-center min-h-full relative",
+          isMobile ? "px-6 py-12" : "px-8 py-20",
+        )}
+      >
+        <div className="space-y-16">
+          <div>
+            <p className="text-orange-500 font-semibold text-sm uppercase tracking-wider mb-4">
+              Make a Difference
+            </p>
+            <h1
+              className={cn(
+                "font-black",
+                isMobile ? "text-5xl" : "text-[7rem]",
+                "text-gray-900 leading-none tracking-tight"
+              )}
+            >
+              IMPACT
+            </h1>
+          </div>
+
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+            <div className="border-l-4 border-orange-500 pl-6">
+              <h3 className="text-gray-900 font-bold text-2xl mb-2">100M+</h3>
+              <p className="text-gray-600">Lives Changed</p>
+            </div>
+            <div className="border-l-4 border-orange-500 pl-6">
+              <h3 className="text-gray-900 font-bold text-2xl mb-2">50+</h3>
+              <p className="text-gray-600">Countries Reached</p>
+            </div>
+            <div className="border-l-4 border-orange-500 pl-6">
+              <h3 className="text-gray-900 font-bold text-2xl mb-2">∞</h3>
+              <p className="text-gray-600">Possibilities</p>
+            </div>
+          </div>
+
+          <div
+            className={cn(
+              "absolute bottom-8 right-8",
+              isMobile ? "hidden" : "block"
+            )}
+          >
+            <div className="w-32 h-32 rounded-full bg-orange-400 opacity-20 blur-3xl"></div>
+          </div>
+        </div>
+      </div>
+    </DemoPage>
+  );
+}
+
+// Route configuration
+const stripRoutes: RouteConfig[] = [
+  { path: "/strip", component: SpeakingPage, label: "Speaking" },
+  { path: "/strip/creating", component: CreatingPage, label: "Creating" },
+  { path: "/strip/impact", component: ImpactPage, label: "Impact" },
+];
+
+
+// Custom Layout Component
+const StripLayout = memo(({ children }: { children: React.ReactNode }) => {
+  const context = React.useContext(BrowserContext);
+  const isMobile = useMobile();
+
+  if (!context) return <>{children}</>;
+
+  const { currentPath, navigate, routes } = context;
+
+  return (
+    <div className="flex flex-col h-full relative bg-gradient-to-br from-orange-50 to-pink-50">
+      {/* Fixed Header */}
+      <header className="sticky top-0 z-30 bg-white/90 backdrop-blur-sm border-b border-gray-200/50">
+        <div className={cn("mx-auto", isMobile ? "px-4" : "max-w-7xl px-8")}>
+          <div className="flex items-center justify-between h-16">
+            <div className="flex items-center gap-8">
+              {/* Logo */}
+              <button
+                onClick={() => navigate(routes[0].path)}
+                className="font-black text-2xl text-orange-500 hover:text-orange-600 transition-colors"
+              >
+                CYD
+              </button>
+
+              {/* Navigation */}
+              {!isMobile && (
+                <nav className="flex items-center gap-6">
+                  {routes.map((route) => {
+                    const isActive = currentPath === route.path;
+                    return (
+                      <button
+                        key={route.path}
+                        onClick={() => navigate(route.path)}
+                        className={cn(
+                          "font-semibold text-sm uppercase tracking-wider transition-all",
+                          isActive
+                            ? "text-orange-500 border-b-2 border-orange-500 pb-1"
+                            : "text-gray-600 hover:text-gray-900",
+                        )}
+                      >
+                        {route.label}
+                      </button>
+                    );
+                  })}
+                </nav>
+              )}
+            </div>
+
+            {/* Mobile menu button */}
+            {isMobile && (
+              <button className="text-gray-600 hover:text-gray-900">
+                <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+                </svg>
+              </button>
+            )}
+          </div>
+        </div>
+      </header>
+
+      {/* Main Content */}
+      <main className="flex-1 overflow-auto relative z-0">{children}</main>
+    </div>
+  );
+});
+
+StripLayout.displayName = "StripLayout";
+
+export function StripDemo() {
+  const config = {
+    defaultTransition: strip(),
+  };
+
+  return (
+    <BrowserMockup
+      routes={stripRoutes}
+      config={config}
+      layout={StripLayout}
+    />
+  );
+}

--- a/packages/core/src/lib/view-transitions/index.ts
+++ b/packages/core/src/lib/view-transitions/index.ts
@@ -7,3 +7,4 @@ export * from "./jaemin";
 export * from "./pinterest";
 export * from "./scroll";
 export * from "./slide";
+export * from "./strip";

--- a/packages/core/src/lib/view-transitions/strip.ts
+++ b/packages/core/src/lib/view-transitions/strip.ts
@@ -1,7 +1,6 @@
 import type { SggoiTransition } from "../types";
 import { prepareOutgoing } from "../utils/prepare-outgoing";
 
-
 const DEFAULT_SPRING = { stiffness: 300, damping: 30 };
 
 export const strip = (): SggoiTransition => {
@@ -38,7 +37,7 @@ export const strip = (): SggoiTransition => {
         spring: DEFAULT_SPRING,
         prepare: (element) => prepareOutgoing(element, context),
         tick: (_progress) => {
-          const progress = 1 -_progress;
+          const progress = 1 - _progress;
           const translateX = progress * 100;
           element.style.transform = `translateX(${translateX}%)`;
         },

--- a/packages/core/src/lib/view-transitions/strip.ts
+++ b/packages/core/src/lib/view-transitions/strip.ts
@@ -12,7 +12,6 @@ export const strip = (): SggoiTransition => {
 
   return {
     in: (element) => {
-      
       return {
         spring: DEFAULT_SPRING,
         prepare: (element) => {

--- a/packages/core/src/lib/view-transitions/strip.ts
+++ b/packages/core/src/lib/view-transitions/strip.ts
@@ -2,6 +2,8 @@ import type { SggoiTransition } from "../types";
 import { prepareOutgoing } from "../utils/prepare-outgoing";
 
 const DEFAULT_SPRING = { stiffness: 300, damping: 30 };
+const ROTATE_Y = 20;
+const PERSPECTIVE = 800;
 
 export const strip = (): SggoiTransition => {
   // Shared promise for coordinating OUT and IN animations
@@ -10,11 +12,11 @@ export const strip = (): SggoiTransition => {
 
   return {
     in: (element) => {
+      
       return {
         spring: DEFAULT_SPRING,
         prepare: (element) => {
-          element.style.transformOrigin = "0% center";
-          element.style.transform = "perspective(800px) rotateY(-85deg)";
+          element.style.transform = `perspective(${PERSPECTIVE}px) rotateY(${ROTATE_Y}deg) translateX(-100%)`;
         },
         wait: async () => {
           // Wait for OUT animation to complete if it exists
@@ -23,8 +25,12 @@ export const strip = (): SggoiTransition => {
           }
         },
         tick: (progress) => {
-          const rotateY = (1 - progress) * -85;
-          element.style.transform = `perspective(800px) rotateY(${rotateY}deg)`;
+          const rotateY = (1 - progress) * ROTATE_Y;
+          const translateX = -(1 - progress) * 100;
+          element.style.transform = `perspective(${PERSPECTIVE}px) rotateY(${rotateY}deg) translateX(${translateX}%)`;
+        },
+        onEnd: () => {
+          element.style.transform = "";
         },
       };
     },
@@ -38,18 +44,19 @@ export const strip = (): SggoiTransition => {
         spring: DEFAULT_SPRING,
         prepare: (element) => {
           prepareOutgoing(element, context);
-          element.style.transformOrigin = "0% center";
         },
         tick: (_progress) => {
           const progress = 1 - _progress;
-          const rotateY = progress * 85;
-          element.style.transform = `perspective(800px) rotateY(${rotateY}deg)`;
+          const rotateY = progress * ROTATE_Y;
+          const translateX = progress * 100;
+          element.style.transform = `perspective(${PERSPECTIVE}px) rotateY(${-rotateY}deg) translateX(${translateX}%)`;
         },
         onEnd: () => {
           // Resolve the promise when OUT animation completes
           if (resolveOutAnimation) {
             resolveOutAnimation();
           }
+          element.style.transform = "";
         },
       };
     },

--- a/packages/core/src/lib/view-transitions/strip.ts
+++ b/packages/core/src/lib/view-transitions/strip.ts
@@ -1,0 +1,54 @@
+import type { SggoiTransition } from "../types";
+import { prepareOutgoing } from "../utils/prepare-outgoing";
+
+
+const DEFAULT_SPRING = { stiffness: 300, damping: 30 };
+
+export const strip = (): SggoiTransition => {
+  // Shared promise for coordinating OUT and IN animations
+  let outAnimationComplete: Promise<void>;
+  let resolveOutAnimation: (() => void) | null = null;
+
+  return {
+    in: (element) => {
+      return {
+        spring: DEFAULT_SPRING,
+        prepare: (element) => {
+          element.style.transform = "translateX(-100%)";
+        },
+        wait: async () => {
+          // Wait for OUT animation to complete if it exists
+          if (outAnimationComplete) {
+            await outAnimationComplete;
+          }
+        },
+        tick: (progress) => {
+          const translateX = (1 - progress) * -100;
+          element.style.transform = `translateX(${translateX}%)`;
+        },
+      };
+    },
+    out: (element, context) => {
+      // Create promise for OUT animation completion
+      outAnimationComplete = new Promise((resolve) => {
+        resolveOutAnimation = resolve;
+      });
+
+      return {
+        spring: DEFAULT_SPRING,
+        prepare: (element) => prepareOutgoing(element, context),
+        tick: (_progress) => {
+          const progress = 1 -_progress;
+          const translateX = progress * 100;
+          element.style.transform = `translateX(${translateX}%)`;
+        },
+        onEnd: () => {
+          // Resolve the promise when OUT animation completes
+          if (resolveOutAnimation) {
+            resolveOutAnimation();
+          }
+        },
+      };
+    },
+  };
+};

--- a/packages/core/src/lib/view-transitions/strip.ts
+++ b/packages/core/src/lib/view-transitions/strip.ts
@@ -13,7 +13,8 @@ export const strip = (): SggoiTransition => {
       return {
         spring: DEFAULT_SPRING,
         prepare: (element) => {
-          element.style.transform = "translateX(-100%)";
+          element.style.transformOrigin = "0% center";
+          element.style.transform = "perspective(800px) rotateY(-85deg)";
         },
         wait: async () => {
           // Wait for OUT animation to complete if it exists
@@ -22,8 +23,8 @@ export const strip = (): SggoiTransition => {
           }
         },
         tick: (progress) => {
-          const translateX = (1 - progress) * -100;
-          element.style.transform = `translateX(${translateX}%)`;
+          const rotateY = (1 - progress) * -85;
+          element.style.transform = `perspective(800px) rotateY(${rotateY}deg)`;
         },
       };
     },
@@ -35,11 +36,14 @@ export const strip = (): SggoiTransition => {
 
       return {
         spring: DEFAULT_SPRING,
-        prepare: (element) => prepareOutgoing(element, context),
+        prepare: (element) => {
+          prepareOutgoing(element, context);
+          element.style.transformOrigin = "0% center";
+        },
         tick: (_progress) => {
           const progress = 1 - _progress;
-          const translateX = progress * 100;
-          element.style.transform = `translateX(${translateX}%)`;
+          const rotateY = progress * 85;
+          element.style.transform = `perspective(800px) rotateY(${rotateY}deg)`;
         },
         onEnd: () => {
           // Resolve the promise when OUT animation completes


### PR DESCRIPTION
## Summary
- Add new strip view transition with film-like 3D curve effect
- Create demo component showcasing the transition
- Add comprehensive documentation in 4 languages

## Changes
- ✨ Implement strip transition in core package with 3D curve animation
- 🎨 Add strip demo component with premium brand design
- 📝 Create documentation in Korean, English, Chinese, and Japanese
- 🎯 Position as premium transition for top-level navigation
- 💡 Recommend transparent page backgrounds for better visual effect

## Demo
The strip transition creates a film strip-like effect where pages curve along a 3D path as they transition, perfect for premium landing pages and brand experiences.

## Test Plan
- [ ] Test strip transition in React demo
- [ ] Test strip transition in Svelte demo
- [ ] Verify demo component renders correctly
- [ ] Check documentation in all languages
- [ ] Test with transparent and opaque backgrounds
- [ ] Verify responsive behavior on mobile

🤖 Generated with [Claude Code](https://claude.ai/code)