### PR TITLE
refactor: unify multi-spring scheduling to progress-based offsets

### DIFF
--- a/packages/core/src/lib/transition/create-transition-callback.ts
+++ b/packages/core/src/lib/transition/create-transition-callback.ts
@@ -1,5 +1,5 @@
 import type { Transition, TransitionCallback } from "../types";
-import { normalizeToMultiSpring } from "../types";
+import { normalizeToMultiSpring, normalizeMultiSpringSchedule } from "../types";
 import { MultiAnimator } from "../animator/multi-animator";
 import { Animation } from "../animator/animation";
 import {
@@ -71,14 +71,16 @@ export function createTransitionCallback(
       await config.wait();
     }
 
-    const animator = MultiAnimator.fromState(setup.state, {
-      config: {
-        ...config,
-        onEnd: () => {
-          currentAnimation = null;
-          config.onEnd?.();
-        },
+    const normalizedConfig = normalizeMultiSpringSchedule({
+      ...config,
+      onEnd: () => {
+        currentAnimation = null;
+        config.onEnd?.();
       },
+    });
+
+    const animator = MultiAnimator.fromState(setup.state, {
+      config: normalizedConfig,
       from: setup.from,
       to: setup.to,
       element,
@@ -133,19 +135,21 @@ export function createTransitionCallback(
       await config.wait();
     }
 
-    const animator = MultiAnimator.fromState(setup.state, {
-      config: {
-        ...config,
-        onEnd: () => {
-          config.onEnd?.();
-          if (currentClone) {
-            currentClone.remove();
-            currentClone = null;
-          }
-          currentAnimation = null;
-          options?.onCleanupEnd?.();
-        },
+    const normalizedConfig = normalizeMultiSpringSchedule({
+      ...config,
+      onEnd: () => {
+        config.onEnd?.();
+        if (currentClone) {
+          currentClone.remove();
+          currentClone = null;
+        }
+        currentAnimation = null;
+        options?.onCleanupEnd?.();
       },
+    });
+
+    const animator = MultiAnimator.fromState(setup.state, {
+      config: normalizedConfig,
       from: setup.from,
       to: setup.to,
       element,

--- a/packages/core/src/lib/view-transitions/blind.ts
+++ b/packages/core/src/lib/view-transitions/blind.ts
@@ -19,7 +19,6 @@ interface BlindOptions {
   transitionDelay?: number;
   blindCount?: number;
   direction?: "horizontal" | "vertical";
-  staggerDelay?: number;
   blindColor?: string;
 }
 
@@ -30,7 +29,6 @@ export const blind = (options: BlindOptions = {}): SggoiTransition => {
     transitionDelay = DEFAULT_TRANSITION_DELAY,
     blindCount = DEFAULT_BLIND_COUNT,
     direction = DEFAULT_DIRECTION,
-    staggerDelay = 100,
     blindColor = DEFAULT_BLIND_COLOR,
   } = options;
 
@@ -121,7 +119,7 @@ export const blind = (options: BlindOptions = {}): SggoiTransition => {
       const springs = Array.from({ length: blindCount }, (_, index) => {
         return {
           spring: outSpring,
-          offset: index * staggerDelay,
+          offset: 0.2,
           tick: (progress: number) => {
             if (!blindsData) return;
             const blind = blindsData.blinds[index];
@@ -140,7 +138,7 @@ export const blind = (options: BlindOptions = {}): SggoiTransition => {
 
       return {
         springs,
-        schedule: "chain",
+        schedule: "stagger",
         prepare: (element) => {
           prepareOutgoing(element);
           element.style.zIndex = "1000";
@@ -166,7 +164,7 @@ export const blind = (options: BlindOptions = {}): SggoiTransition => {
       const springs = Array.from({ length: blindCount }, (_, index) => {
         return {
           spring: inSpring,
-          offset: index * staggerDelay,
+          offset: 0.2,
           tick: (progress: number) => {
             if (!blindsData) return;
             const blind = blindsData.blinds[index];
@@ -185,7 +183,7 @@ export const blind = (options: BlindOptions = {}): SggoiTransition => {
 
       return {
         springs,
-        schedule: "chain",
+        schedule: "stagger",
         prepare: (element) => {
           element.style.position = "relative";
           element.style.zIndex = "0";


### PR DESCRIPTION
## Summary
- Rename schedule types: `overlap`→`parallel`, `wait`→`sequential`, `chain`→`stagger`
- Change `SpringItem.offset` from milliseconds to progress ratio (0-1)
- Add `normalizeMultiSpringSchedule()` to normalize user config before passing to MultiAnimator
- Simplify MultiAnimator by removing schedule branching, use RAF-based progress checking
- Update blind transition to use `stagger` with 0.2 offset

## Test plan
- [ ] Verify blind transition animation timing with new progress-based offset
- [ ] Test parallel, sequential, stagger modes work correctly
- [ ] Verify backward animations respect reversed spring order

🤖 Generated with [Claude Code](https://claude.com/claude-code)