### PR TITLE
fix: Skip film transition when language changes

### DIFF
--- a/apps/docs/src/components/layout/ssgoi.tsx
+++ b/apps/docs/src/components/layout/ssgoi.tsx
@@ -16,15 +16,18 @@ export function SsgoiProvider({ children }: SsgoiProviderProps) {
       transitions: isMobile
         ? []
         : [
-            // Apply film transition to non-demo pages
+            // Apply film transition only within non-demo pages
             {
-              from: "*",
+              from: "/non-demo/*",
               to: "/non-demo/*",
               transition: film(),
             },
           ],
 
       middleware(from, to) {
+        if (from === to) {
+          return { from: "none", to: "none" };
+        }
         // Transform paths: non-demo routes get prefixed with /non-demo
         const isDemoRoute = (path: string) => path.includes("/demo");
 


### PR DESCRIPTION
## Summary
Fixed an issue where the film transition was incorrectly triggered when switching between language routes (e.g., /ko to /en). Now language switches are instant without the film animation.

## Changes
- Updated transition rule to only apply within non-demo pages (`from: "/non-demo/*"` to `"/non-demo/*"`)
- Added middleware check to skip transitions when `from === to`

## Test plan
- [ ] Switch between Korean and English languages on the docs site
- [ ] Verify no film transition occurs during language changes
- [ ] Verify film transition still works when navigating between different pages within the same language

🤖 Generated with [Claude Code](https://claude.com/claude-code)