### PR TITLE
fix(vue): fix transition bugs in Vue adapter

### DIFF
--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/vue",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Vue bindings for SSGOI - Native app-like page transitions for Vue applications",
   "private": false,
   "type": "module",

--- a/packages/vue/src/lib/ssgoi.vue
+++ b/packages/vue/src/lib/ssgoi.vue
@@ -16,7 +16,13 @@ interface Props {
 
 const props = defineProps<Props>();
 
-const contextValue = computed(() => createSggoiTransitionContext(props.config));
+const contextValue = computed(() =>
+  createSggoiTransitionContext(props.config, {
+    // Vue directive uses unmounted hook for cleanup,
+    // so OUT and IN can arrive in any order
+    outFirst: false,
+  }),
+);
 
 // Provide the context value reactively
 watchEffect(() => {

--- a/packages/vue/src/lib/transition.ts
+++ b/packages/vue/src/lib/transition.ts
@@ -22,17 +22,11 @@ export const vTransition: Directive<HTMLElement, TransitionConfig | undefined> =
 
       const transitionConfig = binding.value;
 
-      setTimeout(() => {
-        const cleanup = transition({
-          key: transitionConfig.key,
-          in: transitionConfig.in,
-          out: transitionConfig.out,
-          scope: transitionConfig.scope,
-        })(el);
+      // Pass the entire config including [TRANSITION_STRATEGY] symbol
+      const cleanup = transition(transitionConfig)(el);
 
-        // Store cleanup function on element for unmounted hook
-        (el as any)._ssgoiCleanup = cleanup;
-      }, 0);
+      // Store cleanup function on element for unmounted hook
+      (el as any)._ssgoiCleanup = cleanup;
     },
     unmounted(el) {
       // Call cleanup if it exists


### PR DESCRIPTION
## Summary

- **Fix DOM cleanup issue**: Remove `setTimeout` in `vTransition` mounted hook to fix the bug where previous DOM elements weren't being removed when rapidly toggling between IN/OUT transitions
- **Fix page transitions**: Add `outFirst: false` option to `Ssgoi` component to support any-order IN/OUT transitions (similar to React adapter)
- **Fix TRANSITION_STRATEGY**: Pass entire `transitionConfig` including `[TRANSITION_STRATEGY]` symbol to properly handle page-level transitions

## Test plan

- [x] Test rapid toggle of elements with v-transition directive
- [x] Test page transitions between routes
- [x] Verify DOM cleanup works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)