### PR TITLE
feat(docs): add clickable center content navigation for view transition demos

### DIFF
--- a/apps/docs/src/components/mdx/mdx-components/view-transition-demo/blind-demo.tsx
+++ b/apps/docs/src/components/mdx/mdx-components/view-transition-demo/blind-demo.tsx
@@ -3,10 +3,24 @@
 import React, { memo, useState } from "react";
 import Image from "next/image";
 import { blind } from "@ssgoi/react/view-transitions";
-import { BrowserContext, BrowserMockup, DemoPage } from "../browser-mockup";
+import {
+  BrowserContext,
+  BrowserMockup,
+  DemoPage,
+  useBrowserNavigation,
+} from "../browser-mockup";
 import type { RouteConfig } from "../browser-mockup";
 import { cn } from "../../../../lib/utils";
 import { useMobile } from "../../../../lib/use-mobile";
+
+// Helper to get next route path
+function useNextRoute() {
+  const { currentPath, navigate, routes } = useBrowserNavigation();
+  const currentIndex = routes.findIndex((r) => r.path === currentPath);
+  const nextIndex = (currentIndex + 1) % routes.length;
+  const nextPath = routes[nextIndex]?.path || routes[0]?.path;
+  return { navigateNext: () => navigate(nextPath) };
+}
 
 // Image data - cinematic theme
 const images = {
@@ -19,6 +33,7 @@ const images = {
 // Opening Scene
 function OpeningPage() {
   const isMobile = useMobile();
+  const { navigateNext } = useNextRoute();
 
   return (
     <DemoPage path="/blind" className="relative h-full overflow-hidden">
@@ -37,13 +52,19 @@ function OpeningPage() {
 
       {/* Content - centered */}
       <div className="relative h-full flex items-center justify-center">
-        <div className={cn("text-center", isMobile ? "px-6" : "px-12")}>
-          <p className="text-white/50 text-xs uppercase tracking-[0.3em] mb-4">
+        <button
+          onClick={navigateNext}
+          className={cn(
+            "text-center group cursor-pointer transition-transform duration-300 hover:scale-[1.02]",
+            isMobile ? "px-6" : "px-12",
+          )}
+        >
+          <p className="text-white/50 text-xs uppercase tracking-[0.3em] mb-4 group-hover:text-white/70 transition-colors">
             The curtain rises
           </p>
           <h1
             className={cn(
-              "font-light text-white leading-[0.9] tracking-tight",
+              "font-light text-white leading-[0.9] tracking-tight group-hover:text-white transition-colors",
               isMobile ? "text-4xl" : "text-6xl",
             )}
           >
@@ -53,13 +74,13 @@ function OpeningPage() {
           </h1>
           <p
             className={cn(
-              "text-white/60 mt-6 max-w-md mx-auto leading-relaxed",
+              "text-white/60 mt-6 max-w-md mx-auto leading-relaxed group-hover:text-white/80 transition-colors",
               isMobile ? "text-sm" : "text-base",
             )}
           >
             Like theater blinds revealing a new scene
           </p>
-        </div>
+        </button>
       </div>
     </DemoPage>
   );
@@ -68,6 +89,7 @@ function OpeningPage() {
 // Act I - The Drama
 function Act1Page() {
   const isMobile = useMobile();
+  const { navigateNext } = useNextRoute();
 
   return (
     <DemoPage path="/blind/act1" className="relative h-full overflow-hidden">
@@ -85,13 +107,19 @@ function Act1Page() {
 
       {/* Content - centered */}
       <div className="relative h-full flex items-center justify-center">
-        <div className={cn("text-center", isMobile ? "px-6" : "px-12")}>
-          <p className="text-white/50 text-xs uppercase tracking-[0.3em] mb-4">
+        <button
+          onClick={navigateNext}
+          className={cn(
+            "text-center group cursor-pointer transition-transform duration-300 hover:scale-[1.02]",
+            isMobile ? "px-6" : "px-12",
+          )}
+        >
+          <p className="text-white/50 text-xs uppercase tracking-[0.3em] mb-4 group-hover:text-white/70 transition-colors">
             Act I
           </p>
           <h1
             className={cn(
-              "font-light text-white leading-[0.9] tracking-tight",
+              "font-light text-white leading-[0.9] tracking-tight group-hover:text-white transition-colors",
               isMobile ? "text-4xl" : "text-6xl",
             )}
           >
@@ -102,19 +130,19 @@ function Act1Page() {
           {/* Stats */}
           <div className="flex justify-center gap-8 mt-8">
             <div>
-              <p className="text-white/40 text-xs uppercase tracking-wider">
+              <p className="text-white/40 text-xs uppercase tracking-wider group-hover:text-white/60 transition-colors">
                 Strips
               </p>
               <p className="text-white text-2xl font-light">10</p>
             </div>
             <div>
-              <p className="text-white/40 text-xs uppercase tracking-wider">
+              <p className="text-white/40 text-xs uppercase tracking-wider group-hover:text-white/60 transition-colors">
                 Direction
               </p>
               <p className="text-white text-2xl font-light">Horizontal</p>
             </div>
           </div>
-        </div>
+        </button>
       </div>
     </DemoPage>
   );
@@ -123,6 +151,7 @@ function Act1Page() {
 // Act II - The Mystery
 function Act2Page() {
   const isMobile = useMobile();
+  const { navigateNext } = useNextRoute();
 
   return (
     <DemoPage path="/blind/act2" className="relative h-full overflow-hidden">
@@ -140,13 +169,19 @@ function Act2Page() {
 
       {/* Content - centered */}
       <div className="relative h-full flex items-center justify-center">
-        <div className={cn("text-center", isMobile ? "px-6" : "px-12")}>
-          <p className="text-white/50 text-xs uppercase tracking-[0.3em] mb-4">
+        <button
+          onClick={navigateNext}
+          className={cn(
+            "text-center group cursor-pointer transition-transform duration-300 hover:scale-[1.02]",
+            isMobile ? "px-6" : "px-12",
+          )}
+        >
+          <p className="text-white/50 text-xs uppercase tracking-[0.3em] mb-4 group-hover:text-white/70 transition-colors">
             Act II
           </p>
           <h1
             className={cn(
-              "font-light text-white leading-[0.9] tracking-tight",
+              "font-light text-white leading-[0.9] tracking-tight group-hover:text-white transition-colors",
               isMobile ? "text-4xl" : "text-6xl",
             )}
           >
@@ -154,10 +189,10 @@ function Act2Page() {
             <br />
             <span className="font-semibold">Mystery</span>
           </h1>
-          <p className="text-white/50 text-sm mt-8">
+          <p className="text-white/50 text-sm mt-8 group-hover:text-white/70 transition-colors">
             Tension builds with each strip
           </p>
-        </div>
+        </button>
       </div>
     </DemoPage>
   );
@@ -166,6 +201,7 @@ function Act2Page() {
 // Finale
 function FinalePage() {
   const isMobile = useMobile();
+  const { navigateNext } = useNextRoute();
 
   return (
     <DemoPage path="/blind/finale" className="relative h-full overflow-hidden">
@@ -183,13 +219,16 @@ function FinalePage() {
 
       {/* Content - center */}
       <div className="relative h-full flex items-center justify-center text-center">
-        <div className="p-6">
-          <p className="text-white/50 text-xs uppercase tracking-[0.3em] mb-4">
+        <button
+          onClick={navigateNext}
+          className="p-6 group cursor-pointer transition-transform duration-300 hover:scale-[1.02]"
+        >
+          <p className="text-white/50 text-xs uppercase tracking-[0.3em] mb-4 group-hover:text-white/70 transition-colors">
             The grand finale
           </p>
           <h1
             className={cn(
-              "font-light text-white leading-[0.9] tracking-tight",
+              "font-light text-white leading-[0.9] tracking-tight group-hover:text-white transition-colors",
               isMobile ? "text-4xl" : "text-7xl",
             )}
           >
@@ -199,13 +238,13 @@ function FinalePage() {
           </h1>
           <p
             className={cn(
-              "text-white/60 mt-8 max-w-sm mx-auto",
+              "text-white/60 mt-8 max-w-sm mx-auto group-hover:text-white/80 transition-colors",
               isMobile ? "text-sm" : "text-base",
             )}
           >
             Every transition tells a story. Every reveal holds magic.
           </p>
-        </div>
+        </button>
       </div>
     </DemoPage>
   );

--- a/apps/docs/src/components/mdx/mdx-components/view-transition-demo/fade-demo.tsx
+++ b/apps/docs/src/components/mdx/mdx-components/view-transition-demo/fade-demo.tsx
@@ -3,10 +3,24 @@
 import React, { memo, useState } from "react";
 import Image from "next/image";
 import { fade } from "@ssgoi/react/view-transitions";
-import { BrowserContext, BrowserMockup, DemoPage } from "../browser-mockup";
+import {
+  BrowserContext,
+  BrowserMockup,
+  DemoPage,
+  useBrowserNavigation,
+} from "../browser-mockup";
 import type { RouteConfig } from "../browser-mockup";
 import { cn } from "../../../../lib/utils";
 import { useMobile } from "../../../../lib/use-mobile";
+
+// Helper to get next route path
+function useNextRoute() {
+  const { currentPath, navigate, routes } = useBrowserNavigation();
+  const currentIndex = routes.findIndex((r) => r.path === currentPath);
+  const nextIndex = (currentIndex + 1) % routes.length;
+  const nextPath = routes[nextIndex]?.path || routes[0]?.path;
+  return { navigateNext: () => navigate(nextPath) };
+}
 
 // Image data
 const images = {
@@ -21,6 +35,7 @@ const images = {
 // Page 1: Hero with mountain
 function HeroPage() {
   const isMobile = useMobile();
+  const { navigateNext } = useNextRoute();
 
   return (
     <DemoPage path="/fade" className="relative h-full overflow-hidden">
@@ -39,13 +54,19 @@ function HeroPage() {
 
       {/* Content - centered */}
       <div className="relative h-full flex items-center justify-center">
-        <div className={cn("text-center", isMobile ? "px-6" : "px-12")}>
-          <p className="text-white/60 text-xs uppercase tracking-[0.3em] mb-4">
+        <button
+          onClick={navigateNext}
+          className={cn(
+            "text-center group cursor-pointer transition-transform duration-300 hover:scale-[1.02]",
+            isMobile ? "px-6" : "px-12",
+          )}
+        >
+          <p className="text-white/60 text-xs uppercase tracking-[0.3em] mb-4 group-hover:text-white/80 transition-colors">
             Explore the world
           </p>
           <h1
             className={cn(
-              "font-light text-white leading-[0.9] tracking-tight",
+              "font-light text-white leading-[0.9] tracking-tight group-hover:text-white transition-colors",
               isMobile ? "text-4xl" : "text-6xl",
             )}
           >
@@ -55,13 +76,13 @@ function HeroPage() {
           </h1>
           <p
             className={cn(
-              "text-white/70 mt-6 max-w-md mx-auto leading-relaxed",
+              "text-white/70 mt-6 max-w-md mx-auto leading-relaxed group-hover:text-white/90 transition-colors",
               isMobile ? "text-sm" : "text-base",
             )}
           >
             Discover breathtaking landscapes and unforgettable adventures.
           </p>
-        </div>
+        </button>
       </div>
     </DemoPage>
   );
@@ -70,6 +91,7 @@ function HeroPage() {
 // Page 2: Ocean waves
 function OceanPage() {
   const isMobile = useMobile();
+  const { navigateNext } = useNextRoute();
 
   return (
     <DemoPage path="/fade/ocean" className="relative h-full overflow-hidden">
@@ -87,13 +109,19 @@ function OceanPage() {
 
       {/* Content - centered */}
       <div className="relative h-full flex items-center justify-center">
-        <div className={cn("text-center", isMobile ? "px-6" : "px-12")}>
-          <p className="text-white/60 text-xs uppercase tracking-[0.3em] mb-4">
+        <button
+          onClick={navigateNext}
+          className={cn(
+            "text-center group cursor-pointer transition-transform duration-300 hover:scale-[1.02]",
+            isMobile ? "px-6" : "px-12",
+          )}
+        >
+          <p className="text-white/60 text-xs uppercase tracking-[0.3em] mb-4 group-hover:text-white/80 transition-colors">
             Feel the rhythm
           </p>
           <h1
             className={cn(
-              "font-light text-white leading-[0.9] tracking-tight",
+              "font-light text-white leading-[0.9] tracking-tight group-hover:text-white transition-colors",
               isMobile ? "text-4xl" : "text-6xl",
             )}
           >
@@ -104,19 +132,19 @@ function OceanPage() {
           {/* Stats */}
           <div className="flex justify-center gap-8 mt-8">
             <div>
-              <p className="text-white/40 text-xs uppercase tracking-wider">
+              <p className="text-white/40 text-xs uppercase tracking-wider group-hover:text-white/60 transition-colors">
                 Depth
               </p>
               <p className="text-white text-2xl font-light">3.7km</p>
             </div>
             <div>
-              <p className="text-white/40 text-xs uppercase tracking-wider">
+              <p className="text-white/40 text-xs uppercase tracking-wider group-hover:text-white/60 transition-colors">
                 Temperature
               </p>
               <p className="text-white text-2xl font-light">18°C</p>
             </div>
           </div>
-        </div>
+        </button>
       </div>
     </DemoPage>
   );
@@ -125,6 +153,7 @@ function OceanPage() {
 // Page 3: Forest path
 function ForestPage() {
   const isMobile = useMobile();
+  const { navigateNext } = useNextRoute();
 
   return (
     <DemoPage path="/fade/forest" className="relative h-full overflow-hidden">
@@ -142,13 +171,19 @@ function ForestPage() {
 
       {/* Content - centered */}
       <div className="relative h-full flex items-center justify-center">
-        <div className={cn("text-center", isMobile ? "px-6" : "px-12")}>
-          <p className="text-white/60 text-xs uppercase tracking-[0.3em] mb-4">
+        <button
+          onClick={navigateNext}
+          className={cn(
+            "text-center group cursor-pointer transition-transform duration-300 hover:scale-[1.02]",
+            isMobile ? "px-6" : "px-12",
+          )}
+        >
+          <p className="text-white/60 text-xs uppercase tracking-[0.3em] mb-4 group-hover:text-white/80 transition-colors">
             Find your path
           </p>
           <h1
             className={cn(
-              "font-light text-white leading-[0.9] tracking-tight",
+              "font-light text-white leading-[0.9] tracking-tight group-hover:text-white transition-colors",
               isMobile ? "text-4xl" : "text-6xl",
             )}
           >
@@ -156,8 +191,10 @@ function ForestPage() {
             <br />
             <span className="font-semibold">Nature</span>
           </h1>
-          <p className="text-white/50 text-sm mt-8">Click to explore</p>
-        </div>
+          <p className="text-white/50 text-sm mt-8 group-hover:text-white/70 transition-colors">
+            Click to explore
+          </p>
+        </button>
       </div>
     </DemoPage>
   );
@@ -166,6 +203,7 @@ function ForestPage() {
 // Page 4: Road trip
 function RoadPage() {
   const isMobile = useMobile();
+  const { navigateNext } = useNextRoute();
 
   return (
     <DemoPage path="/fade/road" className="relative h-full overflow-hidden">
@@ -183,13 +221,16 @@ function RoadPage() {
 
       {/* Content - center */}
       <div className="relative h-full flex items-center justify-center text-center">
-        <div className="p-6">
-          <p className="text-white/60 text-xs uppercase tracking-[0.3em] mb-4">
+        <button
+          onClick={navigateNext}
+          className="p-6 group cursor-pointer transition-transform duration-300 hover:scale-[1.02]"
+        >
+          <p className="text-white/60 text-xs uppercase tracking-[0.3em] mb-4 group-hover:text-white/80 transition-colors">
             The journey begins
           </p>
           <h1
             className={cn(
-              "font-light text-white leading-[0.9] tracking-tight",
+              "font-light text-white leading-[0.9] tracking-tight group-hover:text-white transition-colors",
               isMobile ? "text-4xl" : "text-7xl",
             )}
           >
@@ -199,13 +240,13 @@ function RoadPage() {
           </h1>
           <p
             className={cn(
-              "text-white/60 mt-8 max-w-sm mx-auto",
+              "text-white/60 mt-8 max-w-sm mx-auto group-hover:text-white/80 transition-colors",
               isMobile ? "text-sm" : "text-base",
             )}
           >
             Every mile tells a story. Every horizon holds a promise.
           </p>
-        </div>
+        </button>
       </div>
     </DemoPage>
   );

--- a/apps/docs/src/components/mdx/mdx-components/view-transition-demo/strip-demo.tsx
+++ b/apps/docs/src/components/mdx/mdx-components/view-transition-demo/strip-demo.tsx
@@ -2,14 +2,29 @@
 
 import React, { memo } from "react";
 import { strip } from "@ssgoi/react/view-transitions";
-import { BrowserContext, BrowserMockup, DemoPage } from "../browser-mockup";
+import {
+  BrowserContext,
+  BrowserMockup,
+  DemoPage,
+  useBrowserNavigation,
+} from "../browser-mockup";
 import type { RouteConfig } from "../browser-mockup";
 import { cn } from "../../../../lib/utils";
 import { useMobile } from "../../../../lib/use-mobile";
 
+// Helper to get next route path
+function useNextRoute() {
+  const { currentPath, navigate, routes } = useBrowserNavigation();
+  const currentIndex = routes.findIndex((r) => r.path === currentPath);
+  const nextIndex = (currentIndex + 1) % routes.length;
+  const nextPath = routes[nextIndex]?.path || routes[0]?.path;
+  return { navigateNext: () => navigate(nextPath) };
+}
+
 // Page 1 - Bold Typography
 function SpeakingPage() {
   const isMobile = useMobile();
+  const { navigateNext } = useNextRoute();
 
   return (
     <DemoPage path="/strip" className="bg-[#121212] min-h-full">
@@ -19,19 +34,22 @@ function SpeakingPage() {
           isMobile ? "px-6 py-12" : "max-w-6xl px-8 py-20",
         )}
       >
-        <div className="space-y-6">
+        <button
+          onClick={navigateNext}
+          className="space-y-6 text-left group cursor-pointer transition-transform duration-300 hover:scale-[1.01]"
+        >
           <h1
             className={cn(
               "font-light leading-none",
               isMobile ? "text-5xl" : "text-[8rem]",
-              "text-neutral-100 tracking-tight",
+              "text-neutral-100 tracking-tight group-hover:text-white transition-colors",
             )}
           >
             SPEAKING
           </h1>
           <p
             className={cn(
-              "text-neutral-400",
+              "text-neutral-400 group-hover:text-neutral-300 transition-colors",
               isMobile ? "text-sm max-w-sm" : "text-base max-w-2xl",
             )}
           >
@@ -39,14 +57,14 @@ function SpeakingPage() {
             inspire.
           </p>
           <div className="flex gap-3 pt-4">
-            <button className="px-5 py-2.5 bg-white text-neutral-900 text-sm rounded-full hover:bg-neutral-200 transition-colors">
+            <span className="px-5 py-2.5 bg-white text-neutral-900 text-sm rounded-full group-hover:bg-neutral-200 transition-colors">
               Start Now
-            </button>
-            <button className="px-5 py-2.5 bg-white/5 text-neutral-300 text-sm border border-white/10 rounded-full hover:bg-white/10 transition-colors">
+            </span>
+            <span className="px-5 py-2.5 bg-white/5 text-neutral-300 text-sm border border-white/10 rounded-full group-hover:bg-white/10 transition-colors">
               Learn More
-            </button>
+            </span>
           </div>
-        </div>
+        </button>
       </div>
     </DemoPage>
   );
@@ -55,6 +73,7 @@ function SpeakingPage() {
 // Page 2 - Creative Layout
 function CreatingPage() {
   const isMobile = useMobile();
+  const { navigateNext } = useNextRoute();
 
   return (
     <DemoPage path="/strip/creating" className="bg-[#121212] min-h-full">
@@ -64,13 +83,16 @@ function CreatingPage() {
           isMobile ? "px-6 py-12" : "px-8 py-20",
         )}
       >
-        <div className="text-center space-y-10">
+        <button
+          onClick={navigateNext}
+          className="text-center space-y-10 group cursor-pointer transition-transform duration-300 hover:scale-[1.01]"
+        >
           <div className="relative">
             <h1
               className={cn(
                 "font-light",
                 isMobile ? "text-5xl" : "text-[8rem]",
-                "text-neutral-100",
+                "text-neutral-100 group-hover:text-white transition-colors",
                 "tracking-tight leading-none",
               )}
             >
@@ -81,28 +103,34 @@ function CreatingPage() {
           <div className="grid grid-cols-3 gap-6 max-w-3xl mx-auto">
             <div className="text-center">
               <div className="text-2xl mb-2">✨</div>
-              <p className="text-neutral-400 text-xs">Innovate</p>
+              <p className="text-neutral-400 text-xs group-hover:text-neutral-300 transition-colors">
+                Innovate
+              </p>
             </div>
             <div className="text-center">
               <div className="text-2xl mb-2">🎯</div>
-              <p className="text-neutral-400 text-xs">Execute</p>
+              <p className="text-neutral-400 text-xs group-hover:text-neutral-300 transition-colors">
+                Execute
+              </p>
             </div>
             <div className="text-center">
               <div className="text-2xl mb-2">🚀</div>
-              <p className="text-neutral-400 text-xs">Launch</p>
+              <p className="text-neutral-400 text-xs group-hover:text-neutral-300 transition-colors">
+                Launch
+              </p>
             </div>
           </div>
 
           <p
             className={cn(
-              "text-neutral-400 max-w-xl mx-auto",
+              "text-neutral-400 max-w-xl mx-auto group-hover:text-neutral-300 transition-colors",
               isMobile ? "text-sm" : "text-base",
             )}
           >
             Where imagination meets execution. Build something extraordinary
             today.
           </p>
-        </div>
+        </button>
       </div>
     </DemoPage>
   );
@@ -111,6 +139,7 @@ function CreatingPage() {
 // Page 3 - Minimal Impact
 function ImpactPage() {
   const isMobile = useMobile();
+  const { navigateNext } = useNextRoute();
 
   return (
     <DemoPage path="/strip/impact" className="bg-[#121212] min-h-full">
@@ -120,16 +149,19 @@ function ImpactPage() {
           isMobile ? "px-6 py-12" : "px-8 py-20",
         )}
       >
-        <div className="space-y-12">
+        <button
+          onClick={navigateNext}
+          className="space-y-12 text-left group cursor-pointer transition-transform duration-300 hover:scale-[1.01]"
+        >
           <div>
-            <p className="text-neutral-500 text-xs uppercase tracking-wider mb-4">
+            <p className="text-neutral-500 text-xs uppercase tracking-wider mb-4 group-hover:text-neutral-400 transition-colors">
               Make a Difference
             </p>
             <h1
               className={cn(
                 "font-light",
                 isMobile ? "text-5xl" : "text-[7rem]",
-                "text-neutral-100 leading-none tracking-tight",
+                "text-neutral-100 leading-none tracking-tight group-hover:text-white transition-colors",
               )}
             >
               IMPACT
@@ -137,22 +169,28 @@ function ImpactPage() {
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            <div className="border-l border-white/20 pl-5">
+            <div className="border-l border-white/20 pl-5 group-hover:border-white/40 transition-colors">
               <h3 className="text-neutral-100 font-medium text-xl mb-1">
                 100M+
               </h3>
-              <p className="text-neutral-500 text-xs">Lives Changed</p>
+              <p className="text-neutral-500 text-xs group-hover:text-neutral-400 transition-colors">
+                Lives Changed
+              </p>
             </div>
-            <div className="border-l border-white/20 pl-5">
+            <div className="border-l border-white/20 pl-5 group-hover:border-white/40 transition-colors">
               <h3 className="text-neutral-100 font-medium text-xl mb-1">50+</h3>
-              <p className="text-neutral-500 text-xs">Countries Reached</p>
+              <p className="text-neutral-500 text-xs group-hover:text-neutral-400 transition-colors">
+                Countries Reached
+              </p>
             </div>
-            <div className="border-l border-white/20 pl-5">
+            <div className="border-l border-white/20 pl-5 group-hover:border-white/40 transition-colors">
               <h3 className="text-neutral-100 font-medium text-xl mb-1">∞</h3>
-              <p className="text-neutral-500 text-xs">Possibilities</p>
+              <p className="text-neutral-500 text-xs group-hover:text-neutral-400 transition-colors">
+                Possibilities
+              </p>
             </div>
           </div>
-        </div>
+        </button>
       </div>
     </DemoPage>
   );


### PR DESCRIPTION
## Summary
- Add clickable center content area to fade, strip, and blind view transition demos
- Enable users to navigate to the next page by clicking the main content (titles, descriptions)
- Include subtle hover effects (scale animation, opacity transitions) for better UX
- Implement circular navigation using `useNextRoute` helper hook

## Test plan
- [ ] Verify fade demo center content is clickable and navigates to next page
- [ ] Verify strip demo center content is clickable and navigates to next page
- [ ] Verify blind demo center content is clickable and navigates to next page
- [ ] Confirm hover effects are visible and subtle
- [ ] Test on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)