### PR TITLE
fix: upgrade swipe detection (remove heuristic setTImeout)

### DIFF
--- a/packages/core/src/lib/ssgoi-transition/create-ssgoi-transition-context.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-ssgoi-transition-context.ts
@@ -154,7 +154,7 @@ export function createSggoiTransitionContext(
     if (swipeDetector.isSwipePending()) {
       // Reset swipe detection to allow normal navigation after this check
       swipeDetector.resetSwipeDetection();
-      
+
       return () => ({}); // Return empty transition
     }
 

--- a/packages/core/src/lib/ssgoi-transition/create-swipe-detector.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-swipe-detector.ts
@@ -30,7 +30,6 @@ export function createSwipeDetector(enabled: boolean) {
     if (!enabled) return;
     if (!isEdgeTouch) return;
 
-
     const touch = e.touches[0];
     if (!touch) return;
 
@@ -38,7 +37,10 @@ export function createSwipeDetector(enabled: boolean) {
     const deltaY = touch.clientY - startY;
 
     // Detect swipe: moved right more than threshold and horizontal movement is dominant
-    if (deltaX > window.outerWidth / 2 - 5 && Math.abs(deltaX) > Math.abs(deltaY)) {
+    if (
+      deltaX > window.outerWidth / 2 - 5 &&
+      Math.abs(deltaX) > Math.abs(deltaY)
+    ) {
       isSwipeDetected = true;
     } else {
       isSwipeDetected = false;
@@ -85,6 +87,6 @@ export function createSwipeDetector(enabled: boolean) {
     initialize,
     cleanup,
     isSwipePending,
-    resetSwipeDetection
+    resetSwipeDetection,
   };
 }


### PR DESCRIPTION
## Problem
The previous 500ms delay was preventing animations from working properly when attempting to transition pages immediately after detecting a swipe gesture (non-swipe interactions).

I don't know how to solve it (@elrion018 )

