### PR TITLE
fix: correct molasses preset values

### DIFF
--- a/apps/docs/content/en/02.core-concepts/03.spring-presets.mdx
+++ b/apps/docs/content/en/02.core-concepts/03.spring-presets.mdx
@@ -72,8 +72,8 @@ Deliberate and measured animations.
 
 ### molasses
 Very slow and viscous movement.
-- **stiffness**: 280
-- **damping**: 120
+- **stiffness**: 150
+- **damping**: 60
 - **Use case**: Dramatic effects, loading states
 
 ## Custom Spring Configuration

--- a/apps/docs/content/ja/02.core-concepts/03.spring-presets.mdx
+++ b/apps/docs/content/ja/02.core-concepts/03.spring-presets.mdx
@@ -72,8 +72,8 @@ transition({
 
 ### molasses
 非常に遅く粘性のある動き。
-- **stiffness**: 280
-- **damping**: 120
+- **stiffness**: 150
+- **damping**: 60
 - **ユースケース**: ドラマチックな効果、ローディング状態
 
 ## カスタムスプリング設定

--- a/apps/docs/content/ko/02.core-concepts/03.spring-presets.mdx
+++ b/apps/docs/content/ko/02.core-concepts/03.spring-presets.mdx
@@ -72,8 +72,8 @@ transition({
 
 ### molasses
 매우 느리고 점성이 있는 움직임입니다.
-- **stiffness**: 280
-- **damping**: 120
+- **stiffness**: 150
+- **damping**: 60
 - **사용 사례**: 극적인 효과, 로딩 상태
 
 ## 커스텀 스프링 설정

--- a/apps/docs/content/zh/02.core-concepts/03.spring-presets.mdx
+++ b/apps/docs/content/zh/02.core-concepts/03.spring-presets.mdx
@@ -72,8 +72,8 @@ transition({
 
 ### molasses
 非常缓慢和粘稠的运动。
-- **stiffness**: 280
-- **damping**: 120
+- **stiffness**: 150
+- **damping**: 60
 - **用例**: 戏剧性效果、加载状态
 
 ## 自定义弹簧配置

--- a/packages/core/src/lib/presets/index.ts
+++ b/packages/core/src/lib/presets/index.ts
@@ -26,8 +26,8 @@ export const slow: SpringConfig = {
 };
 
 export const molasses: SpringConfig = {
-  stiffness: 280,
-  damping: 120,
+  stiffness: 150,
+  damping: 60,
 };
 
 export const config = {


### PR DESCRIPTION
## Changes
- Change stiffness from 280 to 150
- Change damping from 120 to 60
- Update documentation in all languages


## Additional Note
I noticed that if users manually set `stiffness: 280, damping: 120` in their transitions, they might experience the same issue. But I'm not entirely sure if this is an actual bug or just edge case behavior 🤔