### PR TITLE
fix(core): prevent transition cleanup from removing newer transitions

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/core",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Core animation engine for SSGOI - Native app-like page transitions with spring physics",
   "private": false,
   "type": "module",


### PR DESCRIPTION
## Summary
- Fixed a race condition where rapid page navigation could cause "Transition not found" warnings
- When navigating quickly between pages (e.g., A→B→C), an older transition's cleanup callback could unregister a newer transition registered with the same key
- The fix stores a reference to the transition at registration time and only performs cleanup if the current transition matches the registered one

## Problem
When users navigated rapidly between pages during an animation, they would see:
```
Transition "/demo/posts" not found
```
And the page would transition without animation. The next navigation would work normally.

## Root Cause
In `registerTransition()`, when a callback is reused for the same key, the old callback's `onCleanupEnd` would still call `unregisterTransition(key)`, removing the newer transition that was just registered.

## Solution
Store a reference to the transition when registering, and only unregister if the current transition matches the one that was originally registered with this callback.

## Test plan
- [x] Rapid navigation between pages (A→B→C quickly)
- [x] Browser back/forward button spam
- [x] Verify "Transition not found" warning no longer appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)