### PR TITLE
feat(core): add preserveScroll option for automatic scroll position restoration

### DIFF
--- a/apps/react-demo/app/layout.tsx
+++ b/apps/react-demo/app/layout.tsx
@@ -10,6 +10,7 @@ import {
 import "./globals.css";
 
 const ssgoiConfig: SsgoiConfig = {
+  experimentalPreserveScroll: true,
   transitions: [
     // Use hero transition between main and item detail pages
     {

--- a/apps/svelte-demo/src/routes/+layout.svelte
+++ b/apps/svelte-demo/src/routes/+layout.svelte
@@ -10,6 +10,7 @@
   let { children }: Props = $props();
 
   const ssgoiConfig = {
+    experimentalPreserveScroll: true,
     transitions: [
       // Use hero transition between main and item detail pages
       {

--- a/packages/core/src/lib/ssgoi-transition/create-context-manager.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-context-manager.ts
@@ -46,7 +46,6 @@ export function createContextManager(options: ContextManagerOptions = {}) {
           scrollContainer.scrollTo({
             top: savedPosition.y,
             left: savedPosition.x,
-            // No smooth scroll - instant restoration
           });
         }
       });

--- a/packages/core/src/lib/ssgoi-transition/create-ssgoi-transition-context.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-ssgoi-transition-context.ts
@@ -72,7 +72,7 @@ export function createSggoiTransitionContext(
     defaultTransition,
     middleware = (from, to) => ({ from, to }), // Identity function as default
     skipOnIosSwipe = true, // Default to true - skip animations on iOS swipe
-    preserveScroll = false, // Default to false - manual scroll management
+    experimentalPreserveScroll = false, // Default to false - manual scroll management
   } = options;
 
   // Internal options (set by framework adapters)
@@ -93,7 +93,7 @@ export function createSggoiTransitionContext(
     getScrollContainer,
     getPositionedParentElement,
     getScrollPosition,
-  } = createContextManager({ preserveScroll });
+  } = createContextManager({ preserveScroll: experimentalPreserveScroll });
 
   // Initialize swipe detector
   const swipeDetector = createSwipeDetector(skipOnIosSwipe);

--- a/packages/core/src/lib/ssgoi-transition/create-ssgoi-transition-context.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-ssgoi-transition-context.ts
@@ -72,6 +72,7 @@ export function createSggoiTransitionContext(
     defaultTransition,
     middleware = (from, to) => ({ from, to }), // Identity function as default
     skipOnIosSwipe = true, // Default to true - skip animations on iOS swipe
+    preserveScroll = false, // Default to false - manual scroll management
   } = options;
 
   // Internal options (set by framework adapters)
@@ -85,14 +86,14 @@ export function createSggoiTransitionContext(
   // Process symmetric transitions - creates bidirectional transitions automatically
   const processedTransitions = processSymmetricTransitions(transitions);
 
-  // Initialize context manager
+  // Initialize context manager with preserveScroll option
   const {
     initializeContext,
     calculateScrollOffset,
     getScrollContainer,
     getPositionedParentElement,
     getScrollPosition,
-  } = createContextManager();
+  } = createContextManager({ preserveScroll });
 
   // Initialize swipe detector
   const swipeDetector = createSwipeDetector(skipOnIosSwipe);

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -461,13 +461,15 @@ export type SsgoiConfig = {
    */
   skipOnIosSwipe?: boolean;
   /**
-   * Automatically preserve and restore scroll position when navigating between pages
+   * @description Automatically preserve and restore scroll position when navigating between pages.
    * When enabled, SSGOI will:
    * - Save scroll position when leaving a page
    * - Restore scroll position when returning to a previously visited page
+   *
+   * @experimental This is an experimental feature and may change in future versions.
    * @default false
    */
-  preserveScroll?: boolean;
+  experimentalPreserveScroll?: boolean;
 };
 
 /**

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -460,6 +460,14 @@ export type SsgoiConfig = {
    * @default true
    */
   skipOnIosSwipe?: boolean;
+  /**
+   * Automatically preserve and restore scroll position when navigating between pages
+   * When enabled, SSGOI will:
+   * - Save scroll position when leaving a page
+   * - Restore scroll position when returning to a previously visited page
+   * @default false
+   */
+  preserveScroll?: boolean;
 };
 
 /**

--- a/templates/nextjs/src/components/demo-layout.tsx
+++ b/templates/nextjs/src/components/demo-layout.tsx
@@ -1,13 +1,12 @@
 "use client";
 
-import React, { useMemo, useRef, useEffect, useLayoutEffect } from "react";
+import React, { useMemo } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Ssgoi } from "@ssgoi/react";
 import {
   drill,
   pinterest,
-  fade,
   instagram,
 } from "@ssgoi/react/view-transitions";
 
@@ -17,41 +16,10 @@ interface DemoLayoutProps {
 
 export default function DemoLayout({ children }: DemoLayoutProps) {
   const pathname = usePathname();
-  const pathRef = useRef(pathname);
-  pathRef.current = pathname;
-  const mainRef = useRef<HTMLElement>(null);
-  const scrollPositions = useRef<Record<string, number>>({});
-  const previousPath = useRef(pathname);
-
-  useEffect(() => {
-    if (!mainRef.current) return;
-
-    const handleScroll = () => {
-      if (!mainRef.current) return;
-      scrollPositions.current[pathRef.current] = mainRef.current.scrollTop;
-    };
-
-    const element = mainRef.current;
-    element.addEventListener("scroll", handleScroll);
-    return () => {
-      element?.removeEventListener("scroll", handleScroll);
-    };
-  }, []);
-
-  // Restore scroll position when path changes
-  useLayoutEffect(() => {
-    if (!mainRef.current) return;
-    const savedPosition = scrollPositions.current[pathname] || 0;
-
-    if (mainRef.current) {
-      mainRef.current.scrollTop = savedPosition;
-    }
-
-    previousPath.current = pathname;
-  }, [pathname]);
 
   const config = useMemo(
     () => ({
+      experimentalPreserveScroll: true,
       transitions: [
         // Pinterest transitions
         {
@@ -89,7 +57,6 @@ export default function DemoLayout({ children }: DemoLayoutProps) {
       <div className="w-full bg-[#121212] flex flex-col overflow-hidden relative">
         {/* Main Content Area */}
         <main
-          ref={mainRef}
           id="demo-content"
           className="flex-1 w-full overflow-y-scroll overflow-x-hidden relative z-0 bg-[#121212] scrollbar-hide"
         >

--- a/templates/nextjs/tsconfig.json
+++ b/templates/nextjs/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -11,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "incremental": true,
     "plugins": [
       {
@@ -19,7 +23,9 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
   "include": [
@@ -30,5 +36,7 @@
     ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/templates/nuxt/components/demo-layout.vue
+++ b/templates/nuxt/components/demo-layout.vue
@@ -4,10 +4,8 @@
     <div class="w-full bg-[#121212] flex flex-col overflow-hidden relative">
       <!-- Main Content Area -->
       <main
-        ref="mainRef"
         id="demo-content"
         class="flex-1 w-full overflow-y-scroll overflow-x-hidden relative z-0 bg-[#121212] scrollbar-hide"
-        @scroll="handleScroll"
       >
         <Ssgoi :config="config">
           <slot />
@@ -99,7 +97,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount, watch } from 'vue';
+import { computed } from 'vue';
 import { useRoute } from 'vue-router';
 import { Ssgoi } from '@ssgoi/vue';
 import type { SsgoiConfig } from '@ssgoi/vue';
@@ -111,11 +109,9 @@ import {
 
 const route = useRoute();
 const pathname = computed(() => route.path);
-const mainRef = ref<HTMLElement | null>(null);
-const scrollPositions = ref<Record<string, number>>({});
-const previousPath = ref(pathname.value);
 
 const config: SsgoiConfig = {
+  experimentalPreserveScroll: true,
   transitions: [
     // Pinterest transitions
     {
@@ -145,20 +141,4 @@ const config: SsgoiConfig = {
   ],
 };
 
-const handleScroll = () => {
-  if (!mainRef.value) return;
-  scrollPositions.value[pathname.value] = mainRef.value.scrollTop;
-};
-
-// Restore scroll position when path changes
-watch(pathname, () => {
-  if (!mainRef.value) return;
-  const savedPosition = scrollPositions.value[pathname.value] || 0;
-
-  if (mainRef.value) {
-    mainRef.value.scrollTop = savedPosition;
-  }
-
-  previousPath.value = pathname.value;
-});
 </script>

--- a/templates/react-router/app/components/demo-layout.tsx
+++ b/templates/react-router/app/components/demo-layout.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useEffect, useLayoutEffect } from "react";
+import React, { useMemo } from "react";
 import { Link, useLocation } from "react-router";
 import { Ssgoi } from "@ssgoi/react";
 import {
@@ -14,41 +14,10 @@ interface DemoLayoutProps {
 export default function DemoLayout({ children }: DemoLayoutProps) {
   const location = useLocation();
   const pathname = location.pathname;
-  const pathRef = useRef(pathname);
-  pathRef.current = pathname;
-  const mainRef = useRef<HTMLElement>(null);
-  const scrollPositions = useRef<Record<string, number>>({});
-  const previousPath = useRef(pathname);
-
-  useEffect(() => {
-    if (!mainRef.current) return;
-
-    const handleScroll = () => {
-      if (!mainRef.current) return;
-      scrollPositions.current[pathRef.current] = mainRef.current.scrollTop;
-    };
-
-    const element = mainRef.current;
-    element.addEventListener("scroll", handleScroll);
-    return () => {
-      element?.removeEventListener("scroll", handleScroll);
-    };
-  }, []);
-
-  // Restore scroll position when path changes
-  useLayoutEffect(() => {
-    if (!mainRef.current) return;
-    const savedPosition = scrollPositions.current[pathname] || 0;
-
-    if (mainRef.current) {
-      mainRef.current.scrollTop = savedPosition;
-    }
-
-    previousPath.current = pathname;
-  }, [pathname]);
 
   const config = useMemo(
     () => ({
+      experimentalPreserveScroll: true,
       transitions: [
         // Pinterest transitions
         {
@@ -86,7 +55,6 @@ export default function DemoLayout({ children }: DemoLayoutProps) {
       <div className="w-full bg-[#121212] flex flex-col overflow-hidden relative">
         {/* Main Content Area */}
         <main
-          ref={mainRef}
           id="demo-content"
           className="flex-1 w-full overflow-y-scroll overflow-x-hidden relative z-0 bg-[#121212] scrollbar-hide"
         >

--- a/templates/sveltekit/src/lib/components/demo-layout.svelte
+++ b/templates/sveltekit/src/lib/components/demo-layout.svelte
@@ -6,11 +6,8 @@
 
 	let { children } = $props();
 
-	let mainElement: HTMLElement | null = $state(null);
-	let scrollPositions: Record<string, number> = {};
-	let previousPath = $state($page.url.pathname);
-
 	const config = {
+		experimentalPreserveScroll: true,
 		transitions: [
 			// Pinterest transitions
 			{
@@ -39,26 +36,6 @@
 			}
 		]
 	};
-
-	$effect(() => {
-		const pathname = $page.url.pathname;
-		if (mainElement && previousPath !== pathname) {
-			// Save current scroll position
-			scrollPositions[previousPath] = mainElement.scrollTop;
-
-			// Restore scroll position for new page
-			const savedPosition = scrollPositions[pathname] || 0;
-			mainElement.scrollTop = savedPosition;
-
-			previousPath = pathname;
-		}
-	});
-
-	function handleScroll() {
-		if (mainElement) {
-			scrollPositions[$page.url.pathname] = mainElement.scrollTop;
-		}
-	}
 </script>
 
 <div class="h-full bg-[#121212] flex z-0">
@@ -66,8 +43,6 @@
 	<div class="w-full bg-[#121212] flex flex-col overflow-hidden relative">
 		<!-- Main Content Area -->
 		<main
-			bind:this={mainElement}
-			onscroll={handleScroll}
 			id="demo-content"
 			class="flex-1 w-full overflow-y-scroll overflow-x-hidden relative z-0 bg-[#121212] scrollbar-hide"
 		>

--- a/templates/tanstack-router/app/components/demo-layout.tsx
+++ b/templates/tanstack-router/app/components/demo-layout.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useEffect, useLayoutEffect } from "react";
+import React, { useMemo } from "react";
 import { Link, useRouterState } from "@tanstack/react-router";
 import { Ssgoi } from "@ssgoi/react";
 import {
@@ -14,45 +14,10 @@ interface DemoLayoutProps {
 export default function DemoLayout({ children }: DemoLayoutProps) {
   const location = useRouterState({ select: (s) => s.location });
   const pathname = location.pathname;
-  const pathRef = useRef(pathname);
-  pathRef.current = pathname;
-  const mainRef = useRef<HTMLElement>(null);
-  const scrollPositions = useRef<Record<string, number>>({});
-
-  useEffect(() => {
-    if (!mainRef.current) return;
-
-    const handleScroll = () => {
-      if (!mainRef.current) return;
-      scrollPositions.current[pathRef.current] = mainRef.current.scrollTop;
-    };
-
-    const element = mainRef.current;
-    element.addEventListener("scroll", handleScroll);
-    return () => {
-      element?.removeEventListener("scroll", handleScroll);
-    };
-  }, []);
-
-  // Restore scroll position when path changes
-  useEffect(() => {
-    if (!mainRef.current) return;
-    const savedPosition = scrollPositions.current[pathname] || 0;
-
-    const restoreScroll = () => {
-      if (!mainRef.current) return;
-      mainRef.current.scrollTop = savedPosition;
-
-      if (mainRef.current.scrollTop !== savedPosition && savedPosition > 0) {
-        requestAnimationFrame(restoreScroll);
-      }
-    };
-
-    requestAnimationFrame(restoreScroll);
-  }, [pathname]);
 
   const config = useMemo(
     () => ({
+      experimentalPreserveScroll: true,
       transitions: [
         // Pinterest transitions
         {
@@ -90,7 +55,6 @@ export default function DemoLayout({ children }: DemoLayoutProps) {
       <div className="w-full bg-[#121212] flex flex-col overflow-hidden relative">
         {/* Main Content Area */}
         <main
-          ref={mainRef}
           id="demo-content"
           className="flex-1 w-full overflow-y-scroll overflow-x-hidden relative z-0 bg-[#121212] scrollbar-hide"
         >


### PR DESCRIPTION
## Summary

Add `preserveScroll` option to `SsgoiConfig` that automatically saves and restores scroll positions when navigating between pages.

## Motivation

Currently, users need to implement manual scroll preservation logic in their layout components (using `useLayoutEffect` in React, for example). This is boilerplate code that most users will need.

Example of current workaround (from `templates/nextjs/src/components/demo-layout.tsx`):

```tsx
const scrollPositions = useRef<Record<string, number>>({});

useEffect(() => {
  const handleScroll = () => {
    scrollPositions.current[pathRef.current] = mainRef.current.scrollTop;
  };
  element.addEventListener("scroll", handleScroll);
  return () => element.removeEventListener("scroll", handleScroll);
}, []);

useLayoutEffect(() => {
  const savedPosition = scrollPositions.current[pathname] || 0;
  mainRef.current.scrollTop = savedPosition;
}, [pathname]);
```

## Solution

Add a simple `preserveScroll` option that handles this automatically:

```typescript
const config = {
  preserveScroll: true,  // Enable automatic scroll preservation
  transitions: [
    { from: '/home', to: '/about', transition: fade() }
  ]
};
```

## Changes

- **`packages/core/src/lib/types.ts`**: Added `preserveScroll?: boolean` to `SsgoiConfig`
- **`packages/core/src/lib/ssgoi-transition/create-context-manager.ts`**: 
  - Added `ContextManagerOptions` type with `preserveScroll` option
  - Added `restoreScrollPosition()` function that restores scroll on navigation
  - Uses `requestAnimationFrame` for reliable DOM timing
- **`packages/core/src/lib/ssgoi-transition/create-ssgoi-transition-context.ts`**: 
  - Pass `preserveScroll` option to context manager

## Test Plan

- [ ] Test with Next.js template - navigate between pages and verify scroll restoration
- [ ] Test with SvelteKit template
- [ ] Test with various scroll containers (window, custom scrollable div)
- [ ] Verify backward compatibility when option is not set (default: false)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)