### PR TITLE
feat: Add skipOnIosSwipe option to prevent Safari swipe-back animation conflicts

### DIFF
--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -109,6 +109,12 @@ export type SsgoiConfig = {
   }[];
   defaultTransition?: SggoiTransition;
   middleware?: (from: string, to: string) => { from: string; to: string };
+  /**
+   * Skip page transitions when iOS/Safari swipe-back gesture is detected
+   * This prevents animation conflicts between SSGOI and Safari's native swipe animation
+   * @default true
+   */
+  skipOnIosSwipe?: boolean;
 };
 
 export type SsgoiContext = (


### PR DESCRIPTION
## Summary

This PR implements iOS/Safari swipe-back gesture detection to prevent animation conflicts between SSGOI and Safari's native swipe animation.

**Related Issues:** Fixes #87, Fixes #60

## Problem

When users perform swipe-back gestures on iOS Safari or macOS Safari, both Safari's native swipe animation and SSGOI's page transition animations play simultaneously, creating a jarring user experience with overlapping animations.

## Solution

Added a new `skipOnIosSwipe` option to `SsgoiConfig` that:
- Detects iOS/Safari edge swipe gestures using touch events
- Automatically skips SSGOI page transitions when a swipe-back gesture is detected
- Defaults to `true` to provide the best out-of-box experience
- Can be disabled by setting `skipOnIosSwipe: false` if needed

## Implementation Details

1. **New Config Option**: Added `skipOnIosSwipe?: boolean` to `SsgoiConfig` (default: `true`)

2. **Swipe Detection Logic**:
   - Monitors `touchstart` and `touchmove` events
   - Detects edge swipes starting within 50px from the left edge
   - Validates horizontal rightward movement (>30px)
   - Ensures horizontal movement exceeds vertical movement
   - Auto-resets after 500ms to resume normal navigation

3. **Animation Skip Behavior**:
   - Returns empty transition config when swipe is detected
   - Prevents both OUT and IN animations during swipe navigation
   - No impact on other navigation methods (button clicks, programmatic navigation)

## Changes

- `packages/core/src/lib/types.ts`: Added `skipOnIosSwipe` option to `SsgoiConfig`
- `packages/core/src/lib/create-ssgoi-transition-context.ts`: Implemented swipe detector and skip logic
- React and Svelte packages automatically inherit this feature (no changes needed)

## Testing

- ✅ Builds successfully for all packages (core, react, svelte)
- 🧪 Manual testing needed on iOS Safari and macOS Safari
- 🧪 Verify no regression in other browsers (Chrome, Firefox, Edge)

## Test Plan

- [ ] Test swipe-back gesture on iOS Safari
- [ ] Test swipe-back gesture on macOS Safari  
- [ ] Verify back button navigation still has transitions
- [ ] Verify programmatic navigation still has transitions
- [ ] Test with `skipOnIosSwipe: false` option
- [ ] Test on Chrome, Firefox, Edge (should have no impact)

## Breaking Changes

None. This is a non-breaking change with the feature enabled by default.

## Notes

This is currently a work-in-progress implementation. Feedback and testing on real iOS devices is appreciated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)