### PR TITLE
feat(core): add scrollResetPatterns option for selective scroll reset

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/core",
-  "version": "4.3.1",
+  "version": "4.4.0",
   "description": "Core animation engine for SSGOI - Native app-like page transitions with spring physics",
   "private": false,
   "type": "module",

--- a/packages/core/src/lib/ssgoi-transition/create-context-manager.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-context-manager.ts
@@ -1,5 +1,6 @@
 import { getScrollingElement } from "../utils/get-scrolling-element";
 import { getPositionedParent } from "../utils/get-positioned-parent";
+import { matchPath } from "./find-matching-transition";
 
 /**
  * Options for the context manager
@@ -10,6 +11,11 @@ export type ContextManagerOptions = {
    * @default false
    */
   preserveScroll?: boolean;
+  /**
+   * Patterns for routes that should reset scroll to 0 when leaving
+   * Uses the same wildcard matching as transition routes
+   */
+  resetPatterns?: string[];
 };
 
 /**
@@ -17,7 +23,12 @@ export type ContextManagerOptions = {
  * including scroll positions and DOM element relationships
  */
 export function createContextManager(options: ContextManagerOptions = {}) {
-  const { preserveScroll = false } = options;
+  const { preserveScroll = false, resetPatterns = [] } = options;
+
+  // Check if a path matches any reset pattern
+  const matchesResetPattern = (path: string): boolean => {
+    return resetPatterns.some((pattern) => matchPath(path, pattern));
+  };
 
   let scrollContainer: HTMLElement | null = null;
   let contextElement: HTMLElement | null = null;
@@ -40,8 +51,18 @@ export function createContextManager(options: ContextManagerOptions = {}) {
   const restoreScrollPosition = (path: string) => {
     if (!scrollContainer || !preserveScroll) return;
 
+    // If path matches reset pattern, always scroll to top
+    if (matchesResetPattern(path)) {
+      scrollContainer.scrollTo({ top: 0, left: 0 });
+      return;
+    }
+
     const savedPosition = scrollPositions.get(path);
-    if (!savedPosition) return;
+    if (!savedPosition) {
+      // First visit - scroll to top (SPA doesn't auto-reset scroll)
+      scrollContainer.scrollTo({ top: 0, left: 0 });
+      return;
+    }
 
     const maxRetries = 10;
     let retryCount = 0;
@@ -97,16 +118,7 @@ export function createContextManager(options: ContextManagerOptions = {}) {
     currentPath = path;
 
     // Restore scroll position if preserveScroll is enabled
-    // For first visits (no saved position), scroll to top
-    if (preserveScroll && scrollContainer) {
-      const savedPosition = scrollPositions.get(path);
-      if (savedPosition) {
-        restoreScrollPosition(path);
-      } else {
-        // First visit - scroll to top (SPA doesn't auto-reset scroll)
-        scrollContainer.scrollTo({ top: 0, left: 0 });
-      }
-    }
+    restoreScrollPosition(path);
 
     // Re-enable scroll listener after transition settles
     const maxTransitionRetries = 10;
@@ -134,8 +146,17 @@ export function createContextManager(options: ContextManagerOptions = {}) {
         ? scrollPositions.get(from)!
         : { x: 0, y: 0 };
 
-    const toScroll =
-      to && scrollPositions.has(to) ? scrollPositions.get(to)! : { x: 0, y: 0 };
+    // If 'to' matches reset pattern, use 0,0 and save it
+    const toMatchesReset = to && matchesResetPattern(to);
+    if (toMatchesReset) {
+      scrollPositions.set(to, { x: 0, y: 0 });
+    }
+
+    const toScroll = toMatchesReset
+      ? { x: 0, y: 0 }
+      : to && scrollPositions.has(to)
+        ? scrollPositions.get(to)!
+        : { x: 0, y: 0 };
 
     return {
       x: -toScroll.x + fromScroll.x,

--- a/packages/core/src/lib/ssgoi-transition/create-ssgoi-transition-context.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-ssgoi-transition-context.ts
@@ -73,6 +73,7 @@ export function createSggoiTransitionContext(
     middleware = (from, to) => ({ from, to }), // Identity function as default
     skipOnIosSwipe = true, // Default to true - skip animations on iOS swipe
     experimentalPreserveScroll = false, // Default to false - manual scroll management
+    scrollResetPatterns = [], // Default to empty array - no routes reset scroll
   } = options;
 
   // Internal options (set by framework adapters)
@@ -93,7 +94,10 @@ export function createSggoiTransitionContext(
     getScrollContainer,
     getPositionedParentElement,
     getScrollPosition,
-  } = createContextManager({ preserveScroll: experimentalPreserveScroll });
+  } = createContextManager({
+    preserveScroll: experimentalPreserveScroll,
+    resetPatterns: scrollResetPatterns,
+  });
 
   // Initialize swipe detector
   const swipeDetector = createSwipeDetector(skipOnIosSwipe);

--- a/packages/core/src/lib/ssgoi-transition/find-matching-transition.ts
+++ b/packages/core/src/lib/ssgoi-transition/find-matching-transition.ts
@@ -16,10 +16,11 @@ export function matchPath(path: string, pattern: string): boolean {
     return true;
   }
 
-  // Wildcard match - pattern ending with /* matches path and subpaths
+  // Wildcard match - pattern ending with /* matches only subpaths (not the prefix itself)
+  // e.g., "/posts/*" matches "/posts/123" but NOT "/posts" or "/posts/"
   if (pattern.endsWith("/*")) {
-    const prefix = pattern.slice(0, -2);
-    return path === prefix || path.startsWith(prefix + "/");
+    const prefix = pattern.slice(0, -1); // "/posts/"
+    return path.startsWith(prefix) && path.length > prefix.length;
   }
 
   // Exact match - paths must be identical

--- a/packages/core/src/lib/types.ts
+++ b/packages/core/src/lib/types.ts
@@ -470,6 +470,19 @@ export type SsgoiConfig = {
    * @default false
    */
   experimentalPreserveScroll?: boolean;
+  /**
+   * @description Patterns for routes that should always reset scroll to top when leaving.
+   * When navigating away from a matching route, scroll position will be saved as 0.
+   * This means returning to these routes will always start at the top.
+   *
+   * Supports wildcard patterns:
+   * - '/post/*' matches '/post/123', '/post/abc', etc.
+   * - '*' matches any path
+   *
+   * @example ['/post/*', '/article/*', '/product/detail/*']
+   * @experimental This is an experimental feature and may change in future versions.
+   */
+  scrollResetPatterns?: string[];
 };
 
 /**

--- a/templates/nextjs/src/components/demo-layout.tsx
+++ b/templates/nextjs/src/components/demo-layout.tsx
@@ -4,11 +4,7 @@ import React, { useMemo } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Ssgoi } from "@ssgoi/react";
-import {
-  drill,
-  pinterest,
-  instagram,
-} from "@ssgoi/react/view-transitions";
+import { drill, pinterest, instagram } from "@ssgoi/react/view-transitions";
 
 interface DemoLayoutProps {
   children: React.ReactNode;
@@ -20,6 +16,7 @@ export default function DemoLayout({ children }: DemoLayoutProps) {
   const config = useMemo(
     () => ({
       experimentalPreserveScroll: true,
+      scrollResetPatterns: ["/posts/*"],
       transitions: [
         // Pinterest transitions
         {


### PR DESCRIPTION
## Summary

- Add `scrollResetPatterns` config option to always reset scroll position to top for matching routes
- Fix wildcard pattern matching: `/posts/*` now correctly matches only `/posts/xxx`, not `/posts` or `/posts/` itself
- Integrate reset pattern check in both `restoreScrollPosition` and `calculateScrollOffset` for consistent behavior

## Usage

```typescript
const config = {
  experimentalPreserveScroll: true,
  scrollResetPatterns: ['/posts/*', '/article/*'],
  // ...
};
```

When navigating to `/posts/123`, scroll will always start at top regardless of previous scroll position.

## Test plan

- [ ] Verify `/posts/*` pattern matches `/posts/123` but not `/posts`
- [ ] Verify scroll resets to 0 when entering a route matching reset pattern
- [ ] Verify scroll is preserved for routes not matching reset patterns
- [ ] Verify transition animations work correctly with reset patterns

🤖 Generated with [Claude Code](https://claude.ai/code)