### PR TITLE
fix(core): reset transform and opacity styles in drill transition onEnd

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/core",
-  "version": "4.3.1",
+  "version": "4.3.2",
   "description": "Core animation engine for SSGOI - Native app-like page transitions with spring physics",
   "private": false,
   "type": "module",

--- a/packages/core/src/lib/view-transitions/drill.ts
+++ b/packages/core/src/lib/view-transitions/drill.ts
@@ -54,6 +54,10 @@ export const drill = (options: DrillOptions = {}): SggoiTransition => {
           element.style.backfaceVisibility = "";
           (element.style as CSSStyleDeclaration & { contain: string }).contain =
             "";
+          element.style.transform = "";
+          if (opacity) {
+            element.style.opacity = "";
+          }
         },
       }),
       out: (element, context) => ({
@@ -109,6 +113,10 @@ export const drill = (options: DrillOptions = {}): SggoiTransition => {
           element.style.backfaceVisibility = "";
           (element.style as CSSStyleDeclaration & { contain: string }).contain =
             "";
+          element.style.transform = "";
+          if (opacity) {
+            element.style.opacity = "";
+          }
         },
       }),
       out: (element, context) => ({


### PR DESCRIPTION
## Summary
- Clear `transform` and `opacity` inline styles when drill transition's `in` animation completes
- Prevents mobile browser side effects caused by lingering `translate3d` values
- Applied to both `direction: "enter"` and `direction: "exit"` cases

## Test plan
- [ ] Test drill transition on mobile browsers (iOS Safari, Chrome Android)
- [ ] Verify no lingering transform styles after transition completes
- [ ] Confirm opacity resets properly when `opacity: true` option is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)