### PR TITLE
fix(core): pass context to prepareOutgoing in instagram transition

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/core",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "Core animation engine for SSGOI - Native app-like page transitions with spring physics",
   "private": false,
   "type": "module",

--- a/packages/core/src/lib/view-transitions/instagram.ts
+++ b/packages/core/src/lib/view-transitions/instagram.ts
@@ -317,7 +317,7 @@ export const instagram = (options: InstagramOptions = {}): SggoiTransition => {
         },
       };
     },
-    out: async (element) => {
+    out: async (element, context) => {
       // Create handlersReady promise (will be resolved by IN transition)
       const handlersReady = new Promise<void>((resolve) => {
         resolveHandlers = resolve;
@@ -326,9 +326,11 @@ export const instagram = (options: InstagramOptions = {}): SggoiTransition => {
       return {
         spring,
         prepare: (element) => {
-          prepareOutgoing(element);
           if (!handlers?.isEnterMode) {
+            prepareOutgoing(element, context);
             element.style.zIndex = "-1";
+          } else {
+            prepareOutgoing(element);
           }
         },
         wait: async () => {


### PR DESCRIPTION
## Summary
- Pass `context` to `prepareOutgoing` in exit mode for instagram transition
- This properly handles scroll offset positioning via the existing `top` offset mechanism in `prepareOutgoing`

## Test plan
- [x] Verify Gallery → Detail transition (enter mode)
- [x] Verify Detail → Gallery transition (exit mode)
- [x] Test with scrolled gallery page

🤖 Generated with [Claude Code](https://claude.com/claude-code)