### PR TITLE
fix(react): stabilize ref callback with useCallback and useMemo

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/react",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "React bindings for SSGOI - Native app-like page transitions for React applications",
   "private": false,
   "type": "module",

--- a/packages/react/src/lib/ssgoi-transition.tsx
+++ b/packages/react/src/lib/ssgoi-transition.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef } from "react";
+import { useRef, useCallback, useMemo } from "react";
 import type { ReactNode, ElementType, CSSProperties } from "react";
 import { transition } from "./transition";
 import { useSsgoi } from "./context";
@@ -45,12 +45,23 @@ export const SsgoiTransition = <T extends ElementType = "div">({
     );
   }
 
-  const transitionRef = transition(getTransition(id));
-
-  const combinedRef = combineRefs<HTMLElement>((el) => {
+  const setElementRef = useCallback((el: HTMLElement | null) => {
     elementRef.current = el;
-    isFirstRenderRef.current = false;
-  }, transitionRef);
+    if (el) {
+      isFirstRenderRef.current = false;
+    }
+  }, []);
+
+  const transitionConfig = getTransition(id);
+  const transitionRef = useMemo(
+    () => transition(transitionConfig),
+    [transitionConfig],
+  );
+
+  const combinedRef = useMemo(
+    () => combineRefs<HTMLElement>(setElementRef, transitionRef),
+    [setElementRef, transitionRef],
+  );
 
   return (
     <Component


### PR DESCRIPTION
## Summary
- Stabilize ref callback references in `SsgoiTransition` to prevent unnecessary re-executions
- Wrap `setElementRef` with `useCallback` for stable function reference
- Memoize `transitionRef` and `combinedRef` with `useMemo`

## Problem
The inline arrow function passed to `combineRefs` was creating a new reference on every render, causing React to:
1. Call the previous ref callback with `null`
2. Call the new ref callback with the element

This led to unnecessary ref callback executions on every re-render.

## Test plan
- [x] Build passes
- [x] Published as `@ssgoi/react@4.2.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)