### PR TITLE
[WIP] refactor: progress-based scheduling for AnimationScheduler

### DIFF
--- a/packages/core/src/lib/test-utils.ts
+++ b/packages/core/src/lib/test-utils.ts
@@ -34,7 +34,6 @@ export function createMockSpringItem(
     tick: vi.fn(),
     onStart: vi.fn(),
     onComplete: vi.fn(),
-    offset: 0,
     ...overrides,
   };
 }

--- a/packages/core/src/lib/transition/normalize-config.ts
+++ b/packages/core/src/lib/transition/normalize-config.ts
@@ -46,6 +46,6 @@ export async function normalizeToMultiSpring(
           : undefined,
       },
     ],
-    schedule: "wait",
+    schedule: "parallel",
   };
 }


### PR DESCRIPTION
## Summary

Replace time-based scheduling (`offset` in ms, `chain` mode) with progress-based scheduling (`startProgress` 0-1).

## Breaking Changes

- **Removed**: `chain` from `ScheduleType` 
- **Removed**: `offset` field from `SpringItem`
- **Added**: `startProgress` field to `SpringItem`
- **Changed**: `blind` transition now uses `staggerProgress` instead of `staggerDelay`

## How It Works

Each spring starts when the **previous spring's normalized progress** reaches the `startProgress` threshold:

```typescript
springs: [
  { tick: (p) => ..., startProgress: 0 },   // starts immediately
  { tick: (p) => ..., startProgress: 0.3 }, // starts when prev is 30% done
  { tick: (p) => ..., startProgress: 0.5 }, // starts when prev is 50% done
]
```

## Schedule Types (Syntactic Sugar)

- `overlap`: All springs get `startProgress: 0` (parallel)
- `wait`: All springs get `startProgress: 1` (sequential, first gets 0)

## Benefits

- **No more setTimeout**: Progress-based triggering is frame-accurate
- **Simpler mental model**: Everything is 0-1 progress, no mixed time/progress concepts
- **Unified scheduling**: Single `startProgress` field replaces `offset` + `schedule` modes

## Test Plan

- [x] Build passes
- [ ] Manual test blind transition in demo
- [ ] Manual test other multi-spring transitions

🤖 Generated with [Claude Code](https://claude.ai/code)