### PR TITLE
perf: add GPU acceleration hints to hero transition

### DIFF
--- a/packages/core/src/lib/view-transitions/hero.ts
+++ b/packages/core/src/lib/view-transitions/hero.ts
@@ -85,6 +85,7 @@ export const hero = (options: HeroOptions = {}): SggoiTransition => {
           const originalPosition = toEl.style.position;
           const originalTransformOrigin = toEl.style.transformOrigin;
           const originalZIndex = toEl.style.zIndex;
+          const originalWillChange = toEl.style.willChange;
 
           return {
             toEl,
@@ -96,6 +97,7 @@ export const hero = (options: HeroOptions = {}): SggoiTransition => {
             originalPosition,
             originalTransformOrigin,
             originalZIndex,
+            originalWillChange,
           };
         })
         .filter(
@@ -111,6 +113,7 @@ export const hero = (options: HeroOptions = {}): SggoiTransition => {
             originalPosition: string;
             originalTransformOrigin: string;
             originalZIndex: string;
+            originalWillChange: string;
           } => animation !== null && Math.abs(animation.dy) <= maxDistance,
         );
 
@@ -131,6 +134,7 @@ export const hero = (options: HeroOptions = {}): SggoiTransition => {
             toEl.style.position = "relative";
             toEl.style.transformOrigin = "top left";
             toEl.style.zIndex = "1000";
+            toEl.style.willChange = "transform";
           });
         },
         tick: (progress) => {
@@ -148,11 +152,13 @@ export const hero = (options: HeroOptions = {}): SggoiTransition => {
               originalPosition,
               originalTransformOrigin,
               originalZIndex,
+              originalWillChange,
             }) => {
               toEl.style.transform = originalTransform;
               toEl.style.position = originalPosition;
               toEl.style.transformOrigin = originalTransformOrigin;
               toEl.style.zIndex = originalZIndex;
+              toEl.style.willChange = originalWillChange;
             },
           );
         },


### PR DESCRIPTION
## Summary

This PR optimizes the `hero` transition by adding GPU acceleration hints to animated hero elements.

## Changes

### GPU Optimization
- Added `willChange: 'transform'` hint to hero elements in the `prepare` phase
- Store original `willChange` value along with other original styles
- Restore original `willChange` value in `onEnd` callback for proper cleanup

## Benefits

1. **Better Performance**: GPU hints improve animation smoothness for hero transitions
2. **Proper Cleanup**: Original willChange values are preserved and restored
3. **Memory Efficiency**: Cleanup in onEnd prevents GPU layer memory leaks
4. **Consistent Pattern**: Follows the same optimization pattern as drill transition

## Implementation Details

The optimization is applied to `heroAnimations` array which contains all matching hero elements between the outgoing and incoming pages. Each hero element:
- Gets `willChange: 'transform'` set during preparation
- Has its original willChange value stored
- Gets restored to its original state in onEnd

## Test Plan

- [x] Verify hero transitions work correctly with willChange hints
- [x] Confirm original willChange values are properly restored
- [x] Ensure no memory leaks from GPU layers
- [x] Test with multiple hero elements on same page

🤖 Generated with [Claude Code](https://claude.com/claude-code)