### PR TITLE
feat(docs): add spring physics graph panel to element transition section

### DIFF
--- a/apps/docs/src/components/home/element-transition-section.tsx
+++ b/apps/docs/src/components/home/element-transition-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useMemo } from "react";
 import { transition } from "@ssgoi/react";
 import {
   fade,
@@ -10,119 +10,36 @@ import {
   blur,
   bounce,
 } from "@ssgoi/react/transitions";
-import { CodeBlock } from "@/components/ui/code-block";
 import { useTranslations } from "@/i18n/use-translations";
-import { SpringConfig } from "@ssgoi/core/types";
-
-type TransitionType = "fade" | "scale" | "slide" | "rotate" | "blur" | "bounce";
-
-const codeExamples: Record<TransitionType, string> = {
-  fade: `<div ref={transition({
-  in: () => ({
-    css: (p) => ({
-      opacity: p
-    })
-  }),
-  out: () => ({
-    css: (p) => ({
-      opacity: p
-    })
-  }),
-})}>
-  Content
-</div>`,
-  scale: `<div ref={transition({
-  in: () => ({
-    css: (p) => ({
-      opacity: p,
-      transform: \`scale(\${p})\`
-    })
-  }),
-  out: () => ({
-    css: (p) => ({
-      opacity: p,
-      transform: \`scale(\${p})\`
-    })
-  }),
-})}>
-  Content
-</div>`,
-  slide: `<div ref={transition({
-  in: () => ({
-    css: (p) => ({
-      opacity: p,
-      transform: \`translateY(\${(1 - p) * 20}px)\`
-    })
-  }),
-  out: () => ({
-    css: (p) => ({
-      opacity: p,
-      transform: \`translateY(\${(1 - p) * 20}px)\`
-    })
-  }),
-})}>
-  Content
-</div>`,
-  rotate: `<div ref={transition({
-  in: () => ({
-    css: (p) => ({
-      opacity: p,
-      transform: \`rotate(\${(1 - p) * 90}deg)\`
-    })
-  }),
-  out: () => ({
-    css: (p) => ({
-      opacity: p,
-      transform: \`rotate(\${(1 - p) * 90}deg)\`
-    })
-  }),
-})}>
-  Content
-</div>`,
-  blur: `<div ref={transition({
-  in: () => ({
-    css: (p) => ({
-      opacity: p,
-      filter: \`blur(\${(1 - p) * 10}px)\`
-    })
-  }),
-  out: () => ({
-    css: (p) => ({
-      opacity: p,
-      filter: \`blur(\${(1 - p) * 10}px)\`
-    })
-  }),
-})}>
-  Content
-</div>`,
-  bounce: `<div ref={transition({
-  in: () => ({
-    css: (p) => ({
-      opacity: p,
-      transform: \`translateY(\${Math.sin((1-p) * Math.PI) * -20}px)\`
-    })
-  }),
-  out: () => ({
-    css: (p) => ({
-      opacity: p,
-      transform: \`translateY(\${Math.sin((1-p) * Math.PI) * -20}px)\`
-    })
-  }),
-})}>
-  Content
-</div>`,
-};
-
-const spring: SpringConfig = {
-  stiffness: 300,
-  damping: 30,
-  doubleSpring: true,
-};
+import { SpringGraphPanel, DEFAULT_SPRING } from "./spring-graph";
+import type { GraphConfig } from "./spring-graph";
+import type { SpringConfig } from "@ssgoi/core/types";
 
 export function ElementTransitionSection() {
   const [show, setShow] = useState(true);
-  const [activeCode, setActiveCode] = useState<TransitionType>("scale");
+  const [graphConfig, setGraphConfig] = useState<GraphConfig>({
+    leader: { ...DEFAULT_SPRING },
+    follower: null,
+  });
   const t = useTranslations("home");
+
+  // Convert graph config to spring config for transitions
+  const spring: SpringConfig = useMemo(() => {
+    if (graphConfig.follower) {
+      return {
+        stiffness: graphConfig.leader.stiffness,
+        damping: graphConfig.leader.damping,
+        doubleSpring: {
+          stiffness: graphConfig.follower.stiffness,
+          damping: graphConfig.follower.damping,
+        },
+      };
+    }
+    return {
+      stiffness: graphConfig.leader.stiffness,
+      damping: graphConfig.leader.damping,
+    };
+  }, [graphConfig]);
 
   return (
     <section className="py-24 px-6 border-t border-white/5">
@@ -142,54 +59,54 @@ export function ElementTransitionSection() {
 
         {/* Demo area - multiple elements with reserved positions */}
         <div className="flex items-center justify-center gap-4 mb-6">
-          <div className="w-10 h-10 flex items-center justify-center">
+          <div className="w-12 h-12 flex items-center justify-center">
             {show && (
               <div
                 ref={transition({ key: "demo-fade", ...fade({ spring }) })}
-                className="w-10 h-10 bg-white rounded-lg"
+                className="w-12 h-12 bg-white rounded-lg"
               />
             )}
           </div>
-          <div className="w-10 h-10 flex items-center justify-center">
+          <div className="w-12 h-12 flex items-center justify-center">
             {show && (
               <div
                 ref={transition({ key: "demo-scale", ...scale({ spring }) })}
-                className="w-10 h-10 bg-emerald-500 rounded-lg"
+                className="w-12 h-12 bg-emerald-500 rounded-lg"
               />
             )}
           </div>
-          <div className="w-10 h-10 flex items-center justify-center">
+          <div className="w-12 h-12 flex items-center justify-center">
             {show && (
               <div
                 ref={transition({
                   key: "demo-slide",
                   ...slide({ direction: "up", spring }),
                 })}
-                className="w-10 h-10 bg-blue-500 rounded-lg"
+                className="w-12 h-12 bg-blue-500 rounded-lg"
               />
             )}
           </div>
-          <div className="w-10 h-10 flex items-center justify-center">
+          <div className="w-12 h-12 flex items-center justify-center">
             {show && (
               <div
                 ref={transition({ key: "demo-rotate", ...rotate({ spring }) })}
-                className="w-10 h-10 bg-amber-500 rounded-lg"
+                className="w-12 h-12 bg-amber-500 rounded-lg"
               />
             )}
           </div>
-          <div className="w-10 h-10 flex items-center justify-center">
+          <div className="w-12 h-12 flex items-center justify-center">
             {show && (
               <div
                 ref={transition({ key: "demo-blur", ...blur({ spring }) })}
-                className="w-10 h-10 bg-purple-500 rounded-lg"
+                className="w-12 h-12 bg-purple-500 rounded-lg"
               />
             )}
           </div>
-          <div className="w-10 h-10 flex items-center justify-center">
+          <div className="w-12 h-12 flex items-center justify-center">
             {show && (
               <div
                 ref={transition({ key: "demo-bounce", ...bounce({ spring }) })}
-                className="w-10 h-10 bg-pink-500 rounded-lg"
+                className="w-12 h-12 bg-pink-500 rounded-lg"
               />
             )}
           </div>
@@ -207,27 +124,8 @@ export function ElementTransitionSection() {
           </button>
         </div>
 
-        {/* Code selector */}
-        <div className="flex justify-center gap-2 mb-4">
-          {(
-            ["fade", "scale", "slide", "rotate", "blur", "bounce"] as const
-          ).map((type) => (
-            <button
-              key={type}
-              onClick={() => setActiveCode(type)}
-              className={`px-3 py-1.5 text-xs rounded-md transition-all ${
-                activeCode === type
-                  ? "bg-white/10 text-white border border-white/20"
-                  : "text-neutral-500 border border-transparent hover:text-neutral-300"
-              }`}
-            >
-              {type}
-            </button>
-          ))}
-        </div>
-
-        {/* Code */}
-        <CodeBlock language="tsx" code={codeExamples[activeCode]} />
+        {/* Spring Graph Panel */}
+        <SpringGraphPanel config={graphConfig} onChange={setGraphConfig} />
       </div>
     </section>
   );

--- a/apps/docs/src/components/home/spring-graph/index.tsx
+++ b/apps/docs/src/components/home/spring-graph/index.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { useMemo } from "react";
+import { SpringCurve } from "./spring-curve";
+import { SpringControls } from "./spring-controls";
+import { simulate } from "./simulate";
+import type { GraphConfig } from "./types";
+
+interface SpringGraphPanelProps {
+  config: GraphConfig;
+  onChange: (config: GraphConfig) => void;
+}
+
+export function SpringGraphPanel({ config, onChange }: SpringGraphPanelProps) {
+  const frames = useMemo(() => simulate(config), [config]);
+
+  const duration = frames[frames.length - 1]?.time ?? 0;
+
+  return (
+    <div className="space-y-6">
+      {/* Graph - 넓게 */}
+      <div>
+        <SpringCurve frames={frames} width={600} height={200} />
+      </div>
+
+      {/* Duration */}
+      <div className="text-center">
+        <span className="text-[9px] text-neutral-600">
+          {Math.round(duration)}ms
+        </span>
+      </div>
+
+      {/* Controls - 가운데에 좁게 */}
+      <SpringControls config={config} onChange={onChange} />
+    </div>
+  );
+}
+
+export { type GraphConfig, type SpringSettings, DEFAULT_SPRING } from "./types";

--- a/apps/docs/src/components/home/spring-graph/simulate.ts
+++ b/apps/docs/src/components/home/spring-graph/simulate.ts
@@ -1,0 +1,58 @@
+import {
+  SpringIntegrator,
+  DoubleSpringIntegrator,
+  type Integrator,
+  type IntegratorState,
+} from "@ssgoi/react/transitions";
+import type { GraphConfig, SimulationFrame } from "./types";
+
+const DT = 0.016; // 16ms per frame (60fps)
+const MAX_TIME_MS = 2000; // max 2 seconds
+
+export function createIntegrator(config: GraphConfig): Integrator {
+  if (config.follower) {
+    return new DoubleSpringIntegrator({
+      stiffness: config.leader.stiffness,
+      damping: config.leader.damping,
+      follower: {
+        stiffness: config.follower.stiffness,
+        damping: config.follower.damping,
+      },
+    });
+  }
+  return new SpringIntegrator({
+    stiffness: config.leader.stiffness,
+    damping: config.leader.damping,
+  });
+}
+
+export function simulate(config: GraphConfig): SimulationFrame[] {
+  const integrator = createIntegrator(config);
+  const frames: SimulationFrame[] = [];
+  let state: IntegratorState = { position: 0, velocity: 0 };
+  let time = 0;
+  const target = 1;
+
+  while (time < MAX_TIME_MS) {
+    frames.push({
+      time,
+      position: state.position,
+      velocity: state.velocity,
+    });
+
+    state = integrator.step(state, target, DT);
+
+    if (integrator.isSettled(state, target)) {
+      frames.push({
+        time: time + DT * 1000,
+        position: target,
+        velocity: 0,
+      });
+      break;
+    }
+
+    time += DT * 1000;
+  }
+
+  return frames;
+}

--- a/apps/docs/src/components/home/spring-graph/spring-controls.tsx
+++ b/apps/docs/src/components/home/spring-graph/spring-controls.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import type { GraphConfig, SpringSettings } from "./types";
+import { SLIDER_RANGES, DEFAULT_SPRING } from "./types";
+
+interface SliderProps {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  onChange: (value: number) => void;
+}
+
+function Slider({ label, value, min, max, step, onChange }: SliderProps) {
+  return (
+    <div className="flex items-center gap-3">
+      <span className="text-[10px] text-neutral-500 w-16">{label}</span>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="flex-1 h-0.5 bg-neutral-700 rounded-lg appearance-none cursor-pointer accent-white"
+      />
+      <span className="text-[10px] text-neutral-400 w-8 text-right font-mono">
+        {value}
+      </span>
+    </div>
+  );
+}
+
+interface SpringGroupProps {
+  label: string;
+  settings: SpringSettings;
+  onChange: (settings: SpringSettings) => void;
+  onRemove?: () => void;
+}
+
+function SpringGroup({
+  label,
+  settings,
+  onChange,
+  onRemove,
+}: SpringGroupProps) {
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center gap-2">
+        <span className="text-[9px] text-neutral-500 uppercase tracking-wider">
+          {label}
+        </span>
+        {onRemove && (
+          <button
+            onClick={onRemove}
+            className="text-neutral-600 hover:text-neutral-400 text-[10px] transition-colors"
+            aria-label="Remove"
+          >
+            ×
+          </button>
+        )}
+      </div>
+      <div className="space-y-1">
+        <Slider
+          label="stiffness"
+          value={settings.stiffness}
+          min={SLIDER_RANGES.stiffness.min}
+          max={SLIDER_RANGES.stiffness.max}
+          step={SLIDER_RANGES.stiffness.step}
+          onChange={(stiffness) => onChange({ ...settings, stiffness })}
+        />
+        <Slider
+          label="damping"
+          value={settings.damping}
+          min={SLIDER_RANGES.damping.min}
+          max={SLIDER_RANGES.damping.max}
+          step={SLIDER_RANGES.damping.step}
+          onChange={(damping) => onChange({ ...settings, damping })}
+        />
+      </div>
+    </div>
+  );
+}
+
+interface SpringControlsProps {
+  config: GraphConfig;
+  onChange: (config: GraphConfig) => void;
+}
+
+export function SpringControls({ config, onChange }: SpringControlsProps) {
+  const handleLeaderChange = (leader: SpringSettings) => {
+    onChange({ ...config, leader });
+  };
+
+  const handleFollowerChange = (follower: SpringSettings) => {
+    onChange({ ...config, follower });
+  };
+
+  const handleAddFollower = () => {
+    onChange({ ...config, follower: { ...DEFAULT_SPRING } });
+  };
+
+  const handleRemoveFollower = () => {
+    onChange({ ...config, follower: null });
+  };
+
+  return (
+    <div className="flex justify-center">
+      <div className="flex items-start gap-8">
+        <SpringGroup
+          label="Spring"
+          settings={config.leader}
+          onChange={handleLeaderChange}
+        />
+
+        {config.follower ? (
+          <SpringGroup
+            label="Follower"
+            settings={config.follower}
+            onChange={handleFollowerChange}
+            onRemove={handleRemoveFollower}
+          />
+        ) : (
+          <button
+            onClick={handleAddFollower}
+            className="text-[9px] text-neutral-600 hover:text-neutral-400 transition-colors mt-4"
+          >
+            + follower
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/docs/src/components/home/spring-graph/spring-curve.tsx
+++ b/apps/docs/src/components/home/spring-graph/spring-curve.tsx
@@ -1,0 +1,164 @@
+"use client";
+
+import React, { useMemo } from "react";
+import type { SimulationFrame } from "./types";
+
+interface SpringCurveProps {
+  frames: SimulationFrame[];
+  width?: number;
+  height?: number;
+}
+
+const PADDING = { top: 20, right: 20, bottom: 30, left: 40 };
+
+function generatePath(
+  frames: SimulationFrame[],
+  graphWidth: number,
+  graphHeight: number,
+): string {
+  if (frames.length === 0) return "";
+
+  const maxTime = frames[frames.length - 1]?.time ?? 1;
+
+  const points = frames.map((frame) => {
+    const x = PADDING.left + (frame.time / maxTime) * graphWidth;
+    const y = PADDING.top + (1 - frame.position) * graphHeight;
+    return `${x.toFixed(2)},${y.toFixed(2)}`;
+  });
+
+  return `M ${points.join(" L ")}`;
+}
+
+function generateGridLines(
+  graphWidth: number,
+  graphHeight: number,
+  maxTime: number,
+): { x: React.ReactNode[]; y: React.ReactNode[] } {
+  const xLines: React.ReactNode[] = [];
+  const yLines: React.ReactNode[] = [];
+
+  // Y-axis grid (0, 0.5, 1)
+  [0, 0.5, 1].forEach((val) => {
+    const y = PADDING.top + (1 - val) * graphHeight;
+    yLines.push(
+      <g key={`y-${val}`}>
+        <line
+          x1={PADDING.left}
+          y1={y}
+          x2={PADDING.left + graphWidth}
+          y2={y}
+          stroke="#333"
+          strokeDasharray={val === 0 || val === 1 ? "0" : "4,4"}
+        />
+        <text
+          x={PADDING.left - 8}
+          y={y + 4}
+          textAnchor="end"
+          className="fill-neutral-500 text-[10px]"
+        >
+          {val}
+        </text>
+      </g>,
+    );
+  });
+
+  // X-axis grid (time markers)
+  const timeStep = maxTime <= 500 ? 100 : maxTime <= 1000 ? 200 : 500;
+  for (let t = 0; t <= maxTime; t += timeStep) {
+    const x = PADDING.left + (t / maxTime) * graphWidth;
+    xLines.push(
+      <g key={`x-${t}`}>
+        <line
+          x1={x}
+          y1={PADDING.top}
+          x2={x}
+          y2={PADDING.top + graphHeight}
+          stroke="#333"
+          strokeDasharray={t === 0 ? "0" : "4,4"}
+        />
+        <text
+          x={x}
+          y={PADDING.top + graphHeight + 16}
+          textAnchor="middle"
+          className="fill-neutral-500 text-[10px]"
+        >
+          {t}
+        </text>
+      </g>,
+    );
+  }
+
+  return { x: xLines, y: yLines };
+}
+
+export function SpringCurve({
+  frames,
+  width = 400,
+  height = 200,
+}: SpringCurveProps) {
+  const graphWidth = width - PADDING.left - PADDING.right;
+  const graphHeight = height - PADDING.top - PADDING.bottom;
+  const maxTime = frames[frames.length - 1]?.time ?? 1000;
+
+  const pathD = useMemo(
+    () => generatePath(frames, graphWidth, graphHeight),
+    [frames, graphWidth, graphHeight],
+  );
+
+  const gridLines = useMemo(
+    () => generateGridLines(graphWidth, graphHeight, maxTime),
+    [graphWidth, graphHeight, maxTime],
+  );
+
+  return (
+    <svg
+      width="100%"
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      className="rounded-lg"
+      preserveAspectRatio="xMidYMid meet"
+    >
+      {/* Grid lines */}
+      {gridLines.y}
+      {gridLines.x}
+
+      {/* Axes */}
+      <line
+        x1={PADDING.left}
+        y1={PADDING.top + graphHeight}
+        x2={PADDING.left + graphWidth}
+        y2={PADDING.top + graphHeight}
+        stroke="#525252"
+        strokeWidth={1}
+      />
+      <line
+        x1={PADDING.left}
+        y1={PADDING.top}
+        x2={PADDING.left}
+        y2={PADDING.top + graphHeight}
+        stroke="#525252"
+        strokeWidth={1}
+      />
+
+      {/* Curve */}
+      <path
+        d={pathD}
+        fill="none"
+        stroke="#fff"
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+
+      {/* X-axis label */}
+      <text
+        x={PADDING.left + graphWidth / 2}
+        y={height - 4}
+        textAnchor="middle"
+        className="fill-neutral-600 text-[9px]"
+      >
+        time (ms)
+      </text>
+    </svg>
+  );
+}

--- a/apps/docs/src/components/home/spring-graph/types.ts
+++ b/apps/docs/src/components/home/spring-graph/types.ts
@@ -1,0 +1,25 @@
+export interface SimulationFrame {
+  time: number; // ms
+  position: number; // 0 ~ 1
+  velocity: number;
+}
+
+export interface SpringSettings {
+  stiffness: number;
+  damping: number;
+}
+
+export interface GraphConfig {
+  leader: SpringSettings;
+  follower: SpringSettings | null; // null = single spring mode
+}
+
+export const SLIDER_RANGES = {
+  stiffness: { min: 50, max: 1000, step: 10, default: 300 },
+  damping: { min: 5, max: 100, step: 1, default: 30 },
+} as const;
+
+export const DEFAULT_SPRING: SpringSettings = {
+  stiffness: SLIDER_RANGES.stiffness.default,
+  damping: SLIDER_RANGES.damping.default,
+};


### PR DESCRIPTION
## Summary
- Replace code examples with interactive spring physics visualization in the home page element transition section
- Add SVG graph showing position over time curve based on spring physics simulation
- Add sliders to control stiffness (50-1000) and damping (5-100)
- Support adding follower spring for double spring mode
- Sync graph config with demo animations in real-time
- Increase demo element size from 40x40 to 48x48

## Changes
- `apps/docs/src/components/home/spring-graph/` - New graph panel components
  - `types.ts` - Type definitions
  - `simulate.ts` - Spring physics simulation using Integrator
  - `spring-curve.tsx` - SVG graph rendering
  - `spring-controls.tsx` - Slider controls UI
  - `index.tsx` - Main panel component
- `apps/docs/src/components/home/element-transition-section.tsx` - Replace code block with graph panel

## Test plan
- [ ] Visit home page and scroll to Element Transition section
- [ ] Verify graph displays spring curve correctly
- [ ] Adjust stiffness/damping sliders and confirm graph updates
- [ ] Click "+ follower" to add double spring and verify both springs work
- [ ] Toggle show/hide and verify demo elements animate with configured spring

🤖 Generated with [Claude Code](https://claude.com/claude-code)