### PR TITLE
Improve fade transition responsiveness

### DIFF
--- a/packages/core/src/lib/animator/animate.ts
+++ b/packages/core/src/lib/animator/animate.ts
@@ -57,8 +57,8 @@ export function animate(options: AnimateOptions): AnimationControls {
   const zeta = damping / (2 * Math.sqrt(stiffness * mass)); // Damping ratio
 
   // Convergence thresholds
-  const POSITION_THRESHOLD = 0.01;
-  const VELOCITY_THRESHOLD = 0.01;
+  const POSITION_THRESHOLD = 0.1;
+  const VELOCITY_THRESHOLD = 0.1;
 
   // Track time for stability checks
   let settleTime = 0;

--- a/packages/core/src/lib/view-transitions/fade.ts
+++ b/packages/core/src/lib/view-transitions/fade.ts
@@ -2,8 +2,8 @@ import type { SpringConfig, SggoiTransition } from "../types";
 import { prepareOutgoing } from "../utils/prepare-outgoing";
 import { sleep } from "../utils/sleep";
 
-const DEFAULT_OUT_SPRING = { stiffness: 10, damping: 4 };
-const DEFAULT_IN_SPRING = { stiffness: 11, damping: 4 };
+const DEFAULT_OUT_SPRING = { stiffness: 10, damping: 4.5 };
+const DEFAULT_IN_SPRING = { stiffness: 65, damping: 14 };
 const DEFAULT_TRANSITION_DELAY = 0;
 
 interface FadeOptions {
@@ -54,7 +54,7 @@ export const fade = (options: FadeOptions = {}): SggoiTransition => {
         tick: (progress) => {
           element.style.opacity = progress.toString();
         },
-        prepare: (element) => {
+        prepare: () => {
           prepareOutgoing(element, context);
           element.style.willChange = "opacity";
         },


### PR DESCRIPTION
## Summary
- Increased animation completion threshold to fix stuck animations near completion
- Adjusted fade transition spring values for more natural timing

## Changes
- Raised convergence thresholds from 0.01 to 0.1 to prevent animations appearing stuck while technically still running
- Modified fade transition spring configuration for smoother motion

🤖 Generated with [Claude Code](https://claude.com/claude-code)