### PR TITLE
perf: add GPU acceleration hints to instagram and pinterest transitions

### DIFF
--- a/packages/core/src/lib/view-transitions/instagram.ts
+++ b/packages/core/src/lib/view-transitions/instagram.ts
@@ -296,10 +296,20 @@ export const instagram = (options: InstagramOptions = {}): SggoiTransition => {
 
       return {
         spring,
+        prepare: () => {
+          if (handlers?.inAnimation) {
+            toNode.style.willChange = "transform, clip-path";
+          }
+        },
         tick: (progress) => {
           // Use inAnimation if available (enterMode), otherwise stay visible
           if (handlers?.inAnimation) {
             handlers.inAnimation(progress);
+          }
+        },
+        onEnd: () => {
+          if (handlers?.inAnimation) {
+            toNode.style.willChange = "auto";
           }
         },
       };
@@ -321,6 +331,9 @@ export const instagram = (options: InstagramOptions = {}): SggoiTransition => {
           prepareOutgoing(element, context);
           if (!handlers?.isEnterMode) {
             element.style.zIndex = "-1";
+          }
+          if (handlers?.outAnimation) {
+            element.style.willChange = "transform, clip-path";
           }
         },
         tick: (progress) => {

--- a/packages/core/src/lib/view-transitions/pinterest.ts
+++ b/packages/core/src/lib/view-transitions/pinterest.ts
@@ -370,8 +370,14 @@ export const pinterest = (options: PinterestOptions = {}): SggoiTransition => {
 
       return {
         spring,
+        prepare: () => {
+          toNode.style.willChange = "transform, clip-path, opacity";
+        },
         tick: (progress) => {
           if (handlers) handlers.inAnimation(progress);
+        },
+        onEnd: () => {
+          toNode.style.willChange = "auto";
         },
       };
     },
@@ -391,6 +397,7 @@ export const pinterest = (options: PinterestOptions = {}): SggoiTransition => {
         prepare: (element) => {
           prepareOutgoing(element);
           element.style.zIndex = "-1";
+          element.style.willChange = "transform, clip-path, opacity";
         },
         tick: (progress) => {
           if (handlers) handlers.outAnimation(progress);


### PR DESCRIPTION
## Summary

This PR optimizes both `instagram` and `pinterest` transitions by adding GPU acceleration hints for properties including `transform`, `clip-path`, and `opacity`.

## Changes

### Instagram Transition
- Added conditional willChange hints based on animation availability
- `inAnimation`: Sets `willChange: 'transform, clip-path'` with cleanup in onEnd
- `outAnimation`: Sets `willChange: 'transform, clip-path'` in prepare
- Handles both enter mode (gallery → detail) and exit mode (detail → gallery)

### Pinterest Transition
- Added willChange hints for all animated properties: `transform, clip-path, opacity`
- IN animation: Gets prepare and onEnd for proper GPU layer management
- OUT animation: Gets willChange in prepare (no cleanup needed)
- Covers all animation types:
  - `createDetailIn`: uses clip-path + transform
  - `createGalleryOut`: uses transform + opacity
  - `createGalleryIn`: uses transform + opacity  
  - `createDetailOut`: uses clip-path + transform

## Benefits

1. **Better Performance**: GPU hints significantly improve animation smoothness for complex transitions
2. **Comprehensive Coverage**: Handles transform, clip-path, and opacity animations
3. **Proper Cleanup**: onEnd callbacks in IN animations prevent memory leaks
4. **Smart Optimization**: Instagram uses conditional hints based on animation mode
5. **Consistent Pattern**: Follows same optimization approach as drill, hero, and scroll

## Implementation Details

Both transitions use:
- `prepare()` to set willChange before animation starts
- `onEnd()` in IN animations to cleanup GPU layers (only where element persists)
- No onEnd in OUT animations since elements are removed anyway

## Test Plan

- [x] Verify instagram transition works in both enter and exit modes
- [x] Verify pinterest gallery/detail transitions work correctly
- [x] Confirm clip-path animations render smoothly with GPU hints
- [x] Ensure willChange is properly reset after IN animations complete
- [x] Test that conditional hints in instagram work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)