### PR TITLE
feat(core): add customizable options for mobile view transitions

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/core",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "Core animation engine for SSGOI - Native app-like page transitions with spring physics",
   "private": false,
   "type": "module",

--- a/packages/core/src/lib/view-transitions/depth.ts
+++ b/packages/core/src/lib/view-transitions/depth.ts
@@ -26,12 +26,14 @@ const EXIT_PHYSICS: PhysicsOptions = {
   },
 };
 
-/** Scale offset for depth effect (10% = 0.1) */
-const SCALE_OFFSET = 0.05;
+/** Default scale offset for depth effect (5% = 0.05) */
+const DEFAULT_SCALE_OFFSET = 0.05;
 
 interface DepthOptions {
   direction?: "enter" | "exit";
   physics?: PhysicsOptions;
+  /** Scale offset as a fraction (default: 0.05 = 5%) */
+  scaleOffset?: number;
 }
 
 /**
@@ -67,6 +69,7 @@ export const depth = (options: DepthOptions = {}): SggoiTransition => {
   const { direction = "enter" } = options;
   const physicsOptions =
     options.physics ?? (direction === "enter" ? ENTER_PHYSICS : EXIT_PHYSICS);
+  const scaleOffset = options.scaleOffset ?? DEFAULT_SCALE_OFFSET;
 
   // Shared promise for coordinating OUT and IN animations
   let { promise: outAnimationComplete, resolve: resolveOutAnimation } =
@@ -101,7 +104,7 @@ export const depth = (options: DepthOptions = {}): SggoiTransition => {
             }
           },
           css: (progress): StyleObject => ({
-            transform: `scale(${1 - SCALE_OFFSET + progress * SCALE_OFFSET})`,
+            transform: `scale(${1 - scaleOffset + progress * scaleOffset})`,
             opacity: progress,
           }),
           onEnd: () => {
@@ -135,7 +138,7 @@ export const depth = (options: DepthOptions = {}): SggoiTransition => {
             element.style.transformOrigin = `${centerX}px ${centerY}px`;
           },
           css: (progress): StyleObject => ({
-            transform: `scale(${1 + (1 - progress) * SCALE_OFFSET})`,
+            transform: `scale(${1 + (1 - progress) * scaleOffset})`,
             opacity: progress,
           }),
           onEnd: () => {
@@ -175,7 +178,7 @@ export const depth = (options: DepthOptions = {}): SggoiTransition => {
             }
           },
           css: (progress): StyleObject => ({
-            transform: `scale(${1 + SCALE_OFFSET - progress * SCALE_OFFSET})`,
+            transform: `scale(${1 + scaleOffset - progress * scaleOffset})`,
             opacity: progress,
           }),
           onEnd: () => {
@@ -209,7 +212,7 @@ export const depth = (options: DepthOptions = {}): SggoiTransition => {
             element.style.transformOrigin = `${centerX}px ${centerY}px`;
           },
           css: (progress): StyleObject => ({
-            transform: `scale(${1 - (1 - progress) * SCALE_OFFSET})`,
+            transform: `scale(${1 - (1 - progress) * scaleOffset})`,
             opacity: progress,
           }),
           onEnd: () => {

--- a/packages/core/src/lib/view-transitions/sheet.ts
+++ b/packages/core/src/lib/view-transitions/sheet.ts
@@ -21,9 +21,14 @@ const EXIT: PhysicsOptions = {
   },
 };
 
+/** Default scale offset for sheet effect (20% = 0.2) */
+const DEFAULT_SCALE_OFFSET = 0.2;
+
 interface SheetOptions {
   direction?: "enter" | "exit";
   physics?: PhysicsOptions;
+  /** Scale offset as a fraction (default: 0.2 = 20%) */
+  scaleOffset?: number;
 }
 
 /**
@@ -59,6 +64,7 @@ export const sheet = (options: SheetOptions = {}): SggoiTransition => {
   const { direction = "enter" } = options;
   const physicsOptions =
     options.physics ?? (direction === "enter" ? ENTER : EXIT);
+  const scaleOffset = options.scaleOffset ?? DEFAULT_SCALE_OFFSET;
 
   if (direction === "enter") {
     // Forward: Sheet enters from bottom, background scales down
@@ -109,7 +115,7 @@ export const sheet = (options: SheetOptions = {}): SggoiTransition => {
             element.style.transformOrigin = `${centerX}px ${centerY}px`;
           },
           css: (progress): StyleObject => ({
-            transform: `scale(${0.8 + progress * 0.2})`,
+            transform: `scale(${1 - scaleOffset + progress * scaleOffset})`,
             opacity: progress,
           }),
         };
@@ -135,7 +141,7 @@ export const sheet = (options: SheetOptions = {}): SggoiTransition => {
             element.style.transformOrigin = `${centerX}px ${centerY}px`;
           },
           css: (progress): StyleObject => ({
-            transform: `scale(${0.8 + progress * 0.2})`,
+            transform: `scale(${1 - scaleOffset + progress * scaleOffset})`,
             opacity: progress,
           }),
           onEnd: () => {

--- a/packages/core/src/lib/view-transitions/snap.ts
+++ b/packages/core/src/lib/view-transitions/snap.ts
@@ -2,7 +2,7 @@ import type { PhysicsOptions, SggoiTransition, StyleObject } from "../types";
 import { prepareOutgoing } from "../utils/prepare-outgoing";
 import { withResolvers } from "../utils";
 
-const TRANSLATE_OFFSET = 8; // px
+const DEFAULT_TRANSLATE_OFFSET = 8; // px
 
 const DEFAULT_PHYSICS: PhysicsOptions = {
   spring: {
@@ -16,6 +16,8 @@ const DEFAULT_PHYSICS: PhysicsOptions = {
 interface SnapOptions {
   direction?: "left" | "right";
   physics?: PhysicsOptions;
+  /** Translation offset in pixels (default: 8) */
+  translateOffset?: number;
 }
 
 /**
@@ -27,6 +29,7 @@ interface SnapOptions {
 export const snap = (options: SnapOptions = {}): SggoiTransition => {
   const direction = options.direction ?? "left";
   const physicsOptions = options.physics ?? DEFAULT_PHYSICS;
+  const translateOffset = options.translateOffset ?? DEFAULT_TRANSLATE_OFFSET;
 
   const isLeft = direction === "left";
 
@@ -60,8 +63,8 @@ export const snap = (options: SnapOptions = {}): SggoiTransition => {
           // If direction="left", IN page slides from right (positive → 0)
           // If direction="right", IN page slides from left (negative → 0)
           const translateX = isLeft
-            ? (1 - progress) * TRANSLATE_OFFSET
-            : (1 - progress) * -TRANSLATE_OFFSET;
+            ? (1 - progress) * translateOffset
+            : (1 - progress) * -translateOffset;
 
           // Opacity: IN_OPACITY_START → 1
           const opacity = `${progress}`;
@@ -94,11 +97,11 @@ export const snap = (options: SnapOptions = {}): SggoiTransition => {
         },
         css: (progress): StyleObject => {
           // Slide in the same direction as navigation
-          // If direction="left", OUT page slides left (0 → -8px)
-          // If direction="right", OUT page slides right (0 → 8px)
+          // If direction="left", OUT page slides left (0 → -offset)
+          // If direction="right", OUT page slides right (0 → offset)
           const translateX = isLeft
-            ? (1 - progress) * -TRANSLATE_OFFSET
-            : (1 - progress) * TRANSLATE_OFFSET;
+            ? (1 - progress) * -translateOffset
+            : (1 - progress) * translateOffset;
 
           // Opacity: 1 → OUT_OPACITY_MIN
           const opacity = `${progress}`;

--- a/packages/core/src/lib/view-transitions/swap.ts
+++ b/packages/core/src/lib/view-transitions/swap.ts
@@ -17,11 +17,13 @@ const DEFAULT_PHYSICS: PhysicsOptions = {
   },
 };
 
-/** Scale offset for swap effect (5% = 0.05) */
-const SCALE_OFFSET = 0.05;
+/** Default scale offset for swap effect (5% = 0.05) */
+const DEFAULT_SCALE_OFFSET = 0.05;
 
 interface SwapOptions {
   physics?: PhysicsOptions;
+  /** Scale offset as a fraction (default: 0.05 = 5%) */
+  scaleOffset?: number;
 }
 
 /**
@@ -50,6 +52,7 @@ function getSwapRect(context: SggoiTransitionContext) {
  */
 export const swap = (options: SwapOptions = {}): SggoiTransition => {
   const physicsOptions = options.physics ?? DEFAULT_PHYSICS;
+  const scaleOffset = options.scaleOffset ?? DEFAULT_SCALE_OFFSET;
 
   // Shared promise for coordinating OUT and IN animations
   let { promise: outAnimationComplete, resolve: resolveOutAnimation } =
@@ -81,7 +84,7 @@ export const swap = (options: SwapOptions = {}): SggoiTransition => {
           }
         },
         css: (progress): StyleObject => ({
-          transform: `scale(${1 - SCALE_OFFSET + progress * SCALE_OFFSET})`,
+          transform: `scale(${1 - scaleOffset + progress * scaleOffset})`,
           opacity: progress,
         }),
         onEnd: () => {


### PR DESCRIPTION
## Summary
- Add `translateOffset` option to `snap` transition (default: 8px)
- Add `scaleOffset` option to `swap` transition (default: 0.05 = 5%)
- Add `scaleOffset` option to `depth` transition (default: 0.05 = 5%)

These options allow developers to fine-tune transition animations for better mobile experience while maintaining backward compatibility with existing implementations.

## Usage

```typescript
// Custom snap transition with larger slide offset
snap({ direction: 'left', translateOffset: 16 })

// Custom swap transition with more pronounced scale
swap({ scaleOffset: 0.1 })

// Custom depth transition with subtle scale
depth({ direction: 'enter', scaleOffset: 0.03 })
```

## Test plan
- [ ] Verify default values match previous behavior
- [ ] Test custom `translateOffset` in snap transition
- [ ] Test custom `scaleOffset` in swap transition
- [ ] Test custom `scaleOffset` in depth transition
- [ ] Confirm TypeScript types are exported correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)