### PR TITLE
fix(core): defer transition config resolution to prevent blocking

### DIFF
--- a/packages/core/src/lib/transition/create-transition-callback.ts
+++ b/packages/core/src/lib/transition/create-transition-callback.ts
@@ -42,10 +42,10 @@ export function createTransitionCallback(
     }
     const transition = getTransition();
 
-    const inConfig = transition.in && (await transition.in(element));
+    const inConfig = transition.in && transition.in(element);
     const outConfig =
       !options?.strategy && transition.out
-        ? await transition.out(element)
+        ? transition.out(element)
         : undefined;
 
     if (!inConfig) {
@@ -53,6 +53,7 @@ export function createTransitionCallback(
     }
 
     // Normalize to multi-spring config before passing to strategy
+    // normalizeToMultiSpring accepts Promise and resolves it internally
     const configs: InternalTransitionConfigs = {
       in: normalizeToMultiSpring(inConfig),
       out: outConfig ? normalizeToMultiSpring(outConfig) : undefined,
@@ -102,16 +103,15 @@ export function createTransitionCallback(
 
     const transition = getTransition();
     const inConfig =
-      !options?.strategy && transition.in
-        ? await transition.in(element)
-        : undefined;
-    const outConfig = transition.out && (await transition.out(element));
+      !options?.strategy && transition.in ? transition.in(element) : undefined;
+    const outConfig = transition.out && transition.out(element);
 
     if (!outConfig) {
       return;
     }
 
     // Normalize to multi-spring config before passing to strategy
+    // normalizeToMultiSpring accepts Promise and resolves it internally
     const configs: InternalTransitionConfigs = {
       in: inConfig ? normalizeToMultiSpring(inConfig) : undefined,
       out: normalizeToMultiSpring(outConfig),

--- a/packages/core/src/lib/transition/transition-strategy.ts
+++ b/packages/core/src/lib/transition/transition-strategy.ts
@@ -29,12 +29,12 @@ export interface InternalAnimationSetup {
 
 /**
  * Internal transition configs passed to strategy
- * Always uses MultiSpringConfig (normalized before passing)
+ * Uses Promise<MultiSpringConfig> to allow lazy evaluation
  * @internal
  */
 export interface InternalTransitionConfigs {
-  in?: MultiSpringConfig;
-  out?: MultiSpringConfig;
+  in?: Promise<MultiSpringConfig>;
+  out?: Promise<MultiSpringConfig>;
 }
 
 export interface TransitionStrategy {
@@ -94,9 +94,10 @@ export const createDefaultStrategy = (
 
         // Use OUT config but reverse direction
         if (configs.out) {
+          const outConfig = await configs.out;
           // OUT animation: from=1, to=0, backward goes toward from (1)
           return {
-            config: configs.out,
+            config: outConfig,
             state: { position, velocity },
             from: 1,
             to: 0,
@@ -106,8 +107,7 @@ export const createDefaultStrategy = (
       }
 
       // Scenario 1: No animation running OR IN already running
-      const config = configs.in;
-      if (!config) {
+      if (!configs.in) {
         // No config, return minimal setup
         return {
           state: {
@@ -119,6 +119,8 @@ export const createDefaultStrategy = (
           direction: "forward",
         };
       }
+
+      const config = await configs.in;
 
       // IN animation: from=0, to=1
       return {
@@ -145,9 +147,10 @@ export const createDefaultStrategy = (
 
         // Use IN config but reverse direction
         if (configs.in) {
+          const inConfig = await configs.in;
           // IN animation: from=0, to=1, backward goes toward from (0)
           return {
-            config: configs.in,
+            config: inConfig,
             state: { position, velocity },
             from: 0,
             to: 1,
@@ -157,8 +160,7 @@ export const createDefaultStrategy = (
       }
 
       // Scenario 2: No animation running OR OUT already running
-      const config = configs.out;
-      if (!config) {
+      if (!configs.out) {
         // No config, return minimal setup
         return {
           state: {
@@ -170,6 +172,8 @@ export const createDefaultStrategy = (
           direction: "forward",
         };
       }
+
+      const config = await configs.out;
 
       // OUT animation: from=1, to=0
       return {
@@ -194,8 +198,7 @@ export const createPageTransitionStrategy = (): TransitionStrategy => {
   return {
     runIn: async (configs: InternalTransitionConfigs) => {
       // Always start fresh for IN transition
-      const config = configs.in;
-      if (!config) {
+      if (!configs.in) {
         return {
           state: {
             position: 0,
@@ -206,6 +209,8 @@ export const createPageTransitionStrategy = (): TransitionStrategy => {
           direction: "forward",
         };
       }
+
+      const config = await configs.in;
 
       // IN animation: from=0, to=1
       return {
@@ -222,8 +227,7 @@ export const createPageTransitionStrategy = (): TransitionStrategy => {
 
     runOut: async (configs: InternalTransitionConfigs) => {
       // Always start fresh for OUT transition
-      const config = configs.out;
-      if (!config) {
+      if (!configs.out) {
         return {
           state: {
             position: 1,
@@ -234,6 +238,8 @@ export const createPageTransitionStrategy = (): TransitionStrategy => {
           direction: "forward",
         };
       }
+
+      const config = await configs.out;
 
       // OUT animation: from=1, to=0
       return {

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -210,31 +210,34 @@ export function validateSpringItem(item: SpringItem): void {
 /**
  * Normalize TransitionConfig to MultiSpringConfig
  * Converts SingleSpringConfig to MultiSpringConfig with single spring item
+ * Accepts both sync config and Promise<TransitionConfig>
  * @internal
  */
-export function normalizeToMultiSpring(
-  config: TransitionConfig,
-): MultiSpringConfig {
-  if (isMultiSpring(config)) {
+export async function normalizeToMultiSpring(
+  config: TransitionConfig | Promise<TransitionConfig>,
+): Promise<MultiSpringConfig> {
+  const resolvedConfig = await config;
+
+  if (isMultiSpring(resolvedConfig)) {
     // Validate all spring items
-    config.springs.forEach(validateSpringItem);
-    return config;
+    resolvedConfig.springs.forEach(validateSpringItem);
+    return resolvedConfig;
   }
 
   // Validate single spring config
-  validateAnimationMode(config);
+  validateAnimationMode(resolvedConfig);
 
   // Convert SingleSpringConfig to MultiSpringConfig
   return {
-    prepare: config.prepare,
-    wait: config.wait,
-    onStart: config.onStart,
-    onEnd: config.onEnd,
+    prepare: resolvedConfig.prepare,
+    wait: resolvedConfig.wait,
+    onStart: resolvedConfig.onStart,
+    onEnd: resolvedConfig.onEnd,
     springs: [
       {
-        spring: config.spring,
-        tick: config.tick,
-        css: config.css,
+        spring: resolvedConfig.spring,
+        tick: resolvedConfig.tick,
+        css: resolvedConfig.css,
       },
     ],
     schedule: "parallel",


### PR DESCRIPTION
## Summary
- Fixed page navigation issues in Svelte where awaiting transition configs was blocking the navigation flow
- Changed `normalizeToMultiSpring` to accept `Promise<TransitionConfig>` and return `Promise<MultiSpringConfig>` for lazy evaluation
- Transition configs are now only resolved when actually needed by the strategy

## Changes
- `normalizeToMultiSpring` now accepts and resolves Promise internally
- Removed `await` from `transition.in/out` calls in `runEntrance`/`runExitTransition`
- `InternalTransitionConfigs` now uses `Promise<MultiSpringConfig>`
- Strategies await configs only when they need to use them

## Test plan
- [x] Verify page navigation works correctly in Svelte demo
- [x] Verify transitions still work as expected in React demo
- [x] Build passes without type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)