### PR TITLE
docs: brighten text colors for better readability (#273)

### DIFF
--- a/apps/docs/src/app/[lang]/blog/[slug]/page.tsx
+++ b/apps/docs/src/app/[lang]/blog/[slug]/page.tsx
@@ -75,7 +75,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
           <BlogPostLink
             href={`/${lang}/blog`}
             fallbackHref={`/${lang}/blog`}
-            className="inline-flex items-center text-xs text-neutral-400 hover:text-white transition-colors mb-8"
+            className="inline-flex items-center text-xs text-neutral-300 hover:text-white transition-colors mb-8"
           >
             {t("backToBlog")}
           </BlogPostLink>
@@ -100,7 +100,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
               {post.title}
             </h1>
 
-            <div className="flex items-center gap-3 text-xs text-neutral-500">
+            <div className="flex items-center gap-3 text-xs text-neutral-400">
               {post.date && (
                 <time dateTime={post.date}>
                   {new Date(post.date).toLocaleDateString(lang, {
@@ -124,7 +124,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
                 {post.tags.map((tag) => (
                   <span
                     key={tag}
-                    className="px-2 py-0.5 text-xs bg-white/5 text-neutral-400 rounded border border-white/5"
+                    className="px-2 py-0.5 text-xs bg-white/5 text-neutral-300 rounded border border-white/5"
                   >
                     {tag}
                   </span>
@@ -143,7 +143,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
             <BlogPostLink
               href={`/${lang}/blog`}
               fallbackHref={`/${lang}/blog`}
-              className="inline-flex items-center text-xs text-neutral-400 hover:text-white transition-colors"
+              className="inline-flex items-center text-xs text-neutral-300 hover:text-white transition-colors"
             >
               {t("backToBlog")}
             </BlogPostLink>

--- a/apps/docs/src/app/[lang]/blog/page.tsx
+++ b/apps/docs/src/app/[lang]/blog/page.tsx
@@ -41,7 +41,7 @@ export default async function BlogPage({ params }: BlogPageProps) {
             <h1 className="text-2xl font-medium text-white mb-2">
               {t("pageTitle")}
             </h1>
-            <p className="text-sm text-neutral-400">{t("pageDescription")}</p>
+            <p className="text-sm text-neutral-300">{t("pageDescription")}</p>
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -71,12 +71,12 @@ export default async function BlogPage({ params }: BlogPageProps) {
                     </h2>
 
                     {post.description && (
-                      <p className="text-xs text-neutral-400 mb-3 line-clamp-2">
+                      <p className="text-xs text-neutral-300 mb-3 line-clamp-2">
                         {post.description}
                       </p>
                     )}
 
-                    <div className="flex items-center justify-between text-xs text-neutral-500">
+                    <div className="flex items-center justify-between text-xs text-neutral-400">
                       {post.date && (
                         <time dateTime={post.date}>
                           {new Date(post.date).toLocaleDateString(lang, {
@@ -95,7 +95,7 @@ export default async function BlogPage({ params }: BlogPageProps) {
                         {post.tags.map((tag) => (
                           <span
                             key={tag}
-                            className="px-2 py-0.5 text-xs bg-white/5 text-neutral-400 rounded border border-white/5"
+                            className="px-2 py-0.5 text-xs bg-white/5 text-neutral-300 rounded border border-white/5"
                           >
                             {tag}
                           </span>
@@ -110,7 +110,7 @@ export default async function BlogPage({ params }: BlogPageProps) {
 
           {posts.length === 0 && (
             <div className="text-center py-20">
-              <p className="text-sm text-neutral-400">{t("noPostsYet")}</p>
+              <p className="text-sm text-neutral-300">{t("noPostsYet")}</p>
             </div>
           )}
         </div>

--- a/apps/docs/src/components/docs/docs-navigation.tsx
+++ b/apps/docs/src/components/docs/docs-navigation.tsx
@@ -25,9 +25,9 @@ export function DocsNavigation({ prev, next, lang }: DocsNavigationProps) {
             href={`/${lang}/docs/${prev.path}`}
             className="group flex items-center gap-3 px-4 py-3 rounded-lg border border-zinc-800 bg-zinc-900/50 hover:bg-zinc-800/80 hover:border-zinc-700 transition-all min-w-0 flex-1"
           >
-            <ChevronLeft className="w-5 h-5 text-zinc-500 group-hover:text-white transition-colors flex-shrink-0" />
+            <ChevronLeft className="w-5 h-5 text-zinc-400 group-hover:text-white transition-colors flex-shrink-0" />
             <div className="text-left min-w-0">
-              <div className="text-xs text-zinc-500 group-hover:text-zinc-400 mb-1 transition-colors">
+              <div className="text-xs text-zinc-400 group-hover:text-zinc-300 mb-1 transition-colors">
                 Previous
               </div>
               <div className="text-white font-medium truncate">
@@ -45,14 +45,14 @@ export function DocsNavigation({ prev, next, lang }: DocsNavigationProps) {
             className="group flex items-center gap-3 px-4 py-3 rounded-lg border border-zinc-800 bg-zinc-900/50 hover:bg-zinc-800/80 hover:border-zinc-700 transition-all min-w-0 flex-1"
           >
             <div className="text-right min-w-0 flex-1">
-              <div className="text-xs text-zinc-500 group-hover:text-zinc-400 mb-1 transition-colors">
+              <div className="text-xs text-zinc-400 group-hover:text-zinc-300 mb-1 transition-colors">
                 Next
               </div>
               <div className="text-white font-medium truncate">
                 {next.title}
               </div>
             </div>
-            <ChevronRight className="w-5 h-5 text-zinc-500 group-hover:text-white transition-colors flex-shrink-0" />
+            <ChevronRight className="w-5 h-5 text-zinc-400 group-hover:text-white transition-colors flex-shrink-0" />
           </Link>
         ) : (
           <div className="flex-1" />

--- a/apps/docs/src/components/docs/sidebar-content.tsx
+++ b/apps/docs/src/components/docs/sidebar-content.tsx
@@ -75,13 +75,13 @@ export function SidebarContent({
               onClick={() => toggleExpanded(item.path)}
               className={`
                 w-full text-left px-2 py-1.5 flex items-center justify-between rounded
-                text-neutral-400 hover:text-white transition-colors
+                text-neutral-300 hover:text-white transition-colors
                 ${level > 0 ? "ml-" + level * 4 : ""}
               `}
             >
               <span className="text-xs font-medium">{item.navTitle}</span>
               <ChevronRight
-                className={`w-3 h-3 transition-transform duration-300 text-neutral-600 ${isExpanded ? "rotate-90" : ""}`}
+                className={`w-3 h-3 transition-transform duration-300 text-neutral-500 ${isExpanded ? "rotate-90" : ""}`}
               />
             </button>
             <div
@@ -104,7 +104,7 @@ export function SidebarContent({
               ${
                 isActive
                   ? "text-neutral-100"
-                  : "text-neutral-500 hover:text-neutral-300"
+                  : "text-neutral-400 hover:text-neutral-200"
               }
             `}
           >

--- a/apps/docs/src/components/home/code-section.tsx
+++ b/apps/docs/src/components/home/code-section.tsx
@@ -43,13 +43,13 @@ import { fade } from '@ssgoi/react/view-transitions';
     <section className="py-20 px-6 border-t border-white/5">
       <div className="max-w-6xl mx-auto">
         <div className="mb-12">
-          <p className="text-[10px] text-neutral-500 uppercase tracking-wider mb-3">
+          <p className="text-[10px] text-neutral-400 uppercase tracking-wider mb-3">
             {t("newHome.code.sectionLabel")}
           </p>
           <h2 className="text-xl font-light tracking-tight mb-2">
             {t("newHome.code.title")}
           </h2>
-          <p className="text-xs text-neutral-500">
+          <p className="text-xs text-neutral-400">
             {t("newHome.code.description")}
           </p>
         </div>
@@ -61,7 +61,7 @@ import { fade } from '@ssgoi/react/view-transitions';
             className={`text-xs pb-2 border-b-2 transition-colors ${
               activeTab === "setup"
                 ? "text-white border-white"
-                : "text-neutral-500 border-transparent hover:text-neutral-300"
+                : "text-neutral-400 border-transparent hover:text-neutral-200"
             }`}
           >
             {t("newHome.code.tabSetup")}
@@ -71,7 +71,7 @@ import { fade } from '@ssgoi/react/view-transitions';
             className={`text-xs pb-2 border-b-2 transition-colors ${
               activeTab === "config"
                 ? "text-white border-white"
-                : "text-neutral-500 border-transparent hover:text-neutral-300"
+                : "text-neutral-400 border-transparent hover:text-neutral-200"
             }`}
           >
             {t("newHome.code.tabRouteConfig")}
@@ -106,7 +106,7 @@ function CopyButton({ text }: { text: string }) {
   return (
     <button
       onClick={handleCopy}
-      className="text-neutral-500 hover:text-white transition-colors"
+      className="text-neutral-400 hover:text-white transition-colors"
     >
       {copied ? (
         <Check className="w-3.5 h-3.5 text-emerald-400" />

--- a/apps/docs/src/components/home/cta-section.tsx
+++ b/apps/docs/src/components/home/cta-section.tsx
@@ -17,7 +17,7 @@ export function CTASection({ lang }: CTASectionProps) {
         <h2 className="text-2xl font-light tracking-tight mb-4">
           {t("newHome.cta.title")}
         </h2>
-        <p className="text-sm text-neutral-500 mb-8 max-w-md mx-auto">
+        <p className="text-sm text-neutral-400 mb-8 max-w-md mx-auto">
           {t("newHome.cta.description")}
         </p>
         <div className="flex items-center justify-center gap-4">
@@ -32,7 +32,7 @@ export function CTASection({ lang }: CTASectionProps) {
             href="https://github.com/meursyphus/ssgoi"
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 px-6 py-3 text-xs text-neutral-400 border border-white/10 rounded-lg hover:bg-white/[0.02] transition-colors"
+            className="inline-flex items-center gap-2 px-6 py-3 text-xs text-neutral-300 border border-white/10 rounded-lg hover:bg-white/[0.02] transition-colors"
           >
             <Github className="w-3.5 h-3.5" />
             GitHub

--- a/apps/docs/src/components/home/demo-showcase-section.tsx
+++ b/apps/docs/src/components/home/demo-showcase-section.tsx
@@ -61,13 +61,13 @@ export function DemoShowcaseSection() {
       <div className="max-w-6xl mx-auto">
         {/* Header */}
         <div className="mb-8">
-          <p className="text-[10px] text-neutral-500 uppercase tracking-wider mb-3">
+          <p className="text-[10px] text-neutral-400 uppercase tracking-wider mb-3">
             {t("newHome.demoShowcase.sectionLabel")}
           </p>
           <h2 className="text-xl font-light tracking-tight mb-2">
             {t("newHome.demoShowcase.title")}
           </h2>
-          <p className="text-xs text-neutral-500">
+          <p className="text-xs text-neutral-400">
             {t("newHome.demoShowcase.description")}
           </p>
         </div>
@@ -81,7 +81,7 @@ export function DemoShowcaseSection() {
               className={`flex-shrink-0 px-4 py-2 text-xs rounded-lg transition-all ${
                 activeDemo === demoType
                   ? "bg-white/10 text-white border border-white/20"
-                  : "text-neutral-500 border border-transparent hover:text-neutral-300 hover:bg-white/5"
+                  : "text-neutral-400 border border-transparent hover:text-neutral-200 hover:bg-white/5"
               }`}
             >
               {t(`newHome.demoShowcase.demos.${demoType}.label`)}
@@ -97,7 +97,7 @@ export function DemoShowcaseSection() {
           </div>
 
           {/* Description */}
-          <p className="mt-4 text-xs text-neutral-500 text-center">
+          <p className="mt-4 text-xs text-neutral-400 text-center">
             {t(`newHome.demoShowcase.demos.${activeDemo}.description`)}
           </p>
         </div>

--- a/apps/docs/src/components/home/element-transition-section.tsx
+++ b/apps/docs/src/components/home/element-transition-section.tsx
@@ -58,13 +58,13 @@ export function ElementTransitionSection() {
       <div className="max-w-4xl mx-auto">
         {/* Section header */}
         <div className="text-center mb-12">
-          <p className="text-[10px] text-neutral-500 uppercase tracking-wider mb-3">
+          <p className="text-[10px] text-neutral-400 uppercase tracking-wider mb-3">
             {t("newHome.elementTransition.sectionLabel")}
           </p>
           <h2 className="text-xl font-light tracking-tight mb-2">
             {t("newHome.elementTransition.title")}
           </h2>
-          <p className="text-xs text-neutral-500">
+          <p className="text-xs text-neutral-400">
             {t("newHome.elementTransition.description")}
           </p>
         </div>
@@ -117,7 +117,7 @@ export function ElementTransitionSection() {
         <div className="flex justify-center mb-10">
           <button
             onClick={() => setShow(!show)}
-            className="px-4 py-1.5 text-xs text-neutral-400 border border-white/10 rounded-md hover:border-white/20 hover:text-white transition-all"
+            className="px-4 py-1.5 text-xs text-neutral-300 border border-white/10 rounded-md hover:border-white/20 hover:text-white transition-all"
           >
             {show
               ? t("newHome.elementTransition.toggleHide")

--- a/apps/docs/src/components/home/features-section.tsx
+++ b/apps/docs/src/components/home/features-section.tsx
@@ -33,7 +33,7 @@ export function FeaturesSection() {
     <section className="py-20 px-6 border-t border-white/5">
       <div className="max-w-6xl mx-auto">
         <div className="mb-12">
-          <p className="text-[10px] text-neutral-500 uppercase tracking-wider mb-3">
+          <p className="text-[10px] text-neutral-400 uppercase tracking-wider mb-3">
             {t("newHome.features.sectionLabel")}
           </p>
           <h2 className="text-xl font-light tracking-tight">
@@ -46,13 +46,13 @@ export function FeaturesSection() {
             <div key={i} className="group">
               <div className="flex items-start gap-4">
                 <div className="w-8 h-8 rounded bg-white/[0.03] border border-white/10 flex items-center justify-center flex-shrink-0">
-                  <feature.icon className="w-3.5 h-3.5 text-neutral-500" />
+                  <feature.icon className="w-3.5 h-3.5 text-neutral-400" />
                 </div>
                 <div>
                   <h3 className="text-sm font-medium mb-1">
                     {t(feature.titleKey)}
                   </h3>
-                  <p className="text-xs text-neutral-500 leading-relaxed">
+                  <p className="text-xs text-neutral-400 leading-relaxed">
                     {t(feature.descriptionKey)}
                   </p>
                 </div>

--- a/apps/docs/src/components/home/footer.tsx
+++ b/apps/docs/src/components/home/footer.tsx
@@ -10,9 +10,9 @@ export function Footer() {
         <div className="flex flex-col md:flex-row items-center justify-between gap-4">
           {/* Left - License */}
           <div className="flex items-center gap-2">
-            <span className="text-[10px] text-neutral-600">MIT License</span>
+            <span className="text-[10px] text-neutral-500">MIT License</span>
             <span className="text-neutral-700">·</span>
-            <span className="text-[10px] text-neutral-600">
+            <span className="text-[10px] text-neutral-500">
               Free & Open Source
             </span>
           </div>
@@ -23,7 +23,7 @@ export function Footer() {
               href="https://github.com/meursyphus/ssgoi"
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center gap-1.5 text-[10px] text-neutral-500 hover:text-neutral-300 transition-colors"
+              className="flex items-center gap-1.5 text-[10px] text-neutral-400 hover:text-neutral-200 transition-colors"
             >
               <Github className="w-3 h-3" />
               <span>GitHub</span>
@@ -32,7 +32,7 @@ export function Footer() {
               href="https://discord.gg/9gSSWQbvX4"
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center gap-1.5 text-[10px] text-neutral-500 hover:text-neutral-300 transition-colors"
+              className="flex items-center gap-1.5 text-[10px] text-neutral-400 hover:text-neutral-200 transition-colors"
             >
               <svg
                 viewBox="0 0 24 24"
@@ -47,7 +47,7 @@ export function Footer() {
               href="https://x.com/meursyphus"
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center gap-1.5 text-[10px] text-neutral-500 hover:text-neutral-300 transition-colors"
+              className="flex items-center gap-1.5 text-[10px] text-neutral-400 hover:text-neutral-200 transition-colors"
             >
               <svg
                 viewBox="0 0 24 24"
@@ -61,7 +61,7 @@ export function Footer() {
           </div>
 
           {/* Right - Credit */}
-          <span className="text-[10px] text-neutral-600">
+          <span className="text-[10px] text-neutral-500">
             Built with care by MeurSyphus
           </span>
         </div>

--- a/apps/docs/src/components/home/frameworks-section.tsx
+++ b/apps/docs/src/components/home/frameworks-section.tsx
@@ -18,13 +18,13 @@ export function FrameworksSection() {
     <section className="py-20 px-6 border-t border-white/5">
       <div className="max-w-6xl mx-auto">
         <div className="mb-12">
-          <p className="text-[10px] text-neutral-500 uppercase tracking-wider mb-3">
+          <p className="text-[10px] text-neutral-400 uppercase tracking-wider mb-3">
             {t("newHome.frameworks.sectionLabel")}
           </p>
           <h2 className="text-xl font-light tracking-tight mb-2">
             {t("newHome.frameworks.title")}
           </h2>
-          <p className="text-xs text-neutral-500">
+          <p className="text-xs text-neutral-400">
             {t("newHome.frameworks.description")}
           </p>
         </div>
@@ -36,12 +36,12 @@ export function FrameworksSection() {
               className={`px-4 py-2 rounded border text-xs ${
                 fw.status === "available"
                   ? "bg-white/[0.02] border-white/10 text-neutral-300"
-                  : "border-white/5 text-neutral-600"
+                  : "border-white/5 text-neutral-500"
               }`}
             >
               {fw.name}
               {fw.status === "soon" && (
-                <span className="ml-2 text-[10px] text-neutral-600">
+                <span className="ml-2 text-[10px] text-neutral-500">
                   {t("newHome.frameworks.soon")}
                 </span>
               )}

--- a/apps/docs/src/components/home/hero-section.tsx
+++ b/apps/docs/src/components/home/hero-section.tsx
@@ -40,7 +40,7 @@ export function HeroSection({ lang }: HeroSectionProps) {
             {/* Badge */}
             <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-white/5 border border-white/10 mb-8">
               <span className="w-1.5 h-1.5 rounded-full bg-emerald-400" />
-              <span className="text-[10px] text-neutral-400 uppercase tracking-wider">
+              <span className="text-[10px] text-neutral-300 uppercase tracking-wider">
                 {t("newHome.hero.badge")}
               </span>
             </div>
@@ -49,13 +49,13 @@ export function HeroSection({ lang }: HeroSectionProps) {
             <h1 className="text-3xl sm:text-4xl font-light tracking-tight leading-tight mb-6">
               {t("newHome.hero.title.line1")}
               <br />
-              <span className="text-neutral-500">
+              <span className="text-neutral-400">
                 {t("newHome.hero.title.line2")}
               </span>
             </h1>
 
             {/* Description */}
-            <p className="text-sm text-neutral-400 leading-relaxed mb-8 max-w-md">
+            <p className="text-sm text-neutral-300 leading-relaxed mb-8 max-w-md">
               {t("newHome.hero.description")}
             </p>
 
@@ -68,7 +68,7 @@ export function HeroSection({ lang }: HeroSectionProps) {
                   className={`px-2.5 py-1 text-[10px] rounded transition-all ${
                     activeFramework === i
                       ? "bg-white/10 text-white"
-                      : "text-neutral-500 hover:text-neutral-300"
+                      : "text-neutral-400 hover:text-neutral-200"
                   }`}
                 >
                   {fw.name}
@@ -84,7 +84,7 @@ export function HeroSection({ lang }: HeroSectionProps) {
                 </code>
                 <button
                   onClick={handleCopy}
-                  className="text-neutral-500 hover:text-white transition-colors"
+                  className="text-neutral-400 hover:text-white transition-colors"
                 >
                   {copied ? (
                     <Check className="w-3.5 h-3.5 text-emerald-400" />
@@ -106,7 +106,7 @@ export function HeroSection({ lang }: HeroSectionProps) {
               </Link>
               <Link
                 href={`/${lang}/demo`}
-                className="inline-flex items-center gap-2 px-5 py-2.5 text-xs text-neutral-400 hover:text-white transition-colors"
+                className="inline-flex items-center gap-2 px-5 py-2.5 text-xs text-neutral-300 hover:text-white transition-colors"
               >
                 {t("newHome.hero.viewDemo")}
                 <ChevronRight className="w-3.5 h-3.5" />

--- a/apps/docs/src/components/layout/header.tsx
+++ b/apps/docs/src/components/layout/header.tsx
@@ -50,7 +50,7 @@ export function Header() {
 
       {/* Mobile Menu Button */}
       <button
-        className="md:hidden fixed top-4 right-4 z-50 h-9 w-9 flex items-center justify-center rounded-full bg-neutral-900/70 backdrop-blur-md border border-white/10 text-neutral-400 hover:text-white transition-colors"
+        className="md:hidden fixed top-4 right-4 z-50 h-9 w-9 flex items-center justify-center rounded-full bg-neutral-900/70 backdrop-blur-md border border-white/10 text-neutral-300 hover:text-white transition-colors"
         onClick={() => setMobileDrawerOpen(!mobileDrawerOpen)}
       >
         <Menu className="h-4 w-4" />
@@ -83,7 +83,7 @@ export function Header() {
                 "px-3 py-1.5 text-xs rounded-full transition-colors",
                 isActive(`/${currentLang}/docs`)
                   ? "bg-white/10 text-white"
-                  : "text-neutral-400 hover:text-white",
+                  : "text-neutral-300 hover:text-white",
               )}
             >
               {t("docs")}
@@ -94,7 +94,7 @@ export function Header() {
                 "px-3 py-1.5 text-xs rounded-full transition-colors",
                 isActive(`/${currentLang}/blog`)
                   ? "bg-white/10 text-white"
-                  : "text-neutral-400 hover:text-white",
+                  : "text-neutral-300 hover:text-white",
               )}
             >
               {t("blog")}
@@ -105,7 +105,7 @@ export function Header() {
                 "px-3 py-1.5 text-xs rounded-full transition-colors",
                 isActive(`/${currentLang}/demo`)
                   ? "bg-white/10 text-white"
-                  : "text-neutral-400 hover:text-white",
+                  : "text-neutral-300 hover:text-white",
               )}
             >
               {t("demo")}
@@ -116,7 +116,7 @@ export function Header() {
                 "px-3 py-1.5 text-xs rounded-full transition-colors",
                 isActive(`/${currentLang}/showcase`)
                   ? "bg-white/10 text-white"
-                  : "text-neutral-400 hover:text-white",
+                  : "text-neutral-300 hover:text-white",
               )}
             >
               {t("showcase")}
@@ -135,7 +135,7 @@ export function Header() {
               href="https://discord.gg/9gSSWQbvX4"
               target="_blank"
               rel="noopener noreferrer"
-              className="h-7 w-7 flex items-center justify-center rounded-full text-neutral-400 hover:text-white hover:bg-white/5 transition-colors"
+              className="h-7 w-7 flex items-center justify-center rounded-full text-neutral-300 hover:text-white hover:bg-white/5 transition-colors"
               aria-label="Discord"
             >
               <svg
@@ -152,7 +152,7 @@ export function Header() {
               href="https://x.com/meursyphus"
               target="_blank"
               rel="noopener noreferrer"
-              className="h-7 w-7 flex items-center justify-center rounded-full text-neutral-400 hover:text-white hover:bg-white/5 transition-colors"
+              className="h-7 w-7 flex items-center justify-center rounded-full text-neutral-300 hover:text-white hover:bg-white/5 transition-colors"
               aria-label="X (Twitter)"
             >
               <svg
@@ -169,7 +169,7 @@ export function Header() {
               href="https://github.com/meursyphus/ssgoi"
               target="_blank"
               rel="noopener noreferrer"
-              className="h-7 w-7 flex items-center justify-center rounded-full text-neutral-400 hover:text-white hover:bg-white/5 transition-colors"
+              className="h-7 w-7 flex items-center justify-center rounded-full text-neutral-300 hover:text-white hover:bg-white/5 transition-colors"
               aria-label={t("githubRepository")}
             >
               <Github className="h-3.5 w-3.5" />

--- a/apps/docs/src/components/layout/mobile-drawer.tsx
+++ b/apps/docs/src/components/layout/mobile-drawer.tsx
@@ -80,7 +80,7 @@ export function MobileDrawer({ isOpen, onClose, lang }: MobileDrawerProps) {
                     className={`flex items-center gap-2 text-sm font-medium transition-colors ${
                       activeTab === "docs"
                         ? "text-white border-b-2 border-orange-500 pb-2"
-                        : "text-gray-400 hover:text-white pb-2"
+                        : "text-gray-300 hover:text-white pb-2"
                     }`}
                   >
                     <BookOpen className="h-4 w-4" />
@@ -92,7 +92,7 @@ export function MobileDrawer({ isOpen, onClose, lang }: MobileDrawerProps) {
                   className={`flex items-center gap-2 text-sm font-medium transition-colors ${
                     activeTab === "menu"
                       ? "text-white border-b-2 border-orange-500 pb-2"
-                      : "text-gray-400 hover:text-white pb-2"
+                      : "text-gray-300 hover:text-white pb-2"
                   }`}
                 >
                   <Menu className="h-4 w-4" />
@@ -101,7 +101,7 @@ export function MobileDrawer({ isOpen, onClose, lang }: MobileDrawerProps) {
               </div>
               <button
                 onClick={onClose}
-                className="inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors hover:bg-zinc-800 h-9 w-9 text-gray-400 hover:text-white"
+                className="inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors hover:bg-zinc-800 h-9 w-9 text-gray-300 hover:text-white"
               >
                 <X className="h-5 w-5" />
                 <span className="sr-only">{t("closeDrawer")}</span>
@@ -126,7 +126,7 @@ export function MobileDrawer({ isOpen, onClose, lang }: MobileDrawerProps) {
             {/* 문서 탭이지만 navigation이 없는 경우 (문서 페이지가 아닐 때) */}
             {activeTab === "docs" && !navigation && (
               <div className="text-center py-8">
-                <p className="text-sm text-gray-400">{t("noDocumentPage")}</p>
+                <p className="text-sm text-gray-300">{t("noDocumentPage")}</p>
               </div>
             )}
 
@@ -135,7 +135,7 @@ export function MobileDrawer({ isOpen, onClose, lang }: MobileDrawerProps) {
               <div className="space-y-6">
                 {/* Navigation Section */}
                 <div>
-                  <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">
+                  <h3 className="text-xs font-semibold text-gray-300 uppercase tracking-wider mb-3">
                     {t("navigation")}
                   </h3>
                   <nav>
@@ -203,7 +203,7 @@ export function MobileDrawer({ isOpen, onClose, lang }: MobileDrawerProps) {
 
                 {/* Social Links Section */}
                 <div>
-                  <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">
+                  <h3 className="text-xs font-semibold text-gray-300 uppercase tracking-wider mb-3">
                     Community
                   </h3>
                   <nav>
@@ -271,7 +271,7 @@ export function MobileDrawer({ isOpen, onClose, lang }: MobileDrawerProps) {
 
                 {/* Language Section */}
                 <div>
-                  <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">
+                  <h3 className="text-xs font-semibold text-gray-300 uppercase tracking-wider mb-3">
                     {t("language")}
                   </h3>
                   <div className="space-y-2">

--- a/apps/docs/src/components/mdx/mdx-components/note.tsx
+++ b/apps/docs/src/components/mdx/mdx-components/note.tsx
@@ -6,7 +6,7 @@ export const Note = ({
   children: React.ReactNode;
 }) => {
   return (
-    <div className="my-4 bg-zinc-800/40 px-4 py-3 text-sm text-zinc-400">
+    <div className="my-4 bg-zinc-800/40 px-4 py-3 text-sm text-zinc-300">
       {children}
     </div>
   );

--- a/apps/docs/src/components/mdx/mdx-components/suitability-table.tsx
+++ b/apps/docs/src/components/mdx/mdx-components/suitability-table.tsx
@@ -57,7 +57,7 @@ export function SuitabilityTable({ items, className }: SuitabilityTableProps) {
               <td className="px-4 py-3 text-center">
                 {getSuitabilityIcon(item.suitable)}
               </td>
-              <td className="px-4 py-3 text-sm text-gray-400">
+              <td className="px-4 py-3 text-sm text-gray-300">
                 {item.description}
               </td>
             </tr>

--- a/apps/docs/src/components/mdx/mdx-components/tabs.tsx
+++ b/apps/docs/src/components/mdx/mdx-components/tabs.tsx
@@ -35,7 +35,7 @@ export const Tabs = ({ items, children, defaultValue }: TabsProps) => {
               className={`px-4 py-2 text-sm font-medium transition-colors relative ${
                 activeTab === item.value
                   ? "text-white"
-                  : "text-zinc-400 hover:text-zinc-200"
+                  : "text-zinc-300 hover:text-zinc-100"
               }`}
             >
               {item.label}

--- a/apps/docs/src/components/mdx/mdx-remote.tsx
+++ b/apps/docs/src/components/mdx/mdx-remote.tsx
@@ -30,17 +30,17 @@ const defaultComponents = {
     />
   ),
   p: (props: any) => (
-    <p className="mb-4 text-sm text-neutral-400 leading-relaxed" {...props} />
+    <p className="mb-4 text-sm text-neutral-300 leading-relaxed" {...props} />
   ),
   ul: (props: any) => (
     <ul
-      className="list-disc pl-5 mb-4 text-sm text-neutral-400 space-y-1"
+      className="list-disc pl-5 mb-4 text-sm text-neutral-300 space-y-1"
       {...props}
     />
   ),
   ol: (props: any) => (
     <ol
-      className="list-decimal pl-5 mb-4 text-sm text-neutral-400 space-y-1"
+      className="list-decimal pl-5 mb-4 text-sm text-neutral-300 space-y-1"
       {...props}
     />
   ),
@@ -52,7 +52,7 @@ const defaultComponents = {
     if (isInline) {
       return (
         <code
-          className="bg-white/5 px-1.5 py-0.5 rounded text-xs text-neutral-400 font-mono border border-white/5"
+          className="bg-white/5 px-1.5 py-0.5 rounded text-xs text-neutral-300 font-mono border border-white/5"
           {...rest}
         >
           {children}
@@ -79,20 +79,20 @@ const defaultComponents = {
   },
   blockquote: (props: any) => (
     <blockquote
-      className="border-l border-neutral-700 pl-4 italic my-4 text-sm text-neutral-500"
+      className="border-l border-neutral-700 pl-4 italic my-4 text-sm text-neutral-400"
       {...props}
     />
   ),
   a: (props: any) => (
     <a
-      className="text-neutral-400 underline underline-offset-2 hover:text-neutral-200 transition-colors"
+      className="text-neutral-300 underline underline-offset-2 hover:text-neutral-100 transition-colors"
       {...props}
     />
   ),
   strong: (props: any) => (
     <strong className="font-medium text-neutral-200" {...props} />
   ),
-  em: (props: any) => <em className="italic text-neutral-500" {...props} />,
+  em: (props: any) => <em className="italic text-neutral-400" {...props} />,
   hr: (props: any) => <hr className="border-white/5 my-8" {...props} />,
   table: (props: any) => (
     <div className="overflow-x-auto mb-4">
@@ -106,12 +106,12 @@ const defaultComponents = {
   tr: (props: any) => <tr {...props} />,
   th: (props: any) => (
     <th
-      className="px-4 py-2 text-left text-xs font-medium text-neutral-500 uppercase tracking-wider"
+      className="px-4 py-2 text-left text-xs font-medium text-neutral-400 uppercase tracking-wider"
       {...props}
     />
   ),
   td: (props: any) => (
-    <td className="px-4 py-2 text-xs text-neutral-400" {...props} />
+    <td className="px-4 py-2 text-xs text-neutral-300" {...props} />
   ),
   img: (props: any) => (
     <span className="flex justify-center my-6">


### PR DESCRIPTION
* docs: brighten text colors for better readability

Adjust neutral text colors one step lighter across docs site:
- neutral-400 → neutral-300
- neutral-500 → neutral-400
- neutral-600 → neutral-500
- gray-400 → gray-300

🤖 Generated with [Claude Code](https://claude.com/claude-code)



* docs: brighten text colors in MDX, blog, and sidebar components

Apply consistent lighter text tones across documentation:
- MDX components (paragraphs, lists, code, tables, etc.)
- Blog list and post pages
- Sidebar navigation
- Docs navigation
- Note, Tabs, SuitabilityTable components

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---------