### PR TITLE
perf: add GPU acceleration hints to scroll transition

### DIFF
--- a/packages/core/src/lib/view-transitions/scroll.ts
+++ b/packages/core/src/lib/view-transitions/scroll.ts
@@ -50,6 +50,9 @@ export const scroll = (options: ScrollOptions = {}): SggoiTransition => {
 
       return {
         spring,
+        prepare: () => {
+          element.style.willChange = "transform";
+        },
         tick: (progress) => {
           // Check if height is calculated
           if (calculatedHeight === null) {
@@ -62,6 +65,9 @@ export const scroll = (options: ScrollOptions = {}): SggoiTransition => {
             ? (1 - progress) * calculatedHeight // calculatedHeight → 0
             : (1 - progress) * -calculatedHeight; // -calculatedHeight → 0
           element.style.transform = `translateY(${translateY}px)`;
+        },
+        onEnd: () => {
+          element.style.willChange = "auto";
         },
       };
     },
@@ -93,6 +99,7 @@ export const scroll = (options: ScrollOptions = {}): SggoiTransition => {
         prepareOutgoing(element);
 
         element.style.zIndex = isUp ? "-1" : "1";
+        element.style.willChange = "transform";
       },
     }),
   };


### PR DESCRIPTION
## Summary

This PR optimizes the `scroll` transition by adding GPU acceleration hints to improve animation performance.

## Changes

### GPU Optimization
- Added `willChange: 'transform'` hint in both `in` and `out` animations
- Added `onEnd` callback in `in` animation to reset `willChange: 'auto'` 
- `out` animation doesn't need `onEnd` since the element will be removed anyway

## Benefits

1. **Better Performance**: GPU hints improve scroll animation smoothness
2. **Proper Cleanup**: willChange is reset after animation completes (in phase only)
3. **Memory Efficiency**: Prevents unnecessary GPU layer retention
4. **Consistent Pattern**: Follows the same optimization pattern as drill and hero transitions

## Implementation Details

- **IN animation**: Gets `prepare` to set willChange and `onEnd` to cleanup
- **OUT animation**: Gets willChange in `prepare` but no cleanup needed (element removed)

## Test Plan

- [x] Verify scroll transition works correctly in both up and down directions
- [x] Confirm willChange is applied during animations
- [x] Ensure willChange is properly reset after in animation completes
- [x] Test that out animation performs well without onEnd

🤖 Generated with [Claude Code](https://claude.com/claude-code)