### PR TITLE
chore(core): remove popmotion from vite config

### DIFF
--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -18,13 +18,9 @@ export default defineConfig({
       formats: ["es", "cjs"],
     },
     rollupOptions: {
-      external: ["popmotion"],
       output: {
         preserveModules: false,
         exports: "named",
-        globals: {
-          popmotion: "popmotion",
-        },
       },
     },
   },


### PR DESCRIPTION
## Summary
- Remove leftover popmotion references from rollupOptions in vite.config.ts
- Cleanup after popmotion dependency removal

## Test plan
- [x] Verify no popmotion references remain in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)