### PR TITLE
refactor(core): refactor hero transition to use MultiSpringConfig

### DIFF
--- a/packages/core/src/lib/animator/multi-animator.ts
+++ b/packages/core/src/lib/animator/multi-animator.ts
@@ -2,14 +2,9 @@ import { Animator } from ".";
 import { Animation } from "./animation";
 import type {
   NormalizedMultiSpringConfig,
-  SpringItem,
+  NormalizedSpringItem,
   AnimationState,
 } from "../types";
-
-/**
- * Normalized spring item with offset
- */
-type NormalizedSpringItem = SpringItem & { normalizedOffset: number };
 
 /**
  * Entry to track individual spring animation state
@@ -25,7 +20,6 @@ export interface MultiAnimatorOptions {
   config: NormalizedMultiSpringConfig;
   from: number;
   to: number;
-  element?: HTMLElement;
 }
 
 /**
@@ -50,7 +44,6 @@ export class MultiAnimator extends Animation {
   private direction: "forward" | "backward" = "forward";
   private idCounter = 0;
   private rafId: number | null = null;
-  private element?: HTMLElement;
   private from: number;
   private to: number;
 
@@ -59,7 +52,6 @@ export class MultiAnimator extends Animation {
     this.config = options.config;
     this.from = options.from;
     this.to = options.to;
-    this.element = options.element;
     this.initializeAnimators();
   }
 
@@ -75,10 +67,7 @@ export class MultiAnimator extends Animation {
         to: this.to,
         spring: item.spring,
         tick: item.tick,
-        css:
-          item.css && this.element
-            ? { element: this.element, style: item.css }
-            : undefined,
+        css: item.css,
         onComplete: () => this.onAnimatorComplete(id),
         onStart: item.onStart,
       });
@@ -259,11 +248,6 @@ export class MultiAnimator extends Animation {
 
       if (isCompleted) {
         // Reverse completed animation: swap from/to
-        const cssOption =
-          entry.item.css && this.element
-            ? { element: this.element, style: entry.item.css }
-            : undefined;
-
         const newAnimator = Animator.fromState(
           { position: this.to, velocity: 0 },
           {
@@ -271,7 +255,7 @@ export class MultiAnimator extends Animation {
             to: this.from,
             spring: entry.item.spring,
             tick: entry.item.tick,
-            css: cssOption,
+            css: entry.item.css,
             onComplete: () => this.onAnimatorComplete(entry.id),
             onStart: entry.item.onStart,
           },

--- a/packages/core/src/lib/transition/create-transition-callback.ts
+++ b/packages/core/src/lib/transition/create-transition-callback.ts
@@ -74,19 +74,21 @@ export function createTransitionCallback(
       await config.wait();
     }
 
-    const normalizedConfig = normalizeMultiSpringSchedule({
-      ...config,
-      onEnd: () => {
-        currentAnimation = null;
-        config.onEnd?.();
+    const normalizedConfig = normalizeMultiSpringSchedule(
+      {
+        ...config,
+        onEnd: () => {
+          currentAnimation = null;
+          config.onEnd?.();
+        },
       },
-    });
+      element,
+    );
 
     const animator = MultiAnimator.fromState(setup.state, {
       config: normalizedConfig,
       from: setup.from,
       to: setup.to,
-      element,
     });
 
     currentAnimation = { controller: animator, direction: "in" };
@@ -137,24 +139,26 @@ export function createTransitionCallback(
       await config.wait();
     }
 
-    const normalizedConfig = normalizeMultiSpringSchedule({
-      ...config,
-      onEnd: () => {
-        config.onEnd?.();
-        if (currentClone) {
-          currentClone.remove();
-          currentClone = null;
-        }
-        currentAnimation = null;
-        options?.onCleanupEnd?.();
+    const normalizedConfig = normalizeMultiSpringSchedule(
+      {
+        ...config,
+        onEnd: () => {
+          config.onEnd?.();
+          if (currentClone) {
+            currentClone.remove();
+            currentClone = null;
+          }
+          currentAnimation = null;
+          options?.onCleanupEnd?.();
+        },
       },
-    });
+      element,
+    );
 
     const animator = MultiAnimator.fromState(setup.state, {
       config: normalizedConfig,
       from: setup.from,
       to: setup.to,
-      element,
     });
 
     currentAnimation = { controller: animator, direction: "out" };

--- a/packages/core/src/lib/view-transitions/hero.ts
+++ b/packages/core/src/lib/view-transitions/hero.ts
@@ -128,19 +128,19 @@ export const hero = (options: HeroOptions = {}): SggoiTransition => {
       }
 
       return {
-        spring,
+        springs: heroAnimations.map(({ toEl, dx, dy, dw, dh }) => ({
+          spring,
+          tick: (progress: number) => {
+            toEl.style.transform = `translate(${(1 - progress) * dx}px, ${(1 - progress) * dy}px) scale(${progress + (1 - progress) * dw}, ${progress + (1 - progress) * dh})`;
+          },
+        })),
+        schedule: "parallel" as const,
         prepare: () => {
           heroAnimations.forEach(({ toEl }) => {
             toEl.style.position = "relative";
             toEl.style.transformOrigin = "top left";
             toEl.style.zIndex = "1000";
             toEl.style.willChange = "transform";
-          });
-        },
-        tick: (progress) => {
-          // Animate all hero elements
-          heroAnimations.forEach(({ toEl, dx, dy, dw, dh }) => {
-            toEl.style.transform = `translate(${(1 - progress) * dx}px,${(1 - progress) * dy}px) scale(${progress + (1 - progress) * dw}, ${progress + (1 - progress) * dh})`;
           });
         },
         onEnd: () => {
@@ -166,6 +166,7 @@ export const hero = (options: HeroOptions = {}): SggoiTransition => {
     },
     out: async (element) => {
       return {
+        spring,
         onStart: () => {
           // Store fromNode
           fromNode = element;


### PR DESCRIPTION
## Summary
- Extend `SpringItem.css` type to support custom element specification via `{ element, style }` form
- Add `NormalizedSpringItem` type for internal use with normalized css
- Centralize css normalization logic in `normalizeMultiSpringSchedule` function
- Refactor hero transition to use `MultiSpringConfig` with springs array

## Changes

### New CSS API for SpringItem
```typescript
// Form 1: Function (element from parent) - existing behavior
css: (progress) => ({ opacity: progress })

// Form 2: Object with custom element - NEW
css: {
  element: myElement,
  style: (progress) => ({ transform: `scale(${progress})` })
}
```

### Hero transition refactored
- Uses `MultiSpringConfig` with `springs` array for each hero element
- Each hero element gets its own `SpringItem` with independent tick function
- Uses `schedule: "parallel"` for simultaneous animations

## Test plan
- [ ] Verify hero transition works correctly with multiple hero elements
- [ ] Test page transitions with hero elements in both directions

🤖 Generated with [Claude Code](https://claude.com/claude-code)