### PR TITLE
fix(core): invoke tick immediately on scheduler start

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/core",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Core animation engine for SSGOI - Native app-like page transitions with spring physics",
   "private": false,
   "type": "module",

--- a/packages/core/src/lib/animator/multi-animator.ts
+++ b/packages/core/src/lib/animator/multi-animator.ts
@@ -192,7 +192,7 @@ export class MultiAnimator extends Animation {
         this.rafId = requestAnimationFrame(tick);
       }
     };
-    this.rafId = requestAnimationFrame(tick);
+    tick();
   }
 
   private stopScheduler(): void {


### PR DESCRIPTION
## Summary
- Remove unnecessary frame delay when starting MultiAnimator scheduler
- Call `tick()` synchronously instead of `requestAnimationFrame(tick)` on scheduler start
- First spring animation now starts immediately without waiting for the next frame

## Test plan
- [ ] Verify MultiAnimator starts first animation immediately
- [ ] Check no regression in staggered spring animations

🤖 Generated with [Claude Code](https://claude.com/claude-code)