### PR TITLE
feat(templates): enable experimentalPreserveScroll in all templates

### DIFF
--- a/apps/react-demo/app/layout.tsx
+++ b/apps/react-demo/app/layout.tsx
@@ -10,6 +10,7 @@ import {
 import "./globals.css";
 
 const ssgoiConfig: SsgoiConfig = {
+  experimentalPreserveScroll: true,
   transitions: [
     // Use hero transition between main and item detail pages
     {

--- a/apps/svelte-demo/src/routes/+layout.svelte
+++ b/apps/svelte-demo/src/routes/+layout.svelte
@@ -10,6 +10,7 @@
   let { children }: Props = $props();
 
   const ssgoiConfig = {
+    experimentalPreserveScroll: true,
     transitions: [
       // Use hero transition between main and item detail pages
       {

--- a/templates/nuxt/components/demo-layout.vue
+++ b/templates/nuxt/components/demo-layout.vue
@@ -4,10 +4,8 @@
     <div class="w-full bg-[#121212] flex flex-col overflow-hidden relative">
       <!-- Main Content Area -->
       <main
-        ref="mainRef"
         id="demo-content"
         class="flex-1 w-full overflow-y-scroll overflow-x-hidden relative z-0 bg-[#121212] scrollbar-hide"
-        @scroll="handleScroll"
       >
         <Ssgoi :config="config">
           <slot />
@@ -99,7 +97,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onMounted, onBeforeUnmount, watch } from 'vue';
+import { computed } from 'vue';
 import { useRoute } from 'vue-router';
 import { Ssgoi } from '@ssgoi/vue';
 import type { SsgoiConfig } from '@ssgoi/vue';
@@ -111,11 +109,9 @@ import {
 
 const route = useRoute();
 const pathname = computed(() => route.path);
-const mainRef = ref<HTMLElement | null>(null);
-const scrollPositions = ref<Record<string, number>>({});
-const previousPath = ref(pathname.value);
 
 const config: SsgoiConfig = {
+  experimentalPreserveScroll: true,
   transitions: [
     // Pinterest transitions
     {
@@ -145,20 +141,4 @@ const config: SsgoiConfig = {
   ],
 };
 
-const handleScroll = () => {
-  if (!mainRef.value) return;
-  scrollPositions.value[pathname.value] = mainRef.value.scrollTop;
-};
-
-// Restore scroll position when path changes
-watch(pathname, () => {
-  if (!mainRef.value) return;
-  const savedPosition = scrollPositions.value[pathname.value] || 0;
-
-  if (mainRef.value) {
-    mainRef.value.scrollTop = savedPosition;
-  }
-
-  previousPath.value = pathname.value;
-});
 </script>

--- a/templates/react-router/app/components/demo-layout.tsx
+++ b/templates/react-router/app/components/demo-layout.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useEffect, useLayoutEffect } from "react";
+import React, { useMemo } from "react";
 import { Link, useLocation } from "react-router";
 import { Ssgoi } from "@ssgoi/react";
 import {
@@ -14,41 +14,10 @@ interface DemoLayoutProps {
 export default function DemoLayout({ children }: DemoLayoutProps) {
   const location = useLocation();
   const pathname = location.pathname;
-  const pathRef = useRef(pathname);
-  pathRef.current = pathname;
-  const mainRef = useRef<HTMLElement>(null);
-  const scrollPositions = useRef<Record<string, number>>({});
-  const previousPath = useRef(pathname);
-
-  useEffect(() => {
-    if (!mainRef.current) return;
-
-    const handleScroll = () => {
-      if (!mainRef.current) return;
-      scrollPositions.current[pathRef.current] = mainRef.current.scrollTop;
-    };
-
-    const element = mainRef.current;
-    element.addEventListener("scroll", handleScroll);
-    return () => {
-      element?.removeEventListener("scroll", handleScroll);
-    };
-  }, []);
-
-  // Restore scroll position when path changes
-  useLayoutEffect(() => {
-    if (!mainRef.current) return;
-    const savedPosition = scrollPositions.current[pathname] || 0;
-
-    if (mainRef.current) {
-      mainRef.current.scrollTop = savedPosition;
-    }
-
-    previousPath.current = pathname;
-  }, [pathname]);
 
   const config = useMemo(
     () => ({
+      experimentalPreserveScroll: true,
       transitions: [
         // Pinterest transitions
         {
@@ -86,7 +55,6 @@ export default function DemoLayout({ children }: DemoLayoutProps) {
       <div className="w-full bg-[#121212] flex flex-col overflow-hidden relative">
         {/* Main Content Area */}
         <main
-          ref={mainRef}
           id="demo-content"
           className="flex-1 w-full overflow-y-scroll overflow-x-hidden relative z-0 bg-[#121212] scrollbar-hide"
         >

--- a/templates/sveltekit/src/lib/components/demo-layout.svelte
+++ b/templates/sveltekit/src/lib/components/demo-layout.svelte
@@ -6,11 +6,8 @@
 
 	let { children } = $props();
 
-	let mainElement: HTMLElement | null = $state(null);
-	let scrollPositions: Record<string, number> = {};
-	let previousPath = $state($page.url.pathname);
-
 	const config = {
+		experimentalPreserveScroll: true,
 		transitions: [
 			// Pinterest transitions
 			{
@@ -39,26 +36,6 @@
 			}
 		]
 	};
-
-	$effect(() => {
-		const pathname = $page.url.pathname;
-		if (mainElement && previousPath !== pathname) {
-			// Save current scroll position
-			scrollPositions[previousPath] = mainElement.scrollTop;
-
-			// Restore scroll position for new page
-			const savedPosition = scrollPositions[pathname] || 0;
-			mainElement.scrollTop = savedPosition;
-
-			previousPath = pathname;
-		}
-	});
-
-	function handleScroll() {
-		if (mainElement) {
-			scrollPositions[$page.url.pathname] = mainElement.scrollTop;
-		}
-	}
 </script>
 
 <div class="h-full bg-[#121212] flex z-0">
@@ -66,8 +43,6 @@
 	<div class="w-full bg-[#121212] flex flex-col overflow-hidden relative">
 		<!-- Main Content Area -->
 		<main
-			bind:this={mainElement}
-			onscroll={handleScroll}
 			id="demo-content"
 			class="flex-1 w-full overflow-y-scroll overflow-x-hidden relative z-0 bg-[#121212] scrollbar-hide"
 		>

--- a/templates/tanstack-router/app/components/demo-layout.tsx
+++ b/templates/tanstack-router/app/components/demo-layout.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useEffect, useLayoutEffect } from "react";
+import React, { useMemo } from "react";
 import { Link, useRouterState } from "@tanstack/react-router";
 import { Ssgoi } from "@ssgoi/react";
 import {
@@ -14,45 +14,10 @@ interface DemoLayoutProps {
 export default function DemoLayout({ children }: DemoLayoutProps) {
   const location = useRouterState({ select: (s) => s.location });
   const pathname = location.pathname;
-  const pathRef = useRef(pathname);
-  pathRef.current = pathname;
-  const mainRef = useRef<HTMLElement>(null);
-  const scrollPositions = useRef<Record<string, number>>({});
-
-  useEffect(() => {
-    if (!mainRef.current) return;
-
-    const handleScroll = () => {
-      if (!mainRef.current) return;
-      scrollPositions.current[pathRef.current] = mainRef.current.scrollTop;
-    };
-
-    const element = mainRef.current;
-    element.addEventListener("scroll", handleScroll);
-    return () => {
-      element?.removeEventListener("scroll", handleScroll);
-    };
-  }, []);
-
-  // Restore scroll position when path changes
-  useEffect(() => {
-    if (!mainRef.current) return;
-    const savedPosition = scrollPositions.current[pathname] || 0;
-
-    const restoreScroll = () => {
-      if (!mainRef.current) return;
-      mainRef.current.scrollTop = savedPosition;
-
-      if (mainRef.current.scrollTop !== savedPosition && savedPosition > 0) {
-        requestAnimationFrame(restoreScroll);
-      }
-    };
-
-    requestAnimationFrame(restoreScroll);
-  }, [pathname]);
 
   const config = useMemo(
     () => ({
+      experimentalPreserveScroll: true,
       transitions: [
         // Pinterest transitions
         {
@@ -90,7 +55,6 @@ export default function DemoLayout({ children }: DemoLayoutProps) {
       <div className="w-full bg-[#121212] flex flex-col overflow-hidden relative">
         {/* Main Content Area */}
         <main
-          ref={mainRef}
           id="demo-content"
           className="flex-1 w-full overflow-y-scroll overflow-x-hidden relative z-0 bg-[#121212] scrollbar-hide"
         >


### PR DESCRIPTION
## Summary

Enable the `experimentalPreserveScroll` option across all framework templates and demo apps.

## Changes

- `templates/sveltekit` - enabled option, removed manual scroll handling
- `templates/nuxt` - enabled option, removed manual scroll handling
- `templates/react-router` - enabled option, removed manual scroll handling
- `templates/tanstack-router` - enabled option, removed manual scroll handling
- `apps/react-demo` - enabled option
- `apps/svelte-demo` - enabled option

## Test Results

| Template | Status |
|----------|--------|
| Next.js | ✅ Working |
| SvelteKit | ❌ Issues found |
| Nuxt | ❌ Issues found |
| React Router | ❌ Issues found |
| TanStack Router | ❌ Issues found |

These issues will be resolved once #292 is fixed.