### PR TITLE
docs: update React Auto Key Plugin documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,15 +41,13 @@ npm install @ssgoi/vue
 #### 1. Wrap your app
 
 ```tsx
-import { Ssgoi } from '@ssgoi/react';
-import { fade } from '@ssgoi/react/view-transitions';
+import { Ssgoi } from "@ssgoi/react";
+import { fade } from "@ssgoi/react/view-transitions";
 
 export default function App() {
   return (
     <Ssgoi config={{ defaultTransition: fade() }}>
-      <div style={{ position: 'relative' }}>
-        {/* Your app */}
-      </div>
+      <div style={{ position: "relative" }}>{/* Your app */}</div>
     </Ssgoi>
   );
 }
@@ -58,7 +56,7 @@ export default function App() {
 #### 2. Wrap your pages
 
 ```tsx
-import { SsgoiTransition } from '@ssgoi/react';
+import { SsgoiTransition } from "@ssgoi/react";
 
 export default function HomePage() {
   return (
@@ -82,16 +80,20 @@ Define different transitions for different routes:
 const config = {
   transitions: [
     // Scroll between pages
-    { from: '/home', to: '/about', transition: scroll({ direction: 'up' }) },
-    { from: '/about', to: '/home', transition: scroll({ direction: 'down' }) },
-    
+    { from: "/home", to: "/about", transition: scroll({ direction: "up" }) },
+    { from: "/about", to: "/home", transition: scroll({ direction: "down" }) },
+
     // Drill when entering details
-    { from: '/products', to: '/products/*', transition: drill({ direction: 'enter' }) },
-    
+    {
+      from: "/products",
+      to: "/products/*",
+      transition: drill({ direction: "enter" }),
+    },
+
     // Pinterest-style image transitions
-    { from: '/gallery', to: '/photo/*', transition: pinterest() }
+    { from: "/gallery", to: "/photo/*", transition: pinterest() },
   ],
-  defaultTransition: fade()
+  defaultTransition: fade(),
 };
 ```
 
@@ -102,7 +104,7 @@ Automatically create bidirectional transitions:
 ```tsx
 {
   from: '/home',
-  to: '/about', 
+  to: '/about',
   transition: fade(),
   symmetric: true  // Automatically creates reverse transition
 }
@@ -113,44 +115,95 @@ Automatically create bidirectional transitions:
 Animate specific elements during mount/unmount:
 
 ```tsx
-import { transition } from '@ssgoi/react';
-import { fadeIn, slideUp } from '@ssgoi/react/transitions';
+import { transition } from "@ssgoi/react";
+import { fade, slide } from "@ssgoi/react/transitions";
 
+// With Auto Key Plugin - key is auto-generated based on file:line:column
 function Card() {
   return (
-    <div ref={transition({
-      key: 'card',
-      in: fadeIn(),
-      out: slideUp()
-    })}>
+    <div ref={transition(fade())}>
       <h2>Animated Card</h2>
     </div>
   );
 }
+
+// Without plugin - explicit key is required
+function CardManual() {
+  return (
+    <div
+      ref={transition({
+        key: "card",
+        ...fade(),
+      })}
+    >
+      <h2>Animated Card</h2>
+    </div>
+  );
+}
+
+// For list items in .map(), just use JSX key - the plugin appends it automatically
+function List({ items }) {
+  return items.map((item) => (
+    <div
+      key={item.id} // JSX key is enough - plugin generates file:line:col:${key}
+      ref={transition(fade())}
+    >
+      {item.name}
+    </div>
+  ));
+}
 ```
+
+#### Auto Key Plugin Setup (React)
+
+The Auto Key Plugin automatically generates unique keys for transition elements, eliminating the need to manually specify keys:
+
+```tsx
+// next.config.ts
+import SsgoiAutoKey from "@ssgoi/react/unplugin/webpack";
+
+const nextConfig = {
+  webpack: (config) => {
+    config.plugins.push(SsgoiAutoKey());
+    return config;
+  },
+};
+
+export default nextConfig;
+```
+
+For other bundlers (Vite, Rollup, esbuild), see the [documentation](https://ssgoi.dev).
+
+**Benefits:**
+
+- No need to manually specify `key` for most cases
+- Keys are automatically generated based on source location (`file:line:column`)
+- Cleaner, more maintainable code
+
+**Important:** For dynamic lists (`.map()`), the plugin automatically appends the JSX `key` prop to the generated transition key (e.g., `file:line:col:${key}`), so you only need to provide the JSX `key` - no explicit transition key required.
 
 ### TransitionScope
 
 Control animation behavior for grouped elements. Skip redundant animations when parent and children mount/unmount together:
 
 ```tsx
-import { TransitionScope, transition } from '@ssgoi/react';
-import { fade } from '@ssgoi/react/transitions';
+import { TransitionScope, transition } from "@ssgoi/react";
+import { fade } from "@ssgoi/react/transitions";
 
 function Modal({ show }) {
-  return show && (
-    <TransitionScope>
-      <div className="modal">
-        {/* scope: 'local' - skips animation when mounting/unmounting with parent */}
-        <div ref={transition({ ...fade(), scope: 'local' })}>
-          This won't animate when modal opens/closes
+  return (
+    show && (
+      <TransitionScope>
+        <div className="modal">
+          {/* scope: 'local' - skips animation when mounting/unmounting with parent */}
+          <div ref={transition({ ...fade(), scope: "local" })}>
+            This won't animate when modal opens/closes
+          </div>
+          {/* scope: 'global' (default) - always animates */}
+          <div ref={transition({ ...fade() })}>This always animates</div>
         </div>
-        {/* scope: 'global' (default) - always animates */}
-        <div ref={transition({ ...fade() })}>
-          This always animates
-        </div>
-      </div>
-    </TransitionScope>
+      </TransitionScope>
+    )
   );
 }
 ```
@@ -158,6 +211,7 @@ function Modal({ show }) {
 ## Built-in Transitions
 
 ### Page Transitions
+
 - `fade` - Smooth opacity transition
 - `scroll` - Vertical scrolling (up/down)
 - `drill` - Drill in/out effect (enter/exit)
@@ -165,12 +219,14 @@ function Modal({ show }) {
 - `pinterest` - Pinterest-style expand effect
 
 ### Element Transitions
-- `fadeIn` / `fadeOut`
-- `slideUp` / `slideDown` / `slideLeft` / `slideRight`
-- `scaleIn` / `scaleOut`
-- `bounce`
-- `blur`
-- `rotate`
+
+- `fade()` - Fade in/out
+- `scale()` - Scale in/out
+- `slide()` - Slide (direction: up/down/left/right)
+- `rotate()` - Rotate
+- `bounce()` - Bounce
+- `blur()` - Blur
+- `fly()` - Fly (custom x, y position)
 
 ## Framework Examples
 
@@ -178,13 +234,13 @@ function Modal({ show }) {
 
 ```typescript
 // app.component.ts
-import { Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
-import { Ssgoi } from '@ssgoi/angular';
-import { fade } from '@ssgoi/angular/view-transitions';
+import { Component } from "@angular/core";
+import { RouterOutlet } from "@angular/router";
+import { Ssgoi } from "@ssgoi/angular";
+import { fade } from "@ssgoi/angular/view-transitions";
 
 @Component({
-  selector: 'app-root',
+  selector: "app-root",
   imports: [RouterOutlet, Ssgoi],
   template: `
     <ssgoi [config]="config">
@@ -192,27 +248,27 @@ import { fade } from '@ssgoi/angular/view-transitions';
         <router-outlet />
       </div>
     </ssgoi>
-  `
+  `,
 })
 export class AppComponent {
   config = {
-    defaultTransition: fade()
+    defaultTransition: fade(),
   };
 }
 
 // home.component.ts
-import { Component } from '@angular/core';
-import { SsgoiTransition } from '@ssgoi/angular';
+import { Component } from "@angular/core";
+import { SsgoiTransition } from "@ssgoi/angular";
 
 @Component({
-  selector: 'app-home',
+  selector: "app-home",
   imports: [SsgoiTransition],
   template: `
     <ssgoi-transition id="/">
       <h1>Welcome</h1>
       <!-- Your page content -->
     </ssgoi-transition>
-  `
+  `,
 })
 export class HomeComponent {}
 ```
@@ -221,17 +277,19 @@ export class HomeComponent {}
 
 ```tsx
 // app/layout.tsx
-import { Ssgoi } from '@ssgoi/react';
-import { fade } from '@ssgoi/react/view-transitions';
+import { Ssgoi } from "@ssgoi/react";
+import { fade } from "@ssgoi/react/view-transitions";
 
 export default function RootLayout({ children }) {
   return (
     <html>
       <body>
-        <Ssgoi config={{
-          defaultTransition: fade()
-        }}>
-          <div style={{ position: 'relative', minHeight: '100vh' }}>
+        <Ssgoi
+          config={{
+            defaultTransition: fade(),
+          }}
+        >
+          <div style={{ position: "relative", minHeight: "100vh" }}>
             {children}
           </div>
         </Ssgoi>
@@ -241,14 +299,10 @@ export default function RootLayout({ children }) {
 }
 
 // app/page.tsx
-import { SsgoiTransition } from '@ssgoi/react';
+import { SsgoiTransition } from "@ssgoi/react";
 
 export default function Page() {
-  return (
-    <SsgoiTransition id="/">
-      {/* Your page content */}
-    </SsgoiTransition>
-  );
+  return <SsgoiTransition id="/">{/* Your page content */}</SsgoiTransition>;
 }
 ```
 
@@ -281,11 +335,13 @@ export default function Page() {
 ## Why SSGOI?
 
 ### vs View Transition API
+
 - ✅ Works in all browsers, not just Chrome
 - ✅ More animation options with spring physics
 - ✅ Better developer experience
 
 ### vs Other Animation Libraries
+
 - ✅ Built specifically for page transitions
 - ✅ SSR-first design
 - ✅ No router lock-in
@@ -314,17 +370,21 @@ SSGOI achieves 60fps animations through a unique approach:
 Try out SSGOI with our framework-specific demo applications:
 
 ### React Demo
+
 ```bash
 pnpm react-demo:dev
 # Opens at http://localhost:3001
 ```
+
 Explore Next.js App Router integration with various transition effects.
 
 ### Svelte Demo
+
 ```bash
 pnpm svelte-demo:dev
 # Opens at http://localhost:5174
 ```
+
 See SvelteKit integration with smooth page transitions.
 
 Visit the `/apps` directory to explore the demo source code and learn how to implement SSGOI in your own projects.
@@ -332,6 +392,7 @@ Visit the `/apps` directory to explore the demo source code and learn how to imp
 ## Documentation
 
 Visit [https://ssgoi.dev](https://ssgoi.dev) for:
+
 - Detailed API reference
 - Interactive examples
 - Framework integration guides

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -121,7 +121,7 @@ import { fade, slide, scale } from '@ssgoi/react/view-transitions';
 
 ### `/transitions` - DOM 요소 애니메이션
 ```jsx
-import { fadeIn, slideUp } from '@ssgoi/react/transitions';
+import { fade, slide, blur, bounce, rotate, scale } from '@ssgoi/react/transitions';
 ```
 
 ### `/easing` - 이징 함수
@@ -171,14 +171,15 @@ const customTransition = {
 
 ```jsx
 import { transition } from '@ssgoi/react';
+import { fade } from '@ssgoi/react/transitions';
 
 function Component() {
   const [show, setShow] = useState(true);
-  
+
   return (
     <>
       {show && (
-        <div ref={transition({ key: 'item', ...fadeConfig })}>
+        <div ref={transition({ key: 'item', ...fade() })}>
           애니메이션이 적용될 요소
         </div>
       )}

--- a/apps/docs/content/en/02.core-concepts/01.element-transitions.mdx
+++ b/apps/docs/content/en/02.core-concepts/01.element-transitions.mdx
@@ -15,59 +15,75 @@ How to use various transition effects:
     import { transition } from '@ssgoi/react';
     import { fade, scale, blur, slide, fly, rotate, bounce } from '@ssgoi/react/transitions';
 
+    /**
+     * [React] Auto Key Plugin
+     *
+     * With the plugin, you can omit the key property.
+     * Unique keys are auto-generated based on file:line:column.
+     *
+     * Next.js Setup:
+     * ```ts
+     * // next.config.ts
+     * import SsgoiAutoKey from "@ssgoi/react/unplugin/webpack";
+     *
+     * const nextConfig = {
+     *   webpack: (config) => {
+     *     config.plugins.push(SsgoiAutoKey());
+     *     return config;
+     *   },
+     * };
+     * ```
+     *
+     * ⚠️ Note: In .map() lists, JSX key is enough - the plugin handles it automatically.
+     * Without the plugin, key is required.
+     *
+     * Example:
+     * ```jsx
+     * // In .map() lists, JSX key is sufficient
+     * // Plugin auto-generates file:line:col:${jsxKey}
+     * {items.map((item) => (
+     *   <div
+     *     key={item.id}  // JSX key is enough
+     *     ref={transition(fade())}
+     *   >
+     *     {item.name}
+     *   </div>
+     * ))}
+     * ```
+     */
+
     // Fade transition
-    <div ref={transition({
-      key: "fade-element",
-      ...fade({ spring: { stiffness: 300, damping: 30 } })
-    })}>
+    <div ref={transition(fade())}>
       Fade effect
     </div>
 
     // Scale transition
-    <div ref={transition({
-      key: "scale-element",
-      ...scale({ spring: { stiffness: 300, damping: 30 } })
-    })}>
+    <div ref={transition(scale())}>
       Scale effect
     </div>
 
     // Blur transition
-    <div ref={transition({
-      key: "blur-element",
-      ...blur({ amount: 10, spring: { stiffness: 300, damping: 30 } })
-    })}>
+    <div ref={transition(blur({ amount: 10 }))}>
       Blur effect
     </div>
 
     // Slide transition (with direction)
-    <div ref={transition({
-      key: "slide-element",
-      ...slide({ direction: 'left', spring: { stiffness: 300, damping: 30 } })
-    })}>
+    <div ref={transition(slide({ direction: 'left' }))}>
       Slide effect
     </div>
 
     // Fly transition (custom position)
-    <div ref={transition({
-      key: "fly-element",
-      ...fly({ x: 200, y: -50, spring: { stiffness: 300, damping: 30 } })
-    })}>
+    <div ref={transition(fly({ x: 200, y: -50 }))}>
       Fly effect
     </div>
 
     // Rotate transition
-    <div ref={transition({
-      key: "rotate-element",
-      ...rotate({ spring: { stiffness: 300, damping: 30 } })
-    })}>
+    <div ref={transition(rotate())}>
       Rotate effect
     </div>
 
     // Bounce transition
-    <div ref={transition({
-      key: "bounce-element",
-      ...bounce({ spring: { stiffness: 300, damping: 30 } })
-    })}>
+    <div ref={transition(bounce())}>
       Bounce effect
     </div>
     ```
@@ -552,8 +568,11 @@ import { fade, scale /** etc */ } from "@ssgoi/react/transitions";
 
 ### key
 
-- `key` must be unique within the page (to track animation state even when DOM is created/deleted)
-- If `key` is not set, a default auto-key based on the call location is generated
+- `key` must be unique within the page to track animation state even when DOM is created/deleted
+- Without a `key`, SSGOI cannot distinguish between different elements with the same transition
+- **React Auto Key Plugin**: In React, if `key` is not provided, you can use the Auto Key Plugin to generate keys automatically based on file location (file:line:column)
+- **Important**: In `.map()` lists, JSX key is enough - the plugin automatically generates unique keys using the pattern `file:line:col:${jsxKey}`
+- See the React examples above for setup instructions
 
 ### in Animation
 

--- a/apps/docs/content/en/02.core-concepts/04.react-plugin.mdx
+++ b/apps/docs/content/en/02.core-concepts/04.react-plugin.mdx
@@ -1,0 +1,276 @@
+---
+title: "React Auto Key Plugin"
+description: "Build plugin that auto-generates keys for transition() calls"
+nav-title: "React Plugin"
+---
+
+## Overview
+
+The Auto Key Plugin for `@ssgoi/react` is a build-time plugin that automatically generates unique `key` values for `transition()` function calls.
+
+### Why Keys Are Needed
+
+SSGOI requires unique `key` values to track element animation states. Without keys:
+- Cannot distinguish between elements using the same transition
+- Animation states are not preserved after page navigation
+- Unexpected behavior when elements mount/unmount
+
+### What the Plugin Does
+
+At build time, it analyzes all `transition()` calls and injects unique keys based on **filename:line:column**.
+
+```tsx
+// Your code
+<div ref={transition(fade())}>Content</div>
+
+// Transformed code after build
+<div ref={transition({ ...fade(), key: "page.tsx:15:6" })}>Content</div>
+```
+
+## Installation & Setup
+
+The plugin is included in the `@ssgoi/react` package. No separate installation needed.
+
+### Next.js (Webpack)
+
+```ts
+// next.config.ts
+import type { NextConfig } from "next";
+import SsgoiAutoKey from "@ssgoi/react/unplugin/webpack";
+
+const nextConfig: NextConfig = {
+  webpack: (config) => {
+    config.plugins.push(SsgoiAutoKey());
+    return config;
+  },
+};
+
+export default nextConfig;
+```
+
+### Vite
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import SsgoiAutoKey from "@ssgoi/react/unplugin/vite";
+
+export default defineConfig({
+  plugins: [react(), SsgoiAutoKey()],
+});
+```
+
+### Rollup
+
+```ts
+// rollup.config.js
+import SsgoiAutoKey from "@ssgoi/react/unplugin/rollup";
+
+export default {
+  plugins: [SsgoiAutoKey()],
+};
+```
+
+### esbuild
+
+```ts
+import SsgoiAutoKey from "@ssgoi/react/unplugin/esbuild";
+
+await esbuild.build({
+  plugins: [SsgoiAutoKey()],
+});
+```
+
+## Usage
+
+### Basic Usage (With Plugin)
+
+When the plugin is configured, you can omit the key.
+
+```tsx
+import { transition } from '@ssgoi/react';
+import { fade, scale } from '@ssgoi/react/transitions';
+
+function MyComponent() {
+  return (
+    <>
+      {/* key can be omitted - auto-generated */}
+      <div ref={transition(fade())}>
+        Fade effect
+      </div>
+
+      <div ref={transition(scale())}>
+        Scale effect
+      </div>
+    </>
+  );
+}
+```
+
+### Explicit Key
+
+You can still specify an explicit key when needed. The plugin skips calls that already have a key.
+
+```tsx
+<div ref={transition({
+  key: "my-custom-key",  // explicit key
+  ...fade()
+})}>
+  Content
+</div>
+```
+
+### Lists (.map)
+
+For lists rendered with `.map()`, **JSX key is enough**. The plugin reads the JSX key and generates `filename:line:column:${jsxKey}`.
+
+```tsx
+function ItemList({ items }) {
+  return (
+    <ul>
+      {items.map((item) => (
+        <li
+          key={item.id}  // JSX key is sufficient!
+          ref={transition(fade())}  // plugin handles it
+        >
+          {item.name}
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+Generated key example: `ItemList.tsx:8:10:item-1`, `ItemList.tsx:8:10:item-2`, ...
+
+## Without Plugin
+
+If not using the plugin, you must manually specify unique keys.
+
+```tsx
+// Without plugin - key is required!
+<div ref={transition({
+  key: "unique-key-1",
+  ...fade()
+})}>
+  Content
+</div>
+
+// Lists also require explicit keys
+{items.map((item) => (
+  <li
+    key={item.id}
+    ref={transition({
+      key: `item-${item.id}`,  // transition key also needed
+      ...fade()
+    })}
+  >
+    {item.name}
+  </li>
+))}
+```
+
+## How It Works
+
+### 1. Code Analysis
+
+The plugin scans `.tsx` and `.jsx` files for `transition()` function calls.
+
+### 2. Location-Based Key Generation
+
+Generates unique keys based on source code location (filename, line, column).
+
+```
+filename:line:column
+e.g., MyComponent.tsx:25:8
+```
+
+### 3. JSX Key Combination (Lists)
+
+For elements inside `.map()`, it finds the parent JSX element's `key` prop and combines it.
+
+```
+filename:line:column:${jsxKey}
+e.g., ItemList.tsx:8:10:item-123
+```
+
+### 4. Code Transformation
+
+Transforms the original code to inject the key.
+
+```tsx
+// Before
+transition(fade())
+
+// After
+transition({ ...fade(), key: "MyComponent.tsx:25:8" })
+```
+
+## Plugin Options
+
+```ts
+interface SsgoiAutoKeyOptions {
+  /**
+   * File extensions to process
+   * @default ['.tsx', '.jsx']
+   */
+  include?: string[];
+
+  /**
+   * File patterns to exclude
+   * @default [/node_modules/]
+   */
+  exclude?: (string | RegExp)[];
+}
+```
+
+### Example
+
+```ts
+// next.config.ts
+import SsgoiAutoKey from "@ssgoi/react/unplugin/webpack";
+
+const nextConfig = {
+  webpack: (config) => {
+    config.plugins.push(SsgoiAutoKey({
+      include: ['.tsx'],  // only .tsx files
+      exclude: [/node_modules/, /\.test\.tsx$/],  // exclude test files
+    }));
+    return config;
+  },
+};
+```
+
+## Important Notes
+
+<Note type="info">
+This plugin is **React-only**. It cannot be used with Svelte, Vue, Angular, or other frameworks.
+</Note>
+
+<Note type="warning">
+**Conditional Rendering**: When different elements render at the same location based on conditions, they may get the same key. Use explicit keys in such cases.
+</Note>
+
+```tsx
+// ⚠️ Caution: conditional rendering at same location
+{isLoading
+  ? <div ref={transition(fade())}>Loading...</div>  // key: file:10:6
+  : <div ref={transition(fade())}>Content</div>     // key: file:11:6 (different line, OK)
+}
+
+// ✅ Same line? Use explicit keys
+{isLoading
+  ? <div ref={transition({ key: "loading", ...fade() })}>Loading...</div>
+  : <div ref={transition({ key: "content", ...fade() })}>Content</div>
+}
+```
+
+## Debugging
+
+To check generated keys during development, inspect the built code in browser devtools or log the transition:
+
+```tsx
+const myTransition = transition(fade());
+console.log(myTransition);  // check key value
+```

--- a/apps/docs/content/ja/02.core-concepts/01.element-transitions.mdx
+++ b/apps/docs/content/ja/02.core-concepts/01.element-transitions.mdx
@@ -14,60 +14,82 @@ nav-title: "要素アニメーション"
     import { transition } from '@ssgoi/react';
     import { fade, scale, blur, slide, fly, rotate, bounce } from '@ssgoi/react/transitions';
 
+    /**
+     * [React] Auto Key Plugin
+     *
+     * プラグイン使用時、keyを省略できます。
+     * ファイル:行:列に基づいて一意のkeyが自動生成されます。
+     *
+     * Next.js 設定:
+     * ```ts
+     * // next.config.ts
+     * import SsgoiAutoKey from "@ssgoi/react/unplugin/webpack";
+     *
+     * const nextConfig = {
+     *   webpack: (config) => {
+     *     config.plugins.push(SsgoiAutoKey());
+     *     return config;
+     *   },
+     * };
+     * ```
+     *
+     * ⚠️ 注意: .map()リストではJSX keyだけで十分 - プラグインが自動処理
+     *
+     * // .map()リストではJSX keyだけで十分
+     * // プラグインが自動的にfile:line:col:${jsxKey}を生成
+     * {items.map((item) => (
+     *   <div
+     *     key={item.id}  // JSX keyだけで十分
+     *     ref={transition(fade())}
+     *   >
+     *     {item.name}
+     *   </div>
+     * ))}
+     *
+     * プラグインなしの場合、keyは必須です。
+     */
+
     // Fadeトランジション
-    <div ref={transition({
-      key: "fade-element",
-      ...fade({ spring: { stiffness: 300, damping: 30 } })
-    })}>
+    <div ref={transition(fade({ spring: { stiffness: 300, damping: 30 } }))}>
       Fade効果
     </div>
 
     // Scaleトランジション
-    <div ref={transition({
-      key: "scale-element",
-      ...scale({ spring: { stiffness: 300, damping: 30 } })
-    })}>
+    <div ref={transition(scale({ spring: { stiffness: 300, damping: 30 } }))}>
       Scale効果
     </div>
 
     // Blurトランジション
-    <div ref={transition({
-      key: "blur-element",
-      ...blur({ amount: 10, spring: { stiffness: 300, damping: 30 } })
-    })}>
+    <div ref={transition(blur({ amount: 10, spring: { stiffness: 300, damping: 30 } }))}>
       Blur効果
     </div>
 
     // Slideトランジション（方向指定）
-    <div ref={transition({
-      key: "slide-element",
-      ...slide({ direction: 'left', spring: { stiffness: 300, damping: 30 } })
-    })}>
+    <div ref={transition(slide({ direction: 'left', spring: { stiffness: 300, damping: 30 } }))}>
       Slide効果
     </div>
 
     // Flyトランジション（カスタム位置）
-    <div ref={transition({
-      key: "fly-element",
-      ...fly({ x: 200, y: -50, spring: { stiffness: 300, damping: 30 } })
-    })}>
+    <div ref={transition(fly({ x: 200, y: -50, spring: { stiffness: 300, damping: 30 } }))}>
       Fly効果
     </div>
 
     // Rotateトランジション
-    <div ref={transition({
-      key: "rotate-element",
-      ...rotate({ spring: { stiffness: 300, damping: 30 } })
-    })}>
+    <div ref={transition(rotate({ spring: { stiffness: 300, damping: 30 } }))}>
       Rotate効果
     </div>
 
     // Bounceトランジション
-    <div ref={transition({
-      key: "bounce-element",
-      ...bounce({ spring: { stiffness: 300, damping: 30 } })
-    })}>
+    <div ref={transition(bounce({ spring: { stiffness: 300, damping: 30 } }))}>
       Bounce効果
+    </div>
+
+    // 明示的なkey（プラグインなしの場合は必須）
+    <div ref={transition({
+      key: "explicit-key",
+      ...fade({ spring: { stiffness: 300, damping: 30 } })
+    })}>
+      明示的なkeyを使用
     </div>
     ```
   </TabPanel>
@@ -556,7 +578,8 @@ import { fade, scale /** etc */ } from "@ssgoi/react/transitions";
 ### key
 
 - `key`はページ内で一意である必要があります（DOMが作成された後削除されたり、削除された後作成されたりしてもアニメーション状態を追跡できるようにするため）
-- `key`を設定しない場合、デフォルトで呼び出し位置に基づいた自動キーが生成されます
+- **React**: Auto Key Pluginを使用すると、`key`を省略可能（詳細はReactタブのコメントを参照）
+- **その他のフレームワーク**: `key`は必須です
 
 ### inアニメーション
 

--- a/apps/docs/content/ja/02.core-concepts/04.react-plugin.mdx
+++ b/apps/docs/content/ja/02.core-concepts/04.react-plugin.mdx
@@ -1,0 +1,276 @@
+---
+title: "React Auto Key Plugin"
+description: "transition()呼び出し時にkeyを自動生成するビルドプラグイン"
+nav-title: "React Plugin"
+---
+
+## 概要
+
+`@ssgoi/react`のAuto Key Pluginは、`transition()`関数呼び出し時に一意の`key`を自動生成するビルドタイムプラグインです。
+
+### なぜkeyが必要か？
+
+SSGOIは要素のアニメーション状態を追跡するために一意の`key`が必要です。keyがないと：
+- 同じトランジションを使用する要素を区別できない
+- ページ遷移後にアニメーション状態が維持されない
+- 要素のマウント/アンマウント時に予期しない動作が発生
+
+### プラグインの役割
+
+ビルド時にすべての`transition()`呼び出しを分析し、**ファイル名:行:列**に基づいた一意のkeyを自動注入します。
+
+```tsx
+// 作成したコード
+<div ref={transition(fade())}>Content</div>
+
+// ビルド後の変換されたコード
+<div ref={transition({ ...fade(), key: "page.tsx:15:6" })}>Content</div>
+```
+
+## インストールと設定
+
+プラグインは`@ssgoi/react`パッケージに含まれています。別途インストールは不要です。
+
+### Next.js (Webpack)
+
+```ts
+// next.config.ts
+import type { NextConfig } from "next";
+import SsgoiAutoKey from "@ssgoi/react/unplugin/webpack";
+
+const nextConfig: NextConfig = {
+  webpack: (config) => {
+    config.plugins.push(SsgoiAutoKey());
+    return config;
+  },
+};
+
+export default nextConfig;
+```
+
+### Vite
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import SsgoiAutoKey from "@ssgoi/react/unplugin/vite";
+
+export default defineConfig({
+  plugins: [react(), SsgoiAutoKey()],
+});
+```
+
+### Rollup
+
+```ts
+// rollup.config.js
+import SsgoiAutoKey from "@ssgoi/react/unplugin/rollup";
+
+export default {
+  plugins: [SsgoiAutoKey()],
+};
+```
+
+### esbuild
+
+```ts
+import SsgoiAutoKey from "@ssgoi/react/unplugin/esbuild";
+
+await esbuild.build({
+  plugins: [SsgoiAutoKey()],
+});
+```
+
+## 使用方法
+
+### 基本的な使い方（プラグインあり）
+
+プラグインが設定されている場合、keyを省略できます。
+
+```tsx
+import { transition } from '@ssgoi/react';
+import { fade, scale } from '@ssgoi/react/transitions';
+
+function MyComponent() {
+  return (
+    <>
+      {/* keyを省略可能 - 自動生成されます */}
+      <div ref={transition(fade())}>
+        Fade効果
+      </div>
+
+      <div ref={transition(scale())}>
+        Scale効果
+      </div>
+    </>
+  );
+}
+```
+
+### 明示的なkey
+
+必要に応じて明示的にkeyを指定できます。プラグインは既にkeyがある場合はスキップします。
+
+```tsx
+<div ref={transition({
+  key: "my-custom-key",  // 明示的なkey
+  ...fade()
+})}>
+  Content
+</div>
+```
+
+### リストでの使用（.map）
+
+`.map()`でレンダリングされるリストでは、**JSX keyだけで十分です**。プラグインがJSX keyを読み取り、`ファイル名:行:列:${jsxKey}`形式で自動生成します。
+
+```tsx
+function ItemList({ items }) {
+  return (
+    <ul>
+      {items.map((item) => (
+        <li
+          key={item.id}  // JSX keyだけで十分！
+          ref={transition(fade())}  // プラグインが自動処理
+        >
+          {item.name}
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+生成されるkeyの例：`ItemList.tsx:8:10:item-1`、`ItemList.tsx:8:10:item-2`、...
+
+## プラグインなしで使用
+
+プラグインを使用しない場合、一意のkeyを手動で指定する必要があります。
+
+```tsx
+// プラグインなし - keyは必須！
+<div ref={transition({
+  key: "unique-key-1",
+  ...fade()
+})}>
+  Content
+</div>
+
+// リストでもkeyが必要
+{items.map((item) => (
+  <li
+    key={item.id}
+    ref={transition({
+      key: `item-${item.id}`,  // transition keyも必要
+      ...fade()
+    })}
+  >
+    {item.name}
+  </li>
+))}
+```
+
+## 動作原理
+
+### 1. コード分析
+
+プラグインは`.tsx`、`.jsx`ファイルで`transition()`関数呼び出しを検索します。
+
+### 2. 位置ベースのkey生成
+
+ソースコードの位置（ファイル名、行、列）に基づいて一意のkeyを生成します。
+
+```
+ファイル名:行:列
+例：MyComponent.tsx:25:8
+```
+
+### 3. JSX keyの結合（リスト）
+
+`.map()`内の要素の場合、親JSX要素の`key`プロップを見つけて結合します。
+
+```
+ファイル名:行:列:${jsxKey}
+例：ItemList.tsx:8:10:item-123
+```
+
+### 4. コード変換
+
+元のコードを変換してkeyを注入します。
+
+```tsx
+// Before
+transition(fade())
+
+// After
+transition({ ...fade(), key: "MyComponent.tsx:25:8" })
+```
+
+## プラグインオプション
+
+```ts
+interface SsgoiAutoKeyOptions {
+  /**
+   * 処理するファイル拡張子
+   * @default ['.tsx', '.jsx']
+   */
+  include?: string[];
+
+  /**
+   * 除外するファイルパターン
+   * @default [/node_modules/]
+   */
+  exclude?: (string | RegExp)[];
+}
+```
+
+### 使用例
+
+```ts
+// next.config.ts
+import SsgoiAutoKey from "@ssgoi/react/unplugin/webpack";
+
+const nextConfig = {
+  webpack: (config) => {
+    config.plugins.push(SsgoiAutoKey({
+      include: ['.tsx'],  // .tsxファイルのみ
+      exclude: [/node_modules/, /\.test\.tsx$/],  // テストファイルを除外
+    }));
+    return config;
+  },
+};
+```
+
+## 注意事項
+
+<Note type="info">
+このプラグインは**React専用**です。Svelte、Vue、Angularなど他のフレームワークでは使用できません。
+</Note>
+
+<Note type="warning">
+**条件付きレンダリングに注意**：同じ位置で条件によって異なる要素がレンダリングされる場合、同じkeyが生成される可能性があります。そのような場合は明示的なkeyを使用してください。
+</Note>
+
+```tsx
+// ⚠️ 注意：同じ位置での条件付きレンダリング
+{isLoading
+  ? <div ref={transition(fade())}>Loading...</div>  // key: file:10:6
+  : <div ref={transition(fade())}>Content</div>     // key: file:11:6（異なる行なのでOK）
+}
+
+// ✅ 同じ行の場合は明示的なkeyを使用
+{isLoading
+  ? <div ref={transition({ key: "loading", ...fade() })}>Loading...</div>
+  : <div ref={transition({ key: "content", ...fade() })}>Content</div>
+}
+```
+
+## デバッグ
+
+開発中に生成されたkeyを確認するには、ブラウザの開発者ツールでビルドされたコードを確認するか、次のようにログを出力できます：
+
+```tsx
+const myTransition = transition(fade());
+console.log(myTransition);  // key値を確認
+```

--- a/apps/docs/content/ko/02.core-concepts/01.element-transitions.mdx
+++ b/apps/docs/content/ko/02.core-concepts/01.element-transitions.mdx
@@ -14,60 +14,83 @@ nav-title: "요소 애니메이션"
     import { transition } from '@ssgoi/react';
     import { fade, scale, blur, slide, fly, rotate, bounce } from '@ssgoi/react/transitions';
 
+    /**
+     * [React] Auto Key Plugin
+     *
+     * 플러그인 사용 시 key를 생략할 수 있습니다.
+     * 파일:라인:컬럼 기반으로 고유 key가 자동 생성됩니다.
+     *
+     * Next.js 설정:
+     * ```ts
+     * // next.config.ts
+     * import SsgoiAutoKey from "@ssgoi/react/unplugin/webpack";
+     *
+     * const nextConfig = {
+     *   webpack: (config) => {
+     *     config.plugins.push(SsgoiAutoKey());
+     *     return config;
+     *   },
+     * };
+     * ```
+     *
+     * ⚠️ 주의: .map() 리스트에서는 JSX key만 있으면 됨 - 플러그인이 자동으로 처리
+     *
+     * 예시:
+     * // .map() 리스트에서는 JSX key만 있으면 됨
+     * // 플러그인이 자동으로 file:line:col:${jsxKey} 형태로 생성
+     * {items.map((item) => (
+     *   <div
+     *     key={item.id}  // JSX key만 있으면 충분
+     *     ref={transition(fade())}
+     *   >
+     *     {item.name}
+     *   </div>
+     * ))}
+     *
+     * 플러그인 없이 사용 시에는 key가 필수입니다.
+     */
+
     // Fade 트랜지션
-    <div ref={transition({
-      key: "fade-element",
-      ...fade({ spring: { stiffness: 300, damping: 30 } })
-    })}>
+    <div ref={transition(fade({ spring: { stiffness: 300, damping: 30 } }))}>
       Fade 효과
     </div>
 
     // Scale 트랜지션
+    <div ref={transition(scale({ spring: { stiffness: 300, damping: 30 } }))}>
+      Scale 효과
+    </div>
+
+    // Blur 트랜지션
+    <div ref={transition(blur({ amount: 10, spring: { stiffness: 300, damping: 30 } }))}>
+      Blur 효과
+    </div>
+
+    // Slide 트랜지션 (방향 지정)
+    <div ref={transition(slide({ direction: 'left', spring: { stiffness: 300, damping: 30 } }))}>
+      Slide 효과
+    </div>
+
+    // Fly 트랜지션 (커스텀 위치)
+    <div ref={transition(fly({ x: 200, y: -50, spring: { stiffness: 300, damping: 30 } }))}>
+      Fly 효과
+    </div>
+
+    // Rotate 트랜지션
+    <div ref={transition(rotate({ spring: { stiffness: 300, damping: 30 } }))}>
+      Rotate 효과
+    </div>
+
+    // Bounce 트랜지션
+    <div ref={transition(bounce({ spring: { stiffness: 300, damping: 30 } }))}>
+      Bounce 효과
+    </div>
+
+    // 명시적 key 사용 (플러그인 없이 사용 시 필수)
     <div ref={transition({
       key: "scale-element",
       ...scale({ spring: { stiffness: 300, damping: 30 } })
     })}>
       Scale 효과
-    </div>
-
-    // Blur 트랜지션
-    <div ref={transition({
-      key: "blur-element",
-      ...blur({ amount: 10, spring: { stiffness: 300, damping: 30 } })
-    })}>
-      Blur 효과
-    </div>
-
-    // Slide 트랜지션 (방향 지정)
-    <div ref={transition({
-      key: "slide-element",
-      ...slide({ direction: 'left', spring: { stiffness: 300, damping: 30 } })
-    })}>
-      Slide 효과
-    </div>
-
-    // Fly 트랜지션 (커스텀 위치)
-    <div ref={transition({
-      key: "fly-element",
-      ...fly({ x: 200, y: -50, spring: { stiffness: 300, damping: 30 } })
-    })}>
-      Fly 효과
-    </div>
-
-    // Rotate 트랜지션
-    <div ref={transition({
-      key: "rotate-element",
-      ...rotate({ spring: { stiffness: 300, damping: 30 } })
-    })}>
-      Rotate 효과
-    </div>
-
-    // Bounce 트랜지션
-    <div ref={transition({
-      key: "bounce-element",
-      ...bounce({ spring: { stiffness: 300, damping: 30 } })
-    })}>
-      Bounce 효과
     </div>
     ```
 
@@ -556,8 +579,12 @@ import { fade, scale /** 등등 */ } from "@ssgoi/react/transitions";
 
 ### key
 
-- `key`는 페이지 내에서 고유해야 함 (DOM이 생성되거나 삭제될 때도 애니메이션 상태를 추적할 수 있도록)
-- `key`를 설정하지 않으면 기본적으로 호출 위치 기반의 자동 키가 생성됨
+`key`는 SSGOI가 각 요소의 애니메이션 상태를 추적하는 데 사용하는 고유 식별자입니다:
+
+- **고유성**: 페이지 내에서 각 `transition()` 호출마다 고유한 key가 필요합니다
+- **상태 추적**: DOM 요소가 생성되거나 삭제될 때도 애니메이션 상태를 유지할 수 있도록 합니다
+- **React 자동 생성**: React에서는 Auto Key Plugin을 사용하면 key를 수동으로 지정하지 않아도 됩니다 (설정 방법은 위 React 탭의 주석 참조)
+- **수동 지정**: 다른 프레임워크에서는 명시적으로 key를 지정해야 합니다
 
 ### in 애니메이션
 

--- a/apps/docs/content/ko/02.core-concepts/04.react-plugin.mdx
+++ b/apps/docs/content/ko/02.core-concepts/04.react-plugin.mdx
@@ -1,0 +1,276 @@
+---
+title: "React Auto Key Plugin"
+description: "transition() 호출 시 key를 자동 생성해주는 빌드 플러그인"
+nav-title: "React Plugin"
+---
+
+## 개요
+
+`@ssgoi/react`의 Auto Key Plugin은 `transition()` 함수 호출 시 고유한 `key`를 자동으로 생성해주는 빌드 타임 플러그인입니다.
+
+### 왜 key가 필요한가?
+
+SSGOI는 요소의 애니메이션 상태를 추적하기 위해 고유한 `key`가 필요합니다. key가 없으면:
+- 같은 트랜지션을 사용하는 요소들을 구분할 수 없음
+- 페이지 이동 후 돌아왔을 때 애니메이션 상태가 유지되지 않음
+- 요소가 마운트/언마운트될 때 예상치 못한 동작 발생
+
+### 플러그인의 역할
+
+빌드 시점에 모든 `transition()` 호출을 분석하여 **파일명:라인:컬럼** 기반의 고유한 key를 자동 주입합니다.
+
+```tsx
+// 작성한 코드
+<div ref={transition(fade())}>Content</div>
+
+// 빌드 후 변환된 코드
+<div ref={transition({ ...fade(), key: "page.tsx:15:6" })}>Content</div>
+```
+
+## 설치 및 설정
+
+플러그인은 `@ssgoi/react` 패키지에 포함되어 있습니다. 별도 설치가 필요 없습니다.
+
+### Next.js (Webpack)
+
+```ts
+// next.config.ts
+import type { NextConfig } from "next";
+import SsgoiAutoKey from "@ssgoi/react/unplugin/webpack";
+
+const nextConfig: NextConfig = {
+  webpack: (config) => {
+    config.plugins.push(SsgoiAutoKey());
+    return config;
+  },
+};
+
+export default nextConfig;
+```
+
+### Vite
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import SsgoiAutoKey from "@ssgoi/react/unplugin/vite";
+
+export default defineConfig({
+  plugins: [react(), SsgoiAutoKey()],
+});
+```
+
+### Rollup
+
+```ts
+// rollup.config.js
+import SsgoiAutoKey from "@ssgoi/react/unplugin/rollup";
+
+export default {
+  plugins: [SsgoiAutoKey()],
+};
+```
+
+### esbuild
+
+```ts
+import SsgoiAutoKey from "@ssgoi/react/unplugin/esbuild";
+
+await esbuild.build({
+  plugins: [SsgoiAutoKey()],
+});
+```
+
+## 사용법
+
+### 기본 사용 (플러그인 O)
+
+플러그인이 설정되어 있으면 key를 생략할 수 있습니다.
+
+```tsx
+import { transition } from '@ssgoi/react';
+import { fade, scale } from '@ssgoi/react/transitions';
+
+function MyComponent() {
+  return (
+    <>
+      {/* key 생략 가능 - 자동 생성됨 */}
+      <div ref={transition(fade())}>
+        Fade 효과
+      </div>
+
+      <div ref={transition(scale())}>
+        Scale 효과
+      </div>
+    </>
+  );
+}
+```
+
+### 명시적 key 사용
+
+특별한 경우 명시적으로 key를 지정할 수 있습니다. 플러그인은 이미 key가 있는 경우 건너뜁니다.
+
+```tsx
+<div ref={transition({
+  key: "my-custom-key",  // 명시적 key 사용
+  ...fade()
+})}>
+  Content
+</div>
+```
+
+### 리스트에서 사용 (.map)
+
+`.map()`으로 렌더링되는 리스트에서는 **JSX key만 있으면 됩니다**. 플러그인이 JSX key를 읽어서 `파일:라인:컬럼:${jsxKey}` 형태로 자동 생성합니다.
+
+```tsx
+function ItemList({ items }) {
+  return (
+    <ul>
+      {items.map((item) => (
+        <li
+          key={item.id}  // JSX key만 있으면 충분!
+          ref={transition(fade())}  // 플러그인이 자동 처리
+        >
+          {item.name}
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+생성되는 key 예시: `ItemList.tsx:8:10:item-1`, `ItemList.tsx:8:10:item-2`, ...
+
+## 플러그인 없이 사용
+
+플러그인을 사용하지 않는 경우, 반드시 고유한 key를 직접 지정해야 합니다.
+
+```tsx
+// 플러그인 없이 사용 시 - key 필수!
+<div ref={transition({
+  key: "unique-key-1",
+  ...fade()
+})}>
+  Content
+</div>
+
+// 리스트에서도 key 필수
+{items.map((item) => (
+  <li
+    key={item.id}
+    ref={transition({
+      key: `item-${item.id}`,  // transition key도 필요
+      ...fade()
+    })}
+  >
+    {item.name}
+  </li>
+))}
+```
+
+## 작동 원리
+
+### 1. 코드 분석
+
+플러그인은 `.tsx`, `.jsx` 파일에서 `transition()` 함수 호출을 찾습니다.
+
+### 2. 위치 기반 key 생성
+
+각 호출의 소스 코드 위치(파일명, 라인, 컬럼)를 기반으로 고유한 key를 생성합니다.
+
+```
+파일명:라인:컬럼
+예: MyComponent.tsx:25:8
+```
+
+### 3. JSX key 결합 (리스트)
+
+`.map()` 내부의 요소인 경우, 상위 JSX 요소의 `key` prop을 찾아 결합합니다.
+
+```
+파일명:라인:컬럼:${jsxKey}
+예: ItemList.tsx:8:10:item-123
+```
+
+### 4. 코드 변환
+
+원본 코드를 변환하여 key를 주입합니다.
+
+```tsx
+// Before
+transition(fade())
+
+// After
+transition({ ...fade(), key: "MyComponent.tsx:25:8" })
+```
+
+## 플러그인 옵션
+
+```ts
+interface SsgoiAutoKeyOptions {
+  /**
+   * 처리할 파일 확장자
+   * @default ['.tsx', '.jsx']
+   */
+  include?: string[];
+
+  /**
+   * 제외할 파일 패턴
+   * @default [/node_modules/]
+   */
+  exclude?: (string | RegExp)[];
+}
+```
+
+### 사용 예시
+
+```ts
+// next.config.ts
+import SsgoiAutoKey from "@ssgoi/react/unplugin/webpack";
+
+const nextConfig = {
+  webpack: (config) => {
+    config.plugins.push(SsgoiAutoKey({
+      include: ['.tsx'],  // .tsx 파일만 처리
+      exclude: [/node_modules/, /\.test\.tsx$/],  // 테스트 파일 제외
+    }));
+    return config;
+  },
+};
+```
+
+## 주의사항
+
+<Note type="info">
+이 플러그인은 **React 전용**입니다. Svelte, Vue, Angular 등 다른 프레임워크에서는 사용할 수 없습니다.
+</Note>
+
+<Note type="warning">
+**조건부 렌더링 주의**: 같은 위치에서 조건에 따라 다른 요소가 렌더링되는 경우, 동일한 key가 생성될 수 있습니다. 이런 경우 명시적 key를 사용하세요.
+</Note>
+
+```tsx
+// ⚠️ 주의: 같은 위치에서 조건부 렌더링
+{isLoading
+  ? <div ref={transition(fade())}>Loading...</div>  // key: file:10:6
+  : <div ref={transition(fade())}>Content</div>     // key: file:11:6 (다른 줄이라 OK)
+}
+
+// ✅ 같은 줄이면 명시적 key 사용
+{isLoading
+  ? <div ref={transition({ key: "loading", ...fade() })}>Loading...</div>
+  : <div ref={transition({ key: "content", ...fade() })}>Content</div>
+}
+```
+
+## 디버깅
+
+개발 중 생성된 key를 확인하려면 브라우저 개발자 도구에서 빌드된 코드를 확인하거나, 다음과 같이 로깅할 수 있습니다:
+
+```tsx
+const myTransition = transition(fade());
+console.log(myTransition);  // key 값 확인 가능
+```

--- a/apps/docs/content/zh/02.core-concepts/01.element-transitions.mdx
+++ b/apps/docs/content/zh/02.core-concepts/01.element-transitions.mdx
@@ -14,60 +14,81 @@ nav-title: "元素动画"
     import { transition } from '@ssgoi/react';
     import { fade, scale, blur, slide, fly, rotate, bounce } from '@ssgoi/react/transitions';
 
+    /**
+     * [React] Auto Key Plugin
+     *
+     * 使用插件时可以省略 key 属性。
+     * 基于 文件:行:列 自动生成唯一的 key。
+     *
+     * Next.js 配置:
+     * ```ts
+     * // next.config.ts
+     * import SsgoiAutoKey from "@ssgoi/react/unplugin/webpack";
+     *
+     * const nextConfig = {
+     *   webpack: (config) => {
+     *     config.plugins.push(SsgoiAutoKey());
+     *     return config;
+     *   },
+     * };
+     * ```
+     *
+     * ⚠️ 注意: .map() 列表中只需要 JSX key - 插件会自动处理
+     *
+     * // .map() 列表中的正确用法:
+     * {items.map((item) => (
+     *   <div
+     *     key={item.id}  // JSX key 就足够了
+     *     ref={transition(fade())}
+     *   >
+     *     {item.name}
+     *   </div>
+     * ))}
+     *
+     * // 不使用插件时，key 是必需的
+     */
+
     // Fade过渡
-    <div ref={transition({
-      key: "fade-element",
-      ...fade({ spring: { stiffness: 300, damping: 30 } })
-    })}>
+    <div ref={transition(fade({ spring: { stiffness: 300, damping: 30 } }))}>
       Fade效果
     </div>
 
     // Scale过渡
-    <div ref={transition({
-      key: "scale-element",
-      ...scale({ spring: { stiffness: 300, damping: 30 } })
-    })}>
+    <div ref={transition(scale({ spring: { stiffness: 300, damping: 30 } }))}>
       Scale效果
     </div>
 
     // Blur过渡
-    <div ref={transition({
-      key: "blur-element",
-      ...blur({ amount: 10, spring: { stiffness: 300, damping: 30 } })
-    })}>
+    <div ref={transition(blur({ amount: 10, spring: { stiffness: 300, damping: 30 } }))}>
       Blur效果
     </div>
 
     // Slide过渡（方向指定）
-    <div ref={transition({
-      key: "slide-element",
-      ...slide({ direction: 'left', spring: { stiffness: 300, damping: 30 } })
-    })}>
+    <div ref={transition(slide({ direction: 'left', spring: { stiffness: 300, damping: 30 } }))}>
       Slide效果
     </div>
 
     // Fly过渡（自定义位置）
-    <div ref={transition({
-      key: "fly-element",
-      ...fly({ x: 200, y: -50, spring: { stiffness: 300, damping: 30 } })
-    })}>
+    <div ref={transition(fly({ x: 200, y: -50, spring: { stiffness: 300, damping: 30 } }))}>
       Fly效果
     </div>
 
     // Rotate过渡
-    <div ref={transition({
-      key: "rotate-element",
-      ...rotate({ spring: { stiffness: 300, damping: 30 } })
-    })}>
+    <div ref={transition(rotate({ spring: { stiffness: 300, damping: 30 } }))}>
       Rotate效果
     </div>
 
     // Bounce过渡
-    <div ref={transition({
-      key: "bounce-element",
-      ...bounce({ spring: { stiffness: 300, damping: 30 } })
-    })}>
+    <div ref={transition(bounce({ spring: { stiffness: 300, damping: 30 } }))}>
       Bounce效果
+    </div>
+
+    // 明确指定 key（不使用插件时必须）
+    <div ref={transition({
+      key: "custom-element",
+      ...fade({ spring: { stiffness: 300, damping: 30 } })
+    })}>
+      自定义 Key
     </div>
     ```
   </TabPanel>
@@ -554,7 +575,8 @@ import { fade, scale /** etc */ } from "@ssgoi/react/transitions";
 ### key
 
 - `key`必须在页面内唯一（这样即使DOM被创建后删除或删除后创建，动画状态也可以被跟踪）
-- 如果`key`未设置，则根据调用位置生成默认的自动键
+- React中可以使用Auto Key Plugin自动生成key（详见上方React标签页中的说明）
+- 如果`key`未设置且未使用插件，则根据调用位置生成默认的自动键
 
 ### in动画
 

--- a/apps/docs/content/zh/02.core-concepts/04.react-plugin.mdx
+++ b/apps/docs/content/zh/02.core-concepts/04.react-plugin.mdx
@@ -1,0 +1,276 @@
+---
+title: "React Auto Key Plugin"
+description: "在 transition() 调用时自动生成 key 的构建插件"
+nav-title: "React Plugin"
+---
+
+## 概述
+
+`@ssgoi/react` 的 Auto Key Plugin 是一个构建时插件，可以在 `transition()` 函数调用时自动生成唯一的 `key`。
+
+### 为什么需要 key？
+
+SSGOI 需要唯一的 `key` 来跟踪元素的动画状态。没有 key：
+- 无法区分使用相同过渡效果的元素
+- 页面导航后动画状态不会保留
+- 元素挂载/卸载时会出现意外行为
+
+### 插件的作用
+
+在构建时分析所有 `transition()` 调用，并基于 **文件名:行:列** 自动注入唯一的 key。
+
+```tsx
+// 你写的代码
+<div ref={transition(fade())}>Content</div>
+
+// 构建后转换的代码
+<div ref={transition({ ...fade(), key: "page.tsx:15:6" })}>Content</div>
+```
+
+## 安装和配置
+
+插件已包含在 `@ssgoi/react` 包中，无需单独安装。
+
+### Next.js (Webpack)
+
+```ts
+// next.config.ts
+import type { NextConfig } from "next";
+import SsgoiAutoKey from "@ssgoi/react/unplugin/webpack";
+
+const nextConfig: NextConfig = {
+  webpack: (config) => {
+    config.plugins.push(SsgoiAutoKey());
+    return config;
+  },
+};
+
+export default nextConfig;
+```
+
+### Vite
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import SsgoiAutoKey from "@ssgoi/react/unplugin/vite";
+
+export default defineConfig({
+  plugins: [react(), SsgoiAutoKey()],
+});
+```
+
+### Rollup
+
+```ts
+// rollup.config.js
+import SsgoiAutoKey from "@ssgoi/react/unplugin/rollup";
+
+export default {
+  plugins: [SsgoiAutoKey()],
+};
+```
+
+### esbuild
+
+```ts
+import SsgoiAutoKey from "@ssgoi/react/unplugin/esbuild";
+
+await esbuild.build({
+  plugins: [SsgoiAutoKey()],
+});
+```
+
+## 使用方法
+
+### 基本用法（使用插件）
+
+配置插件后，可以省略 key。
+
+```tsx
+import { transition } from '@ssgoi/react';
+import { fade, scale } from '@ssgoi/react/transitions';
+
+function MyComponent() {
+  return (
+    <>
+      {/* 可以省略 key - 自动生成 */}
+      <div ref={transition(fade())}>
+        Fade 效果
+      </div>
+
+      <div ref={transition(scale())}>
+        Scale 效果
+      </div>
+    </>
+  );
+}
+```
+
+### 显式 key
+
+需要时可以显式指定 key。插件会跳过已有 key 的调用。
+
+```tsx
+<div ref={transition({
+  key: "my-custom-key",  // 显式 key
+  ...fade()
+})}>
+  Content
+</div>
+```
+
+### 列表中使用（.map）
+
+对于使用 `.map()` 渲染的列表，**只需要 JSX key**。插件会读取 JSX key 并生成 `文件名:行:列:${jsxKey}` 格式。
+
+```tsx
+function ItemList({ items }) {
+  return (
+    <ul>
+      {items.map((item) => (
+        <li
+          key={item.id}  // JSX key 就足够了！
+          ref={transition(fade())}  // 插件自动处理
+        >
+          {item.name}
+        </li>
+      ))}
+    </ul>
+  );
+}
+```
+
+生成的 key 示例：`ItemList.tsx:8:10:item-1`、`ItemList.tsx:8:10:item-2`...
+
+## 不使用插件
+
+如果不使用插件，必须手动指定唯一的 key。
+
+```tsx
+// 不使用插件 - key 是必需的！
+<div ref={transition({
+  key: "unique-key-1",
+  ...fade()
+})}>
+  Content
+</div>
+
+// 列表中也需要 key
+{items.map((item) => (
+  <li
+    key={item.id}
+    ref={transition({
+      key: `item-${item.id}`,  // transition key 也需要
+      ...fade()
+    })}
+  >
+    {item.name}
+  </li>
+))}
+```
+
+## 工作原理
+
+### 1. 代码分析
+
+插件扫描 `.tsx` 和 `.jsx` 文件中的 `transition()` 函数调用。
+
+### 2. 基于位置的 key 生成
+
+基于源代码位置（文件名、行、列）生成唯一的 key。
+
+```
+文件名:行:列
+例如：MyComponent.tsx:25:8
+```
+
+### 3. JSX key 组合（列表）
+
+对于 `.map()` 内的元素，会找到父 JSX 元素的 `key` prop 并组合。
+
+```
+文件名:行:列:${jsxKey}
+例如：ItemList.tsx:8:10:item-123
+```
+
+### 4. 代码转换
+
+转换原始代码以注入 key。
+
+```tsx
+// Before
+transition(fade())
+
+// After
+transition({ ...fade(), key: "MyComponent.tsx:25:8" })
+```
+
+## 插件选项
+
+```ts
+interface SsgoiAutoKeyOptions {
+  /**
+   * 要处理的文件扩展名
+   * @default ['.tsx', '.jsx']
+   */
+  include?: string[];
+
+  /**
+   * 要排除的文件模式
+   * @default [/node_modules/]
+   */
+  exclude?: (string | RegExp)[];
+}
+```
+
+### 示例
+
+```ts
+// next.config.ts
+import SsgoiAutoKey from "@ssgoi/react/unplugin/webpack";
+
+const nextConfig = {
+  webpack: (config) => {
+    config.plugins.push(SsgoiAutoKey({
+      include: ['.tsx'],  // 只处理 .tsx 文件
+      exclude: [/node_modules/, /\.test\.tsx$/],  // 排除测试文件
+    }));
+    return config;
+  },
+};
+```
+
+## 注意事项
+
+<Note type="info">
+此插件**仅适用于 React**。不能与 Svelte、Vue、Angular 或其他框架一起使用。
+</Note>
+
+<Note type="warning">
+**条件渲染注意**：当同一位置根据条件渲染不同元素时，可能会生成相同的 key。这种情况下请使用显式 key。
+</Note>
+
+```tsx
+// ⚠️ 注意：同一位置的条件渲染
+{isLoading
+  ? <div ref={transition(fade())}>Loading...</div>  // key: file:10:6
+  : <div ref={transition(fade())}>Content</div>     // key: file:11:6（不同行，OK）
+}
+
+// ✅ 同一行时使用显式 key
+{isLoading
+  ? <div ref={transition({ key: "loading", ...fade() })}>Loading...</div>
+  : <div ref={transition({ key: "content", ...fade() })}>Content</div>
+}
+```
+
+## 调试
+
+开发时要检查生成的 key，可以在浏览器开发者工具中查看构建后的代码，或者这样打印：
+
+```tsx
+const myTransition = transition(fade());
+console.log(myTransition);  // 检查 key 值
+```

--- a/apps/react-demo/app/page.tsx
+++ b/apps/react-demo/app/page.tsx
@@ -777,35 +777,40 @@ export default function Home() {
               >
                 {[
                   {
+                    id: "1",
                     color: "#ff6b6b",
                     effect: fade({ spring: gentle }),
                     label: "fade",
                   },
                   {
+                    id: "2",
                     color: "#4ecdc4",
                     effect: scale({ spring: gentle }),
                     label: "scale",
                   },
                   {
+                    id: "3",
                     color: "#45b7d1",
                     effect: blur({ spring: gentle }),
                     label: "blur",
                   },
                   {
+                    id: "4",
                     color: "#96ceb4",
                     effect: rotate({ spring: gentle }),
                     label: "rotate",
                   },
                   {
+                    id: "5",
                     color: "#feca57",
                     effect: bounce({ spring: gentle }),
                     label: "bounce",
                   },
                 ].map(
-                  (item, index) =>
+                  (item) =>
                     showListItems && (
                       <div
-                        key={index}
+                        key={item.id}
                         ref={transition(item.effect)}
                         style={{
                           width: "32px",

--- a/packages/angular/README.md
+++ b/packages/angular/README.md
@@ -77,7 +77,7 @@ The value you pass to `[ssgoiTransition]` should uniquely identify the view (com
 ```typescript
 import { Component } from "@angular/core";
 import { TransitionDirective } from "@ssgoi/angular";
-import { fadeIn, fadeOut } from "@ssgoi/angular/transitions";
+import { fade } from "@ssgoi/angular/transitions";
 
 @Component({
   selector: "app-call-to-action",
@@ -87,8 +87,8 @@ import { fadeIn, fadeOut } from "@ssgoi/angular/transitions";
     <button
       [transition]="{
         key: 'cta',
-        in: fadeIn({ duration: 220 }),
-        out: fadeOut({ duration: 180 })
+        in: fade({ duration: 220 }),
+        out: fade({ duration: 180 })
       }"
     >
       Get Started
@@ -128,14 +128,9 @@ Element-level factories:
 
 ```typescript
 import {
-  fadeIn,
-  fadeOut,
-  slideUp,
-  slideDown,
-  slideLeft,
-  slideRight,
-  scaleIn,
-  scaleOut,
+  fade,
+  slide,
+  scale,
   bounce,
   blur,
   rotate,

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -106,14 +106,14 @@ Animate specific elements during mount/unmount:
 
 ```tsx
 import { transition } from '@ssgoi/react';
-import { fadeIn, slideUp } from '@ssgoi/react/transitions';
+import { fade, slide } from '@ssgoi/react/transitions';
 
 function Card() {
   return (
     <div ref={transition({
       key: 'card',
-      in: fadeIn(),
-      out: slideUp()
+      in: fade(),
+      out: slide({ direction: 'up' })
     })}>
       <h2>Animated Card</h2>
     </div>
@@ -131,12 +131,13 @@ function Card() {
 - `pinterest` - Pinterest-style expand effect
 
 ### Element Transitions
-- `fadeIn` / `fadeOut`
-- `slideUp` / `slideDown` / `slideLeft` / `slideRight`
-- `scaleIn` / `scaleOut`
-- `bounce`
-- `blur`
-- `rotate`
+- `fade` - Fade in/out
+- `scale` - Scale in/out
+- `slide` - Slide (direction: up/down/left/right)
+- `rotate` - Rotate
+- `bounce` - Bounce
+- `blur` - Blur
+- `fly` - Fly (custom x, y position)
 
 ## Framework Examples
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/core",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "description": "Core animation engine for SSGOI - Native app-like page transitions with spring physics",
   "private": false,
   "type": "module",

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -33,15 +33,13 @@ pnpm add @ssgoi/react
 ### 1. Wrap your app
 
 ```tsx
-import { Ssgoi } from '@ssgoi/react';
-import { fade } from '@ssgoi/react/view-transitions';
+import { Ssgoi } from "@ssgoi/react";
+import { fade } from "@ssgoi/react/view-transitions";
 
 export default function App() {
   return (
     <Ssgoi config={{ defaultTransition: fade() }}>
-      <div style={{ position: 'relative' }}>
-        {/* Your app */}
-      </div>
+      <div style={{ position: "relative" }}>{/* Your app */}</div>
     </Ssgoi>
   );
 }
@@ -50,7 +48,7 @@ export default function App() {
 ### 2. Wrap your pages
 
 ```tsx
-import { SsgoiTransition } from '@ssgoi/react';
+import { SsgoiTransition } from "@ssgoi/react";
 
 export default function HomePage() {
   return (
@@ -74,16 +72,20 @@ Define different transitions for different routes:
 const config = {
   transitions: [
     // Scroll between tabs
-    { from: '/home', to: '/about', transition: scroll({ direction: 'up' }) },
-    { from: '/about', to: '/home', transition: scroll({ direction: 'down' }) },
-    
+    { from: "/home", to: "/about", transition: scroll({ direction: "up" }) },
+    { from: "/about", to: "/home", transition: scroll({ direction: "down" }) },
+
     // Drill in when entering details
-    { from: '/products', to: '/products/*', transition: drill({ direction: 'enter' }) },
-    
+    {
+      from: "/products",
+      to: "/products/*",
+      transition: drill({ direction: "enter" }),
+    },
+
     // Pinterest-style image transitions
-    { from: '/gallery', to: '/photo/*', transition: pinterest() }
+    { from: "/gallery", to: "/photo/*", transition: pinterest() },
   ],
-  defaultTransition: fade()
+  defaultTransition: fade(),
 };
 ```
 
@@ -94,7 +96,7 @@ Automatically create bidirectional transitions:
 ```tsx
 {
   from: '/home',
-  to: '/about', 
+  to: '/about',
   transition: scroll({ direction: 'up' }),
   symmetric: true  // Automatically creates reverse transition
 }
@@ -105,18 +107,117 @@ Automatically create bidirectional transitions:
 Animate specific elements during mount/unmount:
 
 ```tsx
-import { transition } from '@ssgoi/react';
-import { fadeIn, slideUp } from '@ssgoi/react/transitions';
+import { transition } from "@ssgoi/react";
+import { fade, slide } from "@ssgoi/react/transitions";
 
 function Card() {
   return (
-    <div ref={transition({
-      key: 'card',
-      in: fadeIn(),
-      out: slideUp()
-    })}>
+    <div
+      ref={transition({
+        key: "card",
+        in: fade(),
+        out: slide({ direction: "up" }),
+      })}
+    >
       <h2>Animated Card</h2>
     </div>
+  );
+}
+```
+
+### Auto Key Plugin
+
+The Auto Key Plugin automatically generates unique keys for your transitions based on the file location (`file:line:column`), eliminating the need to manually provide keys.
+
+**Benefits:**
+
+- **Automatic Key Generation**: No need to manually specify `key` in `transition()` calls
+- **Collision-Free**: Keys are based on exact code location
+- **Cleaner Code**: Less boilerplate in your components
+
+**⚠️ Important**: For list items rendered with `.map()`, just use JSX key prop - the plugin automatically appends it to generate unique keys.
+
+#### Setup with Next.js
+
+```tsx
+// next.config.ts
+import type { NextConfig } from "next";
+import SsgoiAutoKey from "@ssgoi/react/unplugin/webpack";
+
+const nextConfig: NextConfig = {
+  webpack: (config) => {
+    config.plugins.push(SsgoiAutoKey());
+    return config;
+  },
+};
+
+export default nextConfig;
+```
+
+#### Setup with Vite
+
+```ts
+// vite.config.ts
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import SsgoiAutoKey from "@ssgoi/react/unplugin/vite";
+
+export default defineConfig({
+  plugins: [react(), SsgoiAutoKey()],
+});
+```
+
+#### Usage Examples
+
+**WITH Auto Key Plugin (Recommended):**
+
+```tsx
+import { transition } from "@ssgoi/react";
+import { fade, slide } from "@ssgoi/react/transitions";
+
+function SimpleCard() {
+  return (
+    <div ref={transition(fade())}>
+      <h2>Fades in on mount</h2>
+    </div>
+  );
+}
+```
+
+**WITHOUT Auto Key Plugin:**
+
+```tsx
+// Explicit key required for transition state tracking
+function Card() {
+  return (
+    <div
+      ref={transition({
+        key: "my-card",
+        ...fade(),
+      })}
+    >
+      <h2>Animated Card</h2>
+    </div>
+  );
+}
+```
+
+**List Items:**
+
+```tsx
+// In .map() lists, just use JSX key - the plugin appends it automatically
+function List() {
+  return (
+    <ul>
+      {items.map((item) => (
+        <li
+          key={item.id} // JSX key is enough - plugin generates file:line:col:${key}
+          ref={transition(fade())}
+        >
+          {item.name}
+        </li>
+      ))}
+    </ul>
   );
 }
 ```
@@ -125,17 +226,19 @@ function Card() {
 
 ```tsx
 // app/layout.tsx
-import { Ssgoi } from '@ssgoi/react';
-import { scroll } from '@ssgoi/react/view-transitions';
+import { Ssgoi } from "@ssgoi/react";
+import { scroll } from "@ssgoi/react/view-transitions";
 
 export default function RootLayout({ children }) {
   return (
     <html>
       <body>
-        <Ssgoi config={{
-          defaultTransition: scroll({ direction: 'up' })
-        }}>
-          <div style={{ position: 'relative', minHeight: '100vh' }}>
+        <Ssgoi
+          config={{
+            defaultTransition: scroll({ direction: "up" }),
+          }}
+        >
+          <div style={{ position: "relative", minHeight: "100vh" }}>
             {children}
           </div>
         </Ssgoi>
@@ -145,14 +248,10 @@ export default function RootLayout({ children }) {
 }
 
 // app/page.tsx
-import { SsgoiTransition } from '@ssgoi/react';
+import { SsgoiTransition } from "@ssgoi/react";
 
 export default function Page() {
-  return (
-    <SsgoiTransition id="/">
-      {/* Your page content */}
-    </SsgoiTransition>
-  );
+  return <SsgoiTransition id="/">{/* Your page content */}</SsgoiTransition>;
 }
 ```
 
@@ -161,26 +260,25 @@ export default function Page() {
 ### Components
 
 #### `<Ssgoi>`
+
 The provider component that manages transition context.
 
 ```tsx
-<Ssgoi config={ssgoiConfig}>
-  {children}
-</Ssgoi>
+<Ssgoi config={ssgoiConfig}>{children}</Ssgoi>
 ```
 
 #### `<SsgoiTransition>`
+
 Wrapper component for pages that should transition.
 
 ```tsx
-<SsgoiTransition id="/page-id">
-  {children}
-</SsgoiTransition>
+<SsgoiTransition id="/page-id">{children}</SsgoiTransition>
 ```
 
 ### Hooks
 
 #### `useTransition()`
+
 Access transition state and controls.
 
 ```tsx
@@ -190,14 +288,17 @@ const { isTransitioning, direction } = useTransition();
 ### Functions
 
 #### `transition()`
+
 Apply transitions to individual elements.
 
 ```tsx
-<div ref={transition({
-  key: 'unique-key',
-  in: fadeIn(),
-  out: fadeOut()
-})}>
+<div
+  ref={transition({
+    key: "unique-key",
+    in: fade(),
+    out: fade(),
+  })}
+>
   Content
 </div>
 ```
@@ -205,6 +306,7 @@ Apply transitions to individual elements.
 ## Built-in Transitions
 
 ### Page Transitions (`@ssgoi/react/view-transitions`)
+
 - `fade()` - Smooth opacity transition
 - `scroll()` - Vertical scrolling (up/down)
 - `drill()` - Drill in/out effect (enter/exit)
@@ -212,12 +314,14 @@ Apply transitions to individual elements.
 - `pinterest()` - Pinterest-style expand effect
 
 ### Element Transitions (`@ssgoi/react/transitions`)
-- `fadeIn()` / `fadeOut()`
-- `slideUp()` / `slideDown()` / `slideLeft()` / `slideRight()`
-- `scaleIn()` / `scaleOut()`
-- `bounce()`
-- `blur()`
-- `rotate()`
+
+- `fade()` - Fade in/out
+- `scale()` - Scale in/out
+- `slide()` - Slide (direction: up/down/left/right)
+- `rotate()` - Rotate
+- `bounce()` - Bounce
+- `blur()` - Blur
+- `fly()` - Fly (custom x, y position)
 
 ## Spring Physics Configuration
 
@@ -225,12 +329,12 @@ All transitions use spring physics for natural motion:
 
 ```tsx
 slide({
-  direction: 'left',
+  direction: "left",
   spring: {
-    stiffness: 300,  // 1-1000, higher = faster
-    damping: 30      // 0-100, higher = less oscillation
-  }
-})
+    stiffness: 300, // 1-1000, higher = faster
+    damping: 30, // 0-100, higher = less oscillation
+  },
+});
 ```
 
 ## TypeScript Support
@@ -238,7 +342,7 @@ slide({
 SSGOI is written in TypeScript and provides full type definitions:
 
 ```tsx
-import type { SsgoiConfig, TransitionConfig } from '@ssgoi/react';
+import type { SsgoiConfig, TransitionConfig } from "@ssgoi/react";
 
 const config: SsgoiConfig = {
   // Full type safety
@@ -262,6 +366,7 @@ const config: SsgoiConfig = {
 ## Documentation
 
 Visit [https://ssgoi.dev](https://ssgoi.dev) for:
+
 - Complete API reference
 - Interactive examples
 - Advanced patterns

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/react",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "description": "React bindings for SSGOI - Native app-like page transitions for React applications",
   "private": false,
   "type": "module",

--- a/packages/react/src/lib/transition.ts
+++ b/packages/react/src/lib/transition.ts
@@ -38,7 +38,8 @@ export const transition = (options: TransitionOptions) => {
     throw new Error(
       "[ssgoi] transition() requires a 'key' property. " +
         "Either provide it manually or use plugin for auto-injection. " +
-        "import plugin from @ssgoi/react/unplugin/webpack; ",
+        "import plugin from @ssgoi/react/unplugin/webpack; " +
+        "see: https://ssgoi.dev/en/docs/core-concepts/react-plugin",
     );
   }
 

--- a/packages/svelte/README.md
+++ b/packages/svelte/README.md
@@ -129,14 +129,14 @@ Animate specific elements during mount/unmount:
 ```svelte
 <script>
   import { transition } from "@ssgoi/svelte";
-  import { fadeIn, slideUp } from "@ssgoi/svelte/transitions";
+  import { fade, slide } from "@ssgoi/svelte/transitions";
 </script>
 
 <div
   use:transition={{
     key: "card",
-    in: fadeIn(),
-    out: slideUp(),
+    in: fade(),
+    out: slide({ direction: 'up' }),
   }}
 >
   <h2>Animated Card</h2>
@@ -210,8 +210,8 @@ Apply transitions to individual elements.
 <div
   use:transition={{
     key: "unique-key",
-    in: fadeIn(),
-    out: fadeOut(),
+    in: fade(),
+    out: fade(),
   }}
 >
   Content
@@ -246,9 +246,9 @@ Access transition state.
 
 ### Element Transitions (`@ssgoi/svelte/transitions`)
 
-- `fadeIn()` / `fadeOut()`
-- `slideUp()` / `slideDown()` / `slideLeft()` / `slideRight()`
-- `scaleIn()` / `scaleOut()`
+- `fade()`
+- `slide({ direction: 'up' | 'down' | 'left' | 'right' })`
+- `scale()`
 - `bounce()`
 - `blur()`
 - `rotate()`

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -115,8 +115,8 @@ Animate specific elements during mount/unmount:
 <template>
   <div v-transition="{
     key: 'card',
-    in: fadeIn(),
-    out: slideUp()
+    in: fade(),
+    out: slide({ direction: 'up' })
   }">
     <h2>Animated Card</h2>
   </div>
@@ -124,7 +124,7 @@ Animate specific elements during mount/unmount:
 
 <script setup>
 import { vTransition as vTransitionDirective } from '@ssgoi/vue';
-import { fadeIn, slideUp } from '@ssgoi/vue/transitions';
+import { fade, slide } from '@ssgoi/vue/transitions';
 
 // Local directive registration
 const vTransition = vTransitionDirective;
@@ -157,7 +157,7 @@ app.mount('#app');
 <script setup>
 import { ref, onMounted, onUnmounted } from 'vue';
 import { transition } from '@ssgoi/vue';
-import { fadeIn, slideUp } from '@ssgoi/vue/transitions';
+import { fade, slide } from '@ssgoi/vue/transitions';
 
 const cardRef = ref();
 let cleanup;
@@ -165,8 +165,8 @@ let cleanup;
 onMounted(() => {
   cleanup = transition({
     key: 'card',
-    in: fadeIn(),
-    out: slideUp()
+    in: fade(),
+    out: slide({ direction: 'up' })
   })(cardRef.value);
 });
 
@@ -256,8 +256,8 @@ Apply transitions to individual elements.
 ```vue
 <div v-transition="{
   key: 'unique-key',
-  in: fadeIn(),
-  out: fadeOut()
+  in: fade(),
+  out: fade()
 }">
   Content
 </div>
@@ -271,8 +271,8 @@ Apply transitions programmatically.
 ```javascript
 const cleanup = transition({
   key: 'unique-key',
-  in: fadeIn(),
-  out: fadeOut()
+  in: fade(),
+  out: fade()
 })(element);
 ```
 
@@ -286,12 +286,12 @@ const cleanup = transition({
 - `pinterest()` - Pinterest-style expand effect
 
 ### Element Transitions (`@ssgoi/vue/transitions`)
-- `fadeIn()` / `fadeOut()`
-- `slideUp()` / `slideDown()` / `slideLeft()` / `slideRight()`
-- `scaleIn()` / `scaleOut()`
-- `bounce()`
-- `blur()`
-- `rotate()`
+- `fade()` - Fade in/out effect
+- `slide({ direction })` - Slide animation with direction: 'up', 'down', 'left', 'right'
+- `scale()` - Scale in/out effect
+- `bounce()` - Bounce animation
+- `blur()` - Blur effect
+- `rotate()` - Rotation animation
 
 ## Spring Physics Configuration
 


### PR DESCRIPTION
## Summary

- Add dedicated React Plugin documentation page (ko/en/ja/zh)
- Fix incorrect transition API names across all READMEs
- Update Auto Key Plugin usage examples
- Clarify JSX key handling for `.map()` lists

## Changes

### New Documentation
- `apps/docs/content/*/02.core-concepts/04.react-plugin.mdx` - Comprehensive React Auto Key Plugin guide

### Fixed API Names
- `fadeIn()`/`fadeOut()` → `fade()`
- `slideUp()`/`slideDown()` → `slide({ direction: 'up'|'down' })`
- `scaleIn()`/`scaleOut()` → `scale()`

### Updated READMEs
- Root README.md
- packages/react/README.md
- packages/svelte/README.md
- packages/vue/README.md
- packages/angular/README.md
- packages/core/README.md

### Key Clarifications
- With plugin: key can be omitted
- Without plugin: explicit key required
- In `.map()` lists: JSX key is sufficient (plugin auto-appends)

🤖 Generated with [Claude Code](https://claude.com/claude-code)