### PR TITLE
perf: add GPU acceleration hints to strip transition

### DIFF
--- a/packages/core/src/lib/view-transitions/strip.ts
+++ b/packages/core/src/lib/view-transitions/strip.ts
@@ -15,6 +15,7 @@ export const strip = (): SggoiTransition => {
       return {
         spring: DEFAULT_SPRING,
         prepare: (element) => {
+          element.style.willChange = "transform";
           element.style.transform = `perspective(${PERSPECTIVE}px) rotateY(${ROTATE_Y}deg) translateX(-100%)`;
         },
         wait: async () => {
@@ -30,6 +31,7 @@ export const strip = (): SggoiTransition => {
         },
         onEnd: () => {
           element.style.transform = "";
+          element.style.willChange = "auto";
         },
       };
     },
@@ -43,6 +45,7 @@ export const strip = (): SggoiTransition => {
         spring: DEFAULT_SPRING,
         prepare: (element) => {
           prepareOutgoing(element, context);
+          element.style.willChange = "transform";
         },
         tick: (_progress) => {
           const progress = 1 - _progress;


### PR DESCRIPTION
## Summary

This PR optimizes the `strip` transition by adding GPU acceleration hints to improve animation performance for 3D transforms.

## Changes

### GPU Optimization
- Added `willChange: 'transform'` hint in both `in` and `out` animations
- Added cleanup in `in` animation onEnd to reset `willChange: 'auto'`
- Strip transition uses `perspective` and `rotateY` 3D transforms along with `translateX`

## Benefits

1. **Better Performance**: GPU hints significantly improve 3D transform animation smoothness
2. **Proper Cleanup**: willChange is reset after in animation completes
3. **3D Transform Optimization**: Especially important for perspective and rotateY transforms
4. **Consistent Pattern**: Follows the same optimization pattern as other transitions

## Implementation Details

The strip transition uses complex 3D transforms:
- `perspective(800px)` for depth
- `rotateY()` for 3D rotation effect
- `translateX()` for horizontal movement

GPU acceleration is particularly beneficial for these 3D transforms.

- **IN animation**: Sets willChange in prepare, cleans up in onEnd
- **OUT animation**: Sets willChange in prepare (element will be removed, no cleanup needed)

## Test Plan

- [x] Verify strip transition 3D effect works correctly
- [x] Confirm willChange is applied during animations
- [x] Ensure willChange is properly reset after in animation completes
- [x] Test that perspective and rotateY transforms are smooth

🤖 Generated with [Claude Code](https://claude.com/claude-code)