### PR TITLE
feat(core): add doubleSpring option to all element transitions

### DIFF
--- a/apps/docs/src/components/home/element-transition-section.tsx
+++ b/apps/docs/src/components/home/element-transition-section.tsx
@@ -12,6 +12,7 @@ import {
 } from "@ssgoi/react/transitions";
 import { CodeBlock } from "@/components/ui/code-block";
 import { useTranslations } from "@/i18n/use-translations";
+import { SpringConfig } from "@ssgoi/core/types";
 
 type TransitionType = "fade" | "scale" | "slide" | "rotate" | "blur" | "bounce";
 
@@ -112,6 +113,12 @@ const codeExamples: Record<TransitionType, string> = {
 </div>`,
 };
 
+const spring: SpringConfig = {
+  stiffness: 300,
+  damping: 30,
+  doubleSpring: true,
+};
+
 export function ElementTransitionSection() {
   const [show, setShow] = useState(true);
   const [activeCode, setActiveCode] = useState<TransitionType>("scale");
@@ -138,7 +145,7 @@ export function ElementTransitionSection() {
           <div className="w-10 h-10 flex items-center justify-center">
             {show && (
               <div
-                ref={transition({ key: "demo-fade", ...fade() })}
+                ref={transition({ key: "demo-fade", ...fade({ spring }) })}
                 className="w-10 h-10 bg-white rounded-lg"
               />
             )}
@@ -146,7 +153,7 @@ export function ElementTransitionSection() {
           <div className="w-10 h-10 flex items-center justify-center">
             {show && (
               <div
-                ref={transition({ key: "demo-scale", ...scale() })}
+                ref={transition({ key: "demo-scale", ...scale({ spring }) })}
                 className="w-10 h-10 bg-emerald-500 rounded-lg"
               />
             )}
@@ -156,7 +163,7 @@ export function ElementTransitionSection() {
               <div
                 ref={transition({
                   key: "demo-slide",
-                  ...slide({ direction: "up" }),
+                  ...slide({ direction: "up", spring }),
                 })}
                 className="w-10 h-10 bg-blue-500 rounded-lg"
               />
@@ -165,7 +172,7 @@ export function ElementTransitionSection() {
           <div className="w-10 h-10 flex items-center justify-center">
             {show && (
               <div
-                ref={transition({ key: "demo-rotate", ...rotate() })}
+                ref={transition({ key: "demo-rotate", ...rotate({ spring }) })}
                 className="w-10 h-10 bg-amber-500 rounded-lg"
               />
             )}
@@ -173,7 +180,7 @@ export function ElementTransitionSection() {
           <div className="w-10 h-10 flex items-center justify-center">
             {show && (
               <div
-                ref={transition({ key: "demo-blur", ...blur() })}
+                ref={transition({ key: "demo-blur", ...blur({ spring }) })}
                 className="w-10 h-10 bg-purple-500 rounded-lg"
               />
             )}
@@ -181,7 +188,7 @@ export function ElementTransitionSection() {
           <div className="w-10 h-10 flex items-center justify-center">
             {show && (
               <div
-                ref={transition({ key: "demo-bounce", ...bounce() })}
+                ref={transition({ key: "demo-bounce", ...bounce({ spring }) })}
                 className="w-10 h-10 bg-pink-500 rounded-lg"
               />
             )}

--- a/packages/core/src/lib/transitions/blur.ts
+++ b/packages/core/src/lib/transitions/blur.ts
@@ -1,14 +1,16 @@
-import type { StyleObject, Transition, TransitionKey } from "../types";
+import type {
+  SpringConfig,
+  StyleObject,
+  Transition,
+  TransitionKey,
+} from "../types";
 
 interface BlurOptions {
   amount?: number | string;
   opacity?: number;
   scale?: boolean;
   fade?: boolean;
-  spring?: {
-    stiffness?: number;
-    damping?: number;
-  };
+  spring?: Partial<SpringConfig>;
   key?: TransitionKey;
 }
 
@@ -22,9 +24,10 @@ export const blur = (options: BlurOptions = {}): Transition => {
     key,
   } = options;
 
-  const spring = {
+  const spring: SpringConfig = {
     stiffness: springOption?.stiffness ?? 300,
     damping: springOption?.damping ?? 30,
+    doubleSpring: springOption?.doubleSpring ?? false,
   };
 
   const getCss = (progress: number): StyleObject => {

--- a/packages/core/src/lib/transitions/bounce.ts
+++ b/packages/core/src/lib/transitions/bounce.ts
@@ -1,4 +1,9 @@
-import type { StyleObject, Transition, TransitionKey } from "../types";
+import type {
+  SpringConfig,
+  StyleObject,
+  Transition,
+  TransitionKey,
+} from "../types";
 
 interface BounceOptions {
   height?: number;
@@ -6,10 +11,7 @@ interface BounceOptions {
   scale?: boolean;
   fade?: boolean;
   direction?: "up" | "down";
-  spring?: {
-    stiffness?: number;
-    damping?: number;
-  };
+  spring?: Partial<SpringConfig>;
   key?: TransitionKey;
 }
 
@@ -24,9 +26,10 @@ export const bounce = (options: BounceOptions = {}): Transition => {
     key,
   } = options;
 
-  const spring = {
+  const spring: SpringConfig = {
     stiffness: springOption?.stiffness ?? 800,
     damping: springOption?.damping ?? 15,
+    doubleSpring: springOption?.doubleSpring ?? false,
   };
 
   const getCss = (progress: number): StyleObject => {

--- a/packages/core/src/lib/transitions/fade.ts
+++ b/packages/core/src/lib/transitions/fade.ts
@@ -1,21 +1,24 @@
-import type { StyleObject, Transition, TransitionKey } from "../types";
+import type {
+  SpringConfig,
+  StyleObject,
+  Transition,
+  TransitionKey,
+} from "../types";
 
 interface FadeOptions {
   from?: number;
   to?: number;
-  spring?: {
-    stiffness?: number;
-    damping?: number;
-  };
+  spring?: Partial<SpringConfig>;
   key?: TransitionKey;
 }
 
 export const fade = (options: FadeOptions = {}): Transition => {
   const { from = 0, to = 1, spring: springOption, key } = options;
 
-  const spring = {
+  const spring: SpringConfig = {
     stiffness: springOption?.stiffness ?? 300,
     damping: springOption?.damping ?? 30,
+    doubleSpring: springOption?.doubleSpring ?? false,
   };
 
   return {

--- a/packages/core/src/lib/transitions/fly.ts
+++ b/packages/core/src/lib/transitions/fly.ts
@@ -1,22 +1,25 @@
-import type { StyleObject, Transition, TransitionKey } from "../types";
+import type {
+  SpringConfig,
+  StyleObject,
+  Transition,
+  TransitionKey,
+} from "../types";
 
 interface FlyOptions {
   x?: number | string;
   y?: number | string;
   opacity?: number;
-  spring?: {
-    stiffness?: number;
-    damping?: number;
-  };
+  spring?: Partial<SpringConfig>;
   key?: TransitionKey;
 }
 
 export const fly = (options: FlyOptions = {}): Transition => {
   const { x = 0, y = -100, opacity = 0, spring: springOption, key } = options;
 
-  const spring = {
+  const spring: SpringConfig = {
     stiffness: springOption?.stiffness ?? 400,
     damping: springOption?.damping ?? 35,
+    doubleSpring: springOption?.doubleSpring ?? false,
   };
 
   const getCss = (progress: number): StyleObject => {

--- a/packages/core/src/lib/transitions/mask.ts
+++ b/packages/core/src/lib/transitions/mask.ts
@@ -1,4 +1,9 @@
-import type { StyleObject, Transition, TransitionKey } from "../types";
+import type {
+  SpringConfig,
+  StyleObject,
+  Transition,
+  TransitionKey,
+} from "../types";
 
 interface MaskOptions {
   shape?: "circle" | "ellipse" | "square";
@@ -14,10 +19,7 @@ interface MaskOptions {
     | "bottom-right";
   scale?: number;
   fade?: boolean;
-  spring?: {
-    stiffness?: number;
-    damping?: number;
-  };
+  spring?: Partial<SpringConfig>;
   key?: TransitionKey;
 }
 
@@ -31,9 +33,10 @@ export const mask = (options: MaskOptions = {}): Transition => {
     key,
   } = options;
 
-  const spring = {
+  const spring: SpringConfig = {
     stiffness: springOption?.stiffness ?? 300,
     damping: springOption?.damping ?? 30,
+    doubleSpring: springOption?.doubleSpring ?? false,
   };
 
   const getOriginPosition = (): string => {

--- a/packages/core/src/lib/transitions/none.ts
+++ b/packages/core/src/lib/transitions/none.ts
@@ -1,19 +1,22 @@
-import type { StyleObject, Transition, TransitionKey } from "../types";
+import type {
+  SpringConfig,
+  StyleObject,
+  Transition,
+  TransitionKey,
+} from "../types";
 
 interface NoneOptions {
-  spring?: {
-    stiffness?: number;
-    damping?: number;
-  };
+  spring?: Partial<SpringConfig>;
   key?: TransitionKey;
 }
 
 export const none = (options: NoneOptions = {}): Transition => {
   const { spring: springOption, key } = options;
 
-  const spring = {
+  const spring: SpringConfig = {
     stiffness: springOption?.stiffness ?? 1000,
     damping: springOption?.damping ?? 100,
+    doubleSpring: springOption?.doubleSpring ?? false,
   };
 
   return {

--- a/packages/core/src/lib/transitions/rotate.ts
+++ b/packages/core/src/lib/transitions/rotate.ts
@@ -1,4 +1,9 @@
-import type { StyleObject, Transition, TransitionKey } from "../types";
+import type {
+  SpringConfig,
+  StyleObject,
+  Transition,
+  TransitionKey,
+} from "../types";
 
 interface RotateOptions {
   degrees?: number;
@@ -8,10 +13,7 @@ interface RotateOptions {
   origin?: string;
   axis?: "2d" | "x" | "y" | "z";
   perspective?: number;
-  spring?: {
-    stiffness?: number;
-    damping?: number;
-  };
+  spring?: Partial<SpringConfig>;
   key?: TransitionKey;
 }
 
@@ -28,9 +30,10 @@ export const rotate = (options: RotateOptions = {}): Transition => {
     key,
   } = options;
 
-  const spring = {
+  const spring: SpringConfig = {
     stiffness: springOption?.stiffness ?? 500,
     damping: springOption?.damping ?? 25,
+    doubleSpring: springOption?.doubleSpring ?? false,
   };
 
   const rotation = clockwise ? degrees : -degrees;

--- a/packages/core/src/lib/transitions/scale.ts
+++ b/packages/core/src/lib/transitions/scale.ts
@@ -1,13 +1,15 @@
-import type { StyleObject, Transition, TransitionKey } from "../types";
+import type {
+  SpringConfig,
+  StyleObject,
+  Transition,
+  TransitionKey,
+} from "../types";
 
 interface ScaleOptions {
   start?: number;
   opacity?: number;
   axis?: "x" | "y" | "both";
-  spring?: {
-    stiffness?: number;
-    damping?: number;
-  };
+  spring?: Partial<SpringConfig>;
   key?: TransitionKey;
 }
 
@@ -20,9 +22,10 @@ export const scale = (options: ScaleOptions = {}): Transition => {
     key,
   } = options;
 
-  const spring = {
+  const spring: SpringConfig = {
     stiffness: springOption?.stiffness ?? 300,
     damping: springOption?.damping ?? 30,
+    doubleSpring: springOption?.doubleSpring ?? false,
   };
 
   const getScaleTransform = (value: number): string => {

--- a/packages/core/src/lib/transitions/slide.ts
+++ b/packages/core/src/lib/transitions/slide.ts
@@ -1,4 +1,9 @@
-import type { StyleObject, Transition, TransitionKey } from "../types";
+import type {
+  SpringConfig,
+  StyleObject,
+  Transition,
+  TransitionKey,
+} from "../types";
 
 interface SlideOptions {
   direction?: "left" | "right" | "up" | "down";
@@ -6,10 +11,7 @@ interface SlideOptions {
   opacity?: number;
   fade?: boolean;
   axis?: "x" | "y";
-  spring?: {
-    stiffness?: number;
-    damping?: number;
-  };
+  spring?: Partial<SpringConfig>;
   key?: TransitionKey;
 }
 
@@ -24,9 +26,10 @@ export const slide = (options: SlideOptions = {}): Transition => {
     key,
   } = options;
 
-  const spring = {
+  const spring: SpringConfig = {
     stiffness: springOption?.stiffness ?? 400,
     damping: springOption?.damping ?? 35,
+    doubleSpring: springOption?.doubleSpring ?? false,
   };
 
   // Determine actual direction based on axis parameter


### PR DESCRIPTION
## Summary
- Add `doubleSpring` option support to all element transition functions
- Refactor spring options to use `Partial<SpringConfig>` type for consistency
- Updated transitions: `blur`, `bounce`, `fade`, `fly`, `mask`, `none`, `rotate`, `scale`, `slide`

## Test plan
- [ ] Verify all transitions accept `doubleSpring` option
- [ ] Test transitions with `doubleSpring: true` for ease-in-out animation
- [ ] Ensure backward compatibility with existing usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)