### PR TITLE
[WIP] refactor: unify single/multi-spring paths through AnimationScheduler

### DIFF
--- a/packages/core/src/lib/transition/normalize-config.ts
+++ b/packages/core/src/lib/transition/normalize-config.ts
@@ -1,0 +1,51 @@
+import type {
+  TransitionConfig,
+  MultiSpringConfig,
+  SingleSpringConfig,
+} from "../types";
+import { isMultiSpring } from "../types";
+
+/**
+ * Normalizes any TransitionConfig to MultiSpringConfig
+ *
+ * This allows unified handling through AnimationScheduler,
+ * reducing code duplication between single and multi-spring paths.
+ *
+ * Supports both sync and async configs (Promise).
+ *
+ * @param config - Single or multi spring config (or Promise of it)
+ * @param element - Target element for css animations
+ * @returns Promise<MultiSpringConfig>
+ */
+export async function normalizeToMultiSpring(
+  config: TransitionConfig | Promise<TransitionConfig>,
+  element: HTMLElement,
+): Promise<MultiSpringConfig> {
+  const resolved = await config;
+
+  // Already multi-spring, return as-is
+  if (isMultiSpring(resolved)) {
+    return resolved;
+  }
+
+  const singleConfig = resolved as SingleSpringConfig;
+
+  return {
+    prepare: singleConfig.prepare,
+    wait: singleConfig.wait,
+    onStart: singleConfig.onStart,
+    onEnd: singleConfig.onEnd,
+    springs: [
+      {
+        from: singleConfig.from,
+        to: singleConfig.to,
+        spring: singleConfig.spring,
+        tick: singleConfig.tick,
+        css: singleConfig.css
+          ? { element, style: singleConfig.css }
+          : undefined,
+      },
+    ],
+    schedule: "wait",
+  };
+}

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -76,6 +76,10 @@ export type SingleSpringConfig = BaseTransitionConfig & {
 
 /**
  * Individual spring item in a multi-spring animation
+ *
+ * Supports two animation modes (mutually exclusive):
+ * - tick: RAF-based animation with callback on each frame
+ * - css: Web Animation API with CSS style generation (GPU accelerated)
  */
 export type SpringItem = {
   from?: number; // Default: 0 for in, 1 for out
@@ -113,7 +117,21 @@ export type SpringItem = {
    *   element.style.height = height * progress  // WRITE only
    * }
    */
-  tick: (progress: number) => void;
+  tick?: (progress: number) => void;
+
+  /**
+   * Style generator for Web Animation API mode
+   *
+   * When provided, the animation uses Web Animation API instead of RAF.
+   * Spring physics are pre-computed and converted to keyframes.
+   *
+   * @param progress - Current progress value (0 to 1)
+   * @returns Style object for Web Animation API
+   */
+  css?: {
+    element: HTMLElement;
+    style: (progress: number) => StyleObject;
+  };
 
   onStart?: () => void;
   onComplete?: () => void;
@@ -333,6 +351,9 @@ export type MultiAnimationState = {
   completed: number;
   total: number;
   direction: "forward" | "backward";
+  // Position/velocity from first spring (for reversal support in normalized single-spring)
+  position: number;
+  velocity: number;
 };
 
 /**


### PR DESCRIPTION
## Summary

- Normalize all `SingleSpringConfig` to `MultiSpringConfig` via `normalizeToMultiSpring()`
- All transitions now go through `AnimationScheduler`, removing code duplication
- Add `css` field to `SpringItem` for Web Animation API support
- Add `fromState()` to `AnimationScheduler` for mid-animation state resumption
- Add `position`/`velocity` to `MultiAnimationState` for reversal support

## Changes

- **`normalize-config.ts`** (new): Converts single-spring to multi-spring config
- **`create-transition-callback.ts`**: Simplified from 252 to ~180 lines by removing single/multi branching
- **`transition-strategy.ts`**: Removed type checks, all configs are now `MultiSpringConfig`
- **`animation-scheduler.ts`**: Added `fromState()` and enhanced `getCurrentState()`
- **`types.ts`**: Updated `SpringItem` and `MultiAnimationState`

## Related

- #216 (future work: unify AnimationScheduler and Animator through inheritance)

## Test plan

- [x] Build passes for all packages
- [ ] Manual test in react-demo
- [ ] Manual test in svelte-demo

🤖 Generated with [Claude Code](https://claude.ai/code)