### PR TITLE
fix(core): fix fade transition wait not working properly

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/core",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Core animation engine for SSGOI - Native app-like page transitions with spring physics",
   "private": false,
   "type": "module",

--- a/packages/core/src/lib/utils/index.ts
+++ b/packages/core/src/lib/utils/index.ts
@@ -5,3 +5,4 @@ export { parseCallerLocation } from "./parse-caller-location";
 export { sleep } from "./sleep";
 export { getRect } from "./get-rect";
 export { round, floor, ceil, toFixed } from "./number";
+export { withResolvers } from "./with-resolvers";

--- a/packages/core/src/lib/utils/with-resolvers.ts
+++ b/packages/core/src/lib/utils/with-resolvers.ts
@@ -1,0 +1,16 @@
+export function withResolvers<T = void>(): Deferred<T> {
+  let resolve: Deferred<T>["resolve"];
+  let reject: Deferred<T>["reject"];
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve: resolve!, reject: reject! };
+}
+
+export interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+}


### PR DESCRIPTION
## Summary

- Fixed the fade transition's wait mechanism that was broken due to incorrect Promise initialization
- The original code had a nested Promise creation that caused the IN animation to not properly wait for the OUT animation to complete

## Changes

- Use `withResolvers` utility for cleaner Promise handling
- Reset resolvers in `wait()` after OUT completes (for reusability when `fade()` is reused)
- Add initial opacity style in `prepare()` to prevent flash
- Adjust spring config for smoother animation

## Root Cause

The original code had a bug in Promise initialization:

```typescript
// Before (broken)
outAnimationComplete = new Promise((resolve) => {
  resolveOutAnimation = resolve;
  outAnimationComplete = new Promise((resolve) => {  // Nested - overwrites before used
    resolveOutAnimation = resolve;
  });
});
```

This caused `wait()` to not properly await the OUT animation completion.

## Test plan

- [x] Tested fade transition in demo app
- [x] Verified IN animation waits for OUT animation to complete
- [x] Published `@ssgoi/core@3.2.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)