### PR TITLE
fix: Improve fade transition timing and demo pacing

### DIFF
--- a/apps/docs/src/components/demo/index.tsx
+++ b/apps/docs/src/components/demo/index.tsx
@@ -45,7 +45,7 @@ export default function Demo({ autoPlay = true }: DemoProps) {
       currentRouteIndex.current =
         (currentRouteIndex.current + 1) % routingPaths.length;
       setCurrentPath(routingPaths[currentRouteIndex.current]);
-    }, 3000); // 3 seconds interval
+    }, 5000); // 3 seconds interval
 
     return () => clearInterval(intervalId);
   }, [autoPlay, isHovered, isMobile, routingPaths]);

--- a/packages/core/src/lib/view-transitions/fade.ts
+++ b/packages/core/src/lib/view-transitions/fade.ts
@@ -2,8 +2,8 @@ import type { SpringConfig, SggoiTransition } from "../types";
 import { prepareOutgoing } from "../utils/prepare-outgoing";
 import { sleep } from "../utils/sleep";
 
-const DEFAULT_OUT_SPRING = { stiffness: 7, damping: 4 };
-const DEFAULT_IN_SPRING = { stiffness: 8, damping: 4 };
+const DEFAULT_OUT_SPRING = { stiffness: 10, damping: 4 };
+const DEFAULT_IN_SPRING = { stiffness: 11, damping: 4 };
 const DEFAULT_TRANSITION_DELAY = 0;
 
 interface FadeOptions {


### PR DESCRIPTION
## Summary

- Increased fade transition spring stiffness values for snappier, more responsive animations
  - OUT spring stiffness: 7 → 10
  - IN spring stiffness: 8 → 11
- Increased demo auto-play interval from 3s to 5s to give users more time to observe each transition

## Test plan

- [ ] Test fade transitions in the demo site to verify improved responsiveness
- [ ] Verify auto-play timing feels comfortable and not too fast
- [ ] Check that animations remain smooth with the new spring values
- [ ] Test on different devices/browsers to ensure consistent behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)