### PR TITLE
perf: use Web Animation API for element transitions

### DIFF
--- a/packages/core/src/lib/transitions/blur.ts
+++ b/packages/core/src/lib/transitions/blur.ts
@@ -1,4 +1,4 @@
-import type { TransitionKey } from "../types";
+import type { StyleObject, TransitionKey } from "../types";
 
 interface BlurOptions {
   amount?: number | string;
@@ -22,62 +22,35 @@ export const blur = (options: BlurOptions = {}) => {
     key,
   } = options;
 
-  const getBlurAmount = (value: number | string): string => {
-    return typeof value === "number" ? `${value}px` : value;
+  const getCss = (progress: number): StyleObject => {
+    const blurMultiplier = 1 - progress;
+    const style: StyleObject = {};
+
+    if (typeof amount === "number") {
+      style.filter = `blur(${blurMultiplier * amount}px)`;
+    } else {
+      style.filter = `blur(calc(${amount} * ${blurMultiplier}))`;
+    }
+
+    if (scale) {
+      style.transform = `scale(${0.8 + progress * 0.2})`;
+    }
+
+    if (fade) {
+      style.opacity = opacity + (1 - opacity) * progress;
+    }
+
+    return style;
   };
 
   return {
-    in: (element: HTMLElement) => ({
+    in: () => ({
       spring,
-      tick: (progress: number) => {
-        const blurMultiplier = 1 - progress;
-        const blurValue =
-          typeof amount === "number"
-            ? blurMultiplier * amount
-            : `calc(${getBlurAmount(amount)} * ${blurMultiplier})`;
-
-        element.style.filter =
-          typeof amount === "number"
-            ? `blur(${blurValue}px)`
-            : `blur(${blurValue})`;
-
-        if (scale) {
-          element.style.transform = `scale(${0.8 + progress * 0.2})`;
-        }
-
-        if (fade) {
-          element.style.opacity = (
-            opacity +
-            (1 - opacity) * progress
-          ).toString();
-        }
-      },
+      css: getCss,
     }),
-    out: (element: HTMLElement) => ({
+    out: () => ({
       spring,
-      tick: (progress: number) => {
-        const blurMultiplier = 1 - progress;
-        const blurValue =
-          typeof amount === "number"
-            ? blurMultiplier * amount
-            : `calc(${getBlurAmount(amount)} * ${blurMultiplier})`;
-
-        element.style.filter =
-          typeof amount === "number"
-            ? `blur(${blurValue}px)`
-            : `blur(${blurValue})`;
-
-        if (scale) {
-          element.style.transform = `scale(${0.8 + progress * 0.2})`;
-        }
-
-        if (fade) {
-          element.style.opacity = (
-            opacity +
-            (1 - opacity) * progress
-          ).toString();
-        }
-      },
+      css: getCss,
     }),
     ...(key && { key }),
   };

--- a/packages/core/src/lib/transitions/bounce.ts
+++ b/packages/core/src/lib/transitions/bounce.ts
@@ -1,4 +1,4 @@
-import type { TransitionKey } from "../types";
+import type { StyleObject, TransitionKey } from "../types";
 
 interface BounceOptions {
   height?: number;
@@ -24,64 +24,43 @@ export const bounce = (options: BounceOptions = {}) => {
     key,
   } = options;
 
+  const getCss = (progress: number): StyleObject => {
+    const style: StyleObject = {};
+    const transforms: string[] = [];
+
+    // Enhanced bounce effect with intensity control
+    const bounceWave = Math.sin(progress * Math.PI * (1 + intensity));
+    const dampening = 1 - progress;
+    const bounceOffset = bounceWave * height * dampening;
+
+    if (direction === "up") {
+      transforms.push(`translateY(${-Math.abs(bounceOffset)}px)`);
+    } else {
+      transforms.push(`translateY(${Math.abs(bounceOffset)}px)`);
+    }
+
+    if (scale) {
+      const scaleValue = 0.8 + progress * 0.2 + bounceWave * 0.05 * dampening;
+      transforms.push(`scale(${scaleValue})`);
+    }
+
+    style.transform = transforms.join(" ");
+
+    if (fade) {
+      style.opacity = progress;
+    }
+
+    return style;
+  };
+
   return {
-    in: (element: HTMLElement) => ({
+    in: () => ({
       spring,
-      tick: (progress: number) => {
-        const transforms = [];
-
-        // Enhanced bounce effect with intensity control
-        const bounceWave = Math.sin(progress * Math.PI * (1 + intensity));
-        const dampening = 1 - progress;
-        const bounceOffset = bounceWave * height * dampening;
-
-        if (direction === "up") {
-          transforms.push(`translateY(${-Math.abs(bounceOffset)}px)`);
-        } else {
-          transforms.push(`translateY(${Math.abs(bounceOffset)}px)`);
-        }
-
-        if (scale) {
-          const scaleValue =
-            0.8 + progress * 0.2 + bounceWave * 0.05 * dampening;
-          transforms.push(`scale(${scaleValue})`);
-        }
-
-        element.style.transform = transforms.join(" ");
-
-        if (fade) {
-          element.style.opacity = progress.toString();
-        }
-      },
+      css: getCss,
     }),
-    out: (element: HTMLElement) => ({
+    out: () => ({
       spring,
-      tick: (progress: number) => {
-        const transforms = [];
-
-        // Enhanced bounce effect with intensity control
-        const bounceWave = Math.sin(progress * Math.PI * (1 + intensity));
-        const dampening = 1 - progress;
-        const bounceOffset = bounceWave * height * dampening;
-
-        if (direction === "up") {
-          transforms.push(`translateY(${-Math.abs(bounceOffset)}px)`);
-        } else {
-          transforms.push(`translateY(${Math.abs(bounceOffset)}px)`);
-        }
-
-        if (scale) {
-          const scaleValue =
-            0.8 + progress * 0.2 + bounceWave * 0.05 * dampening;
-          transforms.push(`scale(${scaleValue})`);
-        }
-
-        element.style.transform = transforms.join(" ");
-
-        if (fade) {
-          element.style.opacity = progress.toString();
-        }
-      },
+      css: getCss,
     }),
     ...(key && { key }),
   };

--- a/packages/core/src/lib/transitions/fade.ts
+++ b/packages/core/src/lib/transitions/fade.ts
@@ -1,4 +1,4 @@
-import type { TransitionKey } from "../types";
+import type { StyleObject, TransitionKey } from "../types";
 
 interface FadeOptions {
   from?: number;
@@ -19,19 +19,17 @@ export const fade = (options: FadeOptions = {}) => {
   } = options;
 
   return {
-    in: (element: HTMLElement) => ({
+    in: () => ({
       spring,
-      tick: (progress: number) => {
-        const opacity = from + (to - from) * progress;
-        element.style.opacity = opacity.toString();
-      },
+      css: (progress: number): StyleObject => ({
+        opacity: from + (to - from) * progress,
+      }),
     }),
-    out: (element: HTMLElement) => ({
+    out: () => ({
       spring,
-      tick: (progress: number) => {
-        const opacity = from + (to - from) * progress;
-        element.style.opacity = opacity.toString();
-      },
+      css: (progress: number): StyleObject => ({
+        opacity: from + (to - from) * progress,
+      }),
     }),
     ...(key && { key }),
   };

--- a/packages/core/src/lib/transitions/fly.ts
+++ b/packages/core/src/lib/transitions/fly.ts
@@ -1,4 +1,4 @@
-import type { TransitionKey } from "../types";
+import type { StyleObject, TransitionKey } from "../types";
 
 interface FlyOptions {
   x?: number | string;
@@ -20,46 +20,38 @@ export const fly = (options: FlyOptions = {}) => {
     key,
   } = options;
 
-  const getX = (value: number | string): string => {
-    return typeof value === "number" ? `${value}px` : value;
-  };
+  const getCss = (progress: number): StyleObject => {
+    const multiplier = 1 - progress;
 
-  const getY = (value: number | string): string => {
-    return typeof value === "number" ? `${value}px` : value;
+    let xOffset: string;
+    let yOffset: string;
+
+    if (typeof x === "number") {
+      xOffset = `${multiplier * x}px`;
+    } else {
+      xOffset = `calc(${x} * ${multiplier})`;
+    }
+
+    if (typeof y === "number") {
+      yOffset = `${multiplier * y}px`;
+    } else {
+      yOffset = `calc(${y} * ${multiplier})`;
+    }
+
+    return {
+      transform: `translate3d(${xOffset}, ${yOffset}, 0)`,
+      opacity: opacity + (1 - opacity) * progress,
+    };
   };
 
   return {
-    in: (element: HTMLElement) => ({
+    in: () => ({
       spring,
-      tick: (progress: number) => {
-        const xOffset =
-          typeof x === "number"
-            ? (1 - progress) * x
-            : `calc(${getX(x)} * ${1 - progress})`;
-        const yOffset =
-          typeof y === "number"
-            ? (1 - progress) * y
-            : `calc(${getY(y)} * ${1 - progress})`;
-
-        element.style.transform = `translate(${typeof x === "number" ? xOffset + "px" : xOffset}, ${typeof y === "number" ? yOffset + "px" : yOffset})`;
-        element.style.opacity = (opacity + (1 - opacity) * progress).toString();
-      },
+      css: getCss,
     }),
-    out: (element: HTMLElement) => ({
+    out: () => ({
       spring,
-      tick: (progress: number) => {
-        const xOffset =
-          typeof x === "number"
-            ? (1 - progress) * x
-            : `calc(${getX(x)} * ${1 - progress})`;
-        const yOffset =
-          typeof y === "number"
-            ? (1 - progress) * y
-            : `calc(${getY(y)} * ${1 - progress})`;
-
-        element.style.transform = `translate(${typeof x === "number" ? xOffset + "px" : xOffset}, ${typeof y === "number" ? yOffset + "px" : yOffset})`;
-        element.style.opacity = (opacity + (1 - opacity) * progress).toString();
-      },
+      css: getCss,
     }),
     ...(key && { key }),
   };

--- a/packages/core/src/lib/transitions/mask.ts
+++ b/packages/core/src/lib/transitions/mask.ts
@@ -1,4 +1,4 @@
-import type { TransitionKey } from "../types";
+import type { StyleObject, TransitionKey } from "../types";
 
 interface MaskOptions {
   shape?: "circle" | "ellipse" | "square";
@@ -80,26 +80,26 @@ export const mask = (options: MaskOptions = {}) => {
     }
   };
 
+  const getCss = (progress: number): StyleObject => {
+    const style: StyleObject = {
+      clipPath: getClipPath(progress),
+    };
+
+    if (fade) {
+      style.opacity = progress;
+    }
+
+    return style;
+  };
+
   return {
-    in: (element: HTMLElement) => ({
+    in: () => ({
       spring,
-      tick: (progress: number) => {
-        element.style.clipPath = getClipPath(progress);
-
-        if (fade) {
-          element.style.opacity = progress.toString();
-        }
-      },
+      css: getCss,
     }),
-    out: (element: HTMLElement) => ({
+    out: () => ({
       spring,
-      tick: (progress: number) => {
-        element.style.clipPath = getClipPath(progress);
-
-        if (fade) {
-          element.style.opacity = progress.toString();
-        }
-      },
+      css: getCss,
     }),
     ...(key && { key }),
   };

--- a/packages/core/src/lib/transitions/none.ts
+++ b/packages/core/src/lib/transitions/none.ts
@@ -1,4 +1,4 @@
-import type { TransitionKey } from "../types";
+import type { StyleObject, TransitionKey } from "../types";
 
 interface NoneOptions {
   spring?: {
@@ -14,15 +14,11 @@ export const none = (options: NoneOptions = {}) => {
   return {
     in: () => ({
       spring,
-      tick: () => {
-        // No animation, just instantly show
-      },
+      css: (): StyleObject => ({}),
     }),
     out: () => ({
       spring,
-      tick: () => {
-        // No animation, just instantly hide
-      },
+      css: (): StyleObject => ({}),
     }),
     ...(key && { key }),
   };

--- a/packages/core/src/lib/transitions/rotate.ts
+++ b/packages/core/src/lib/transitions/rotate.ts
@@ -1,4 +1,4 @@
-import type { TransitionKey } from "../types";
+import type { StyleObject, TransitionKey } from "../types";
 
 interface RotateOptions {
   degrees?: number;
@@ -45,40 +45,32 @@ export const rotate = (options: RotateOptions = {}) => {
     }
   };
 
+  const getCss = (progress: number): StyleObject => {
+    const style: StyleObject = {};
+    const transforms = [getRotateTransform(progress)];
+
+    if (scale) {
+      transforms.push(`scale(${progress})`);
+    }
+
+    style.transform = transforms.join(" ");
+    style.transformOrigin = origin;
+
+    if (fade) {
+      style.opacity = progress;
+    }
+
+    return style;
+  };
+
   return {
-    in: (element: HTMLElement) => ({
+    in: () => ({
       spring,
-      tick: (progress: number) => {
-        const transforms = [getRotateTransform(progress)];
-
-        if (scale) {
-          transforms.push(`scale(${progress})`);
-        }
-
-        element.style.transform = transforms.join(" ");
-        element.style.transformOrigin = origin;
-
-        if (fade) {
-          element.style.opacity = progress.toString();
-        }
-      },
+      css: getCss,
     }),
-    out: (element: HTMLElement) => ({
+    out: () => ({
       spring,
-      tick: (progress: number) => {
-        const transforms = [getRotateTransform(progress)];
-
-        if (scale) {
-          transforms.push(`scale(${progress})`);
-        }
-
-        element.style.transform = transforms.join(" ");
-        element.style.transformOrigin = origin;
-
-        if (fade) {
-          element.style.opacity = progress.toString();
-        }
-      },
+      css: getCss,
     }),
     ...(key && { key }),
   };

--- a/packages/core/src/lib/transitions/scale.ts
+++ b/packages/core/src/lib/transitions/scale.ts
@@ -1,4 +1,4 @@
-import type { TransitionKey } from "../types";
+import type { StyleObject, TransitionKey } from "../types";
 
 interface ScaleOptions {
   start?: number;
@@ -32,22 +32,22 @@ export const scale = (options: ScaleOptions = {}) => {
     }
   };
 
+  const getCss = (progress: number): StyleObject => {
+    const scaleValue = start + (1 - start) * progress;
+    return {
+      transform: getScaleTransform(scaleValue),
+      opacity: opacity + (1 - opacity) * progress,
+    };
+  };
+
   return {
-    in: (element: HTMLElement) => ({
+    in: () => ({
       spring,
-      tick: (progress: number) => {
-        const scaleValue = start + (1 - start) * progress;
-        element.style.transform = getScaleTransform(scaleValue);
-        element.style.opacity = (opacity + (1 - opacity) * progress).toString();
-      },
+      css: getCss,
     }),
-    out: (element: HTMLElement) => ({
+    out: () => ({
       spring,
-      tick: (progress: number) => {
-        const scaleValue = start + (1 - start) * progress;
-        element.style.transform = getScaleTransform(scaleValue);
-        element.style.opacity = (opacity + (1 - opacity) * progress).toString();
-      },
+      css: getCss,
     }),
     ...(key && { key }),
   };


### PR DESCRIPTION
## Summary
- Convert all element transitions from tick (RAF-based) to css (Web Animation API)
- Follows the same pattern used in drill.ts for view-transitions
- Improves performance by leveraging browser-native animation capabilities

## Changed Transitions
| Transition | Change |
|------------|--------|
| fade | tick -> css |
| slide | tick -> css (with translate3d) |
| scale | tick -> css |
| blur | tick -> css |
| bounce | tick -> css |
| fly | tick -> css (with translate3d) |
| rotate | tick -> css |
| mask | tick -> css |
| none | tick -> css |

## Benefits
- Smoother animations through Web Animation API
- GPU acceleration via translate3d for slide/fly transitions
- Reduced JavaScript execution on the main thread
- Consistent animation approach across element and view transitions

## Test plan
- [ ] Verify all transitions work in React demo app
- [ ] Verify all transitions work in Svelte demo app
- [ ] Test transitions with different spring configurations
- [ ] Verify no regressions in existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)