### PR TITLE
fix(react): stable ref callback to prevent re-trigger on re-render

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/core",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Core animation engine for SSGOI - Native app-like page transitions with spring physics",
   "private": false,
   "type": "module",

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -297,6 +297,19 @@ export type TransitionCallback = (
 ) => void | (() => void);
 
 /**
+ * Ref callback type for 'auto' mode
+ * Handles null and manages unmount automatically via MutationObserver
+ */
+export type RefCallback = (element: HTMLElement | null) => void;
+
+/**
+ * Transition mode
+ * - 'manual': Returns TransitionCallback with cleanup function (default)
+ * - 'auto': Returns RefCallback with automatic unmount detection via MutationObserver
+ */
+export type TransitionMode = "manual" | "auto";
+
+/**
  * Context object passed to view transitions
  * Provides essential information for smooth page transitions
  */

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/react",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "React bindings for SSGOI - Native app-like page transitions for React applications",
   "private": false,
   "type": "module",

--- a/packages/react/src/lib/transition.ts
+++ b/packages/react/src/lib/transition.ts
@@ -2,7 +2,6 @@
 
 import {
   transition as _transition,
-  watchUnmount,
   type Transition,
   type TransitionKey,
   type TransitionScope,
@@ -20,6 +19,9 @@ type TransitionOptions = Transition<undefined> & {
  * OUT transition is automatically triggered by MutationObserver
  * when the element is removed from the DOM - works with React 18+
  *
+ * The returned ref callback has a stable reference (cached by key),
+ * so it won't cause unnecessary re-renders when used with React refs.
+ *
  * @example
  * ```tsx
  * <div ref={transition({
@@ -30,17 +32,5 @@ type TransitionOptions = Transition<undefined> & {
  * ```
  */
 export const transition = (options: TransitionOptions) => {
-  const callback = _transition(options);
-
-  // Return ref callback
-  // Use MutationObserver to detect unmount and trigger OUT transition
-  return (element: HTMLElement | null) => {
-    if (element) {
-      const cleanup = callback(element);
-      if (cleanup) {
-        // Register cleanup with MutationObserver for automatic OUT transition
-        watchUnmount(element, cleanup);
-      }
-    }
-  };
+  return _transition(options, "auto");
 };


### PR DESCRIPTION
## Summary
- Fixed React transition re-triggering on every re-render due to unstable function reference
- Added `auto` mode to core's `transition()` function that returns cached `RefCallback` with MutationObserver integration
- Simplified React's `transition.ts` to use the new `auto` mode

## Changes
- **core**: Added `TransitionMode` type (`'manual'` | `'auto'`) and `RefCallback` type
- **core**: `transition(options, 'auto')` now returns stable cached ref callback
- **react**: Simplified to just call `_transition(options, 'auto')`

## Test plan
- [ ] Verify React transition doesn't re-trigger on parent re-render
- [ ] Verify IN/OUT animations still work correctly
- [ ] Verify Svelte transitions are unaffected (uses default 'manual' mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)