### PR TITLE
perf: add GPU acceleration hints to slide transition

### DIFF
--- a/packages/core/src/lib/view-transitions/slide.ts
+++ b/packages/core/src/lib/view-transitions/slide.ts
@@ -23,11 +23,17 @@ export const slide = (options: SlideOptions = {}): SggoiTransition => {
   return {
     in: (element) => ({
       spring,
+      prepare: () => {
+        element.style.willChange = "transform";
+      },
       tick: (progress) => {
         const translateX = isLeft
           ? (1 - progress) * 100 // 100 → 0
           : (1 - progress) * -100; // -100 → 0
         element.style.transform = `translateX(${translateX}%)`;
+      },
+      onEnd: () => {
+        element.style.willChange = "auto";
       },
     }),
     out: (element, context) => ({
@@ -42,6 +48,7 @@ export const slide = (options: SlideOptions = {}): SggoiTransition => {
         prepareOutgoing(element, context);
 
         element.style.zIndex = isLeft ? "-1" : "1";
+        element.style.willChange = "transform";
       },
     }),
   };


### PR DESCRIPTION
## Summary

This PR optimizes the `slide` transition by adding GPU acceleration hints to improve animation performance.

## Changes

### GPU Optimization
- Added `willChange: 'transform'` hint in both `in` and `out` animations
- Added `onEnd` callback in `in` animation to reset `willChange: 'auto'`
- `out` animation doesn't need `onEnd` since the element will be removed anyway

## Benefits

1. **Better Performance**: GPU hints improve slide animation smoothness
2. **Proper Cleanup**: willChange is reset after animation completes (in phase only)
3. **Memory Efficiency**: Prevents unnecessary GPU layer retention
4. **Consistent Pattern**: Follows the same optimization pattern as other transitions

## Implementation Details

- **IN animation**: Gets `prepare` to set willChange and `onEnd` to cleanup
- **OUT animation**: Gets willChange in `prepare` but no cleanup needed (element removed)

## Test Plan

- [x] Verify slide transition works correctly in both left and right directions
- [x] Confirm willChange is applied during animations
- [x] Ensure willChange is properly reset after in animation completes
- [x] Test that out animation performs well without onEnd

🤖 Generated with [Claude Code](https://claude.com/claude-code)