### PR TITLE
feat(core): React Activity API support

### DIFF
--- a/packages/core/src/lib/transition/activity-observer.ts
+++ b/packages/core/src/lib/transition/activity-observer.ts
@@ -1,0 +1,152 @@
+/**
+ * Activity Observer for detecting React Activity hidden state
+ *
+ * React 19.2's Activity component hides elements using `display: none`
+ * instead of unmounting them. This observer detects that style change
+ * and triggers exit animations without cloning.
+ *
+ * Detection flow:
+ * 1. Watch for style attribute changes on element
+ * 2. When display changes to 'none', it's Activity hiding
+ * 3. Reveal element (display: ''), run exit animation, then hide back (display: none)
+ */
+
+type ActivityHideCallback = (element: HTMLElement) => void;
+
+// Map of watched elements to their callbacks
+const watchedElements = new Map<HTMLElement, ActivityHideCallback>();
+
+// Shared observer instance
+let sharedObserver: MutationObserver | null = null;
+
+// Flag to track initialization
+let isInitialized = false;
+
+// Elements currently being animated (to prevent re-triggering)
+const animatingElements = new WeakSet<HTMLElement>();
+
+/**
+ * Check if element was hidden by Activity (display: none)
+ */
+function isActivityHidden(element: HTMLElement): boolean {
+  return element.style.display === "none";
+}
+
+/**
+ * Initialize the shared MutationObserver for Activity detection
+ */
+function initActivityObserver(): void {
+  if (isInitialized || typeof document === "undefined") return;
+
+  isInitialized = true;
+
+  sharedObserver = new MutationObserver((mutations) => {
+    for (const mutation of mutations) {
+      if (
+        mutation.type !== "attributes" ||
+        mutation.attributeName !== "style"
+      ) {
+        continue;
+      }
+
+      const element = mutation.target as HTMLElement;
+
+      // Skip if not watched
+      if (!watchedElements.has(element)) continue;
+
+      // Skip if currently animating (we set display ourselves)
+      if (animatingElements.has(element)) continue;
+
+      // Check if Activity just hid this element
+      if (isActivityHidden(element)) {
+        const callback = watchedElements.get(element)!;
+        // Mark as animating to prevent re-trigger
+        animatingElements.add(element);
+        callback(element);
+      }
+    }
+  });
+
+  if (document.body) {
+    sharedObserver.observe(document.body, {
+      attributes: true,
+      attributeFilter: ["style"],
+      subtree: true,
+    });
+  } else {
+    document.addEventListener(
+      "DOMContentLoaded",
+      () => {
+        sharedObserver?.observe(document.body, {
+          attributes: true,
+          attributeFilter: ["style"],
+          subtree: true,
+        });
+      },
+      { once: true },
+    );
+  }
+}
+
+/**
+ * Watch an element for Activity hide (display: none)
+ *
+ * @param element - Element to watch
+ * @param callback - Called when Activity hides the element
+ */
+export function watchActivityHide(
+  element: HTMLElement,
+  callback: ActivityHideCallback,
+): void {
+  initActivityObserver();
+  watchedElements.set(element, callback);
+}
+
+/**
+ * Stop watching an element
+ */
+export function unwatchActivityHide(element: HTMLElement): void {
+  watchedElements.delete(element);
+  animatingElements.delete(element);
+}
+
+/**
+ * Check if element is being watched for Activity
+ */
+export function isWatchedForActivity(element: HTMLElement): boolean {
+  return watchedElements.has(element);
+}
+
+/**
+ * Reveal an Activity-hidden element for animation
+ * Call this before running exit animation
+ */
+export function revealForAnimation(element: HTMLElement): void {
+  element.style.display = "";
+}
+
+/**
+ * Hide element back after animation completes
+ * Call this after exit animation finishes
+ */
+export function hideAfterAnimation(element: HTMLElement): void {
+  element.style.display = "none";
+  animatingElements.delete(element);
+}
+
+/**
+ * Mark animation as complete (cleanup)
+ */
+export function completeActivityAnimation(element: HTMLElement): void {
+  animatingElements.delete(element);
+}
+
+/**
+ * Reset observer (for testing)
+ */
+export function resetActivityObserver(): void {
+  watchedElements.clear();
+  sharedObserver?.disconnect();
+  sharedObserver = null;
+  isInitialized = false;
+}

--- a/packages/core/src/lib/transition/create-transition-callback.ts
+++ b/packages/core/src/lib/transition/create-transition-callback.ts
@@ -10,6 +10,12 @@ import {
 } from "./transition-strategy";
 import { findScope, isScopeReady } from "./transition-scope";
 import { waitPaint } from "../utils";
+import {
+  watchActivityHide,
+  unwatchActivityHide,
+  revealForAnimation,
+  hideAfterAnimation,
+} from "./activity-observer";
 
 export function createTransitionCallback(
   getTransition: () => Transition<undefined>,
@@ -106,8 +112,20 @@ export function createTransitionCallback(
     }
   };
 
-  const runExitTransition = async (element: HTMLElement) => {
-    currentClone = element;
+  /**
+   * Run exit transition
+   * @param element - Element to animate (clone for traditional mode, original for Activity mode)
+   * @param mode - 'clone' for traditional unmount, 'activity' for Activity hidden
+   */
+  const runExitTransition = async (
+    element: HTMLElement,
+    mode: "clone" | "activity" = "clone",
+  ) => {
+    const isActivityMode = mode === "activity";
+
+    if (!isActivityMode) {
+      currentClone = element;
+    }
 
     const transition = getTransition();
     const inConfig =
@@ -115,6 +133,14 @@ export function createTransitionCallback(
     const outConfig = transition.out && transition.out(element);
 
     if (!outConfig) {
+      if (!isActivityMode && currentClone) {
+        currentClone.remove();
+        currentClone = null;
+      }
+      if (isActivityMode) {
+        // Keep element hidden if no animation
+        hideAfterAnimation(element);
+      }
       return;
     }
 
@@ -130,16 +156,24 @@ export function createTransitionCallback(
       if (currentAnimation) {
         currentAnimation.direction = "out";
       }
-      if (currentClone) {
+      if (!isActivityMode && currentClone) {
         currentClone.remove();
         currentClone = null;
+      }
+      if (isActivityMode) {
+        hideAfterAnimation(element);
       }
       return;
     }
 
     const config = setup.config;
 
-    insertClone();
+    // Activity mode: reveal element; Clone mode: insert clone
+    if (isActivityMode) {
+      revealForAnimation(element);
+    } else {
+      insertClone();
+    }
     config.prepare?.();
 
     const normalizedConfig = normalizeSchedule(
@@ -147,7 +181,11 @@ export function createTransitionCallback(
         ...config,
         onEnd: () => {
           config.onEnd?.();
-          if (currentClone) {
+          if (isActivityMode) {
+            // Activity mode: hide element back
+            hideAfterAnimation(element);
+          } else if (currentClone) {
+            // Clone mode: remove clone
             currentClone.remove();
             currentClone = null;
           }
@@ -194,14 +232,39 @@ export function createTransitionCallback(
   // Cached scope reference (only set for 'local' scope)
   let scopeRef: Element | null = null;
 
-  // Track if unmount has been triggered (prevents double execution)
-  let unmountTriggered = false;
+  // Track if exit has been triggered (prevents double execution from both Activity and unmount)
+  let exitTriggered = false;
 
-  // Function to handle unmount - returns cleanup function for framework adapters
+  // Current element reference for Activity cleanup
+  let currentElementRef: HTMLElement | null = null;
+
+  // Handler for Activity hidden detection (display: none)
+  const handleActivityHide = (element: HTMLElement) => {
+    if (exitTriggered) return;
+    exitTriggered = true;
+
+    if (scopeRef) {
+      queueMicrotask(() => {
+        if (!document.contains(scopeRef!)) {
+          // Scope removed = skip OUT animation
+          hideAfterAnimation(element);
+          return;
+        }
+        runExitTransition(element, "activity");
+      });
+    } else {
+      runExitTransition(element, "activity");
+    }
+  };
+
+  // Function to handle unmount (traditional clone mode) - returns cleanup function for framework adapters
   const createUnmountHandler = (element: HTMLElement) => {
     return () => {
-      if (unmountTriggered) return;
-      unmountTriggered = true;
+      // Cleanup Activity watcher
+      unwatchActivityHide(element);
+
+      if (exitTriggered) return;
+      exitTriggered = true;
 
       const cloned = element.cloneNode(true) as HTMLElement;
 
@@ -212,24 +275,37 @@ export function createTransitionCallback(
             // Scope removed = simultaneous unmount = skip OUT animation
             return;
           }
-          runExitTransition(cloned);
+          runExitTransition(cloned, "clone");
         });
       } else {
         // Global scope: run immediately
-        runExitTransition(cloned);
+        runExitTransition(cloned, "clone");
       }
     };
   };
 
   return (element: HTMLElement | null) => {
     if (!element) return;
+
+    // Cleanup previous element's Activity watcher if any
+    if (currentElementRef) {
+      unwatchActivityHide(currentElementRef);
+    }
+    currentElementRef = element;
+
     requestAnimationFrame(() => {
       parentRef = element.parentElement;
       nextSiblingRef = element.nextElementSibling;
     });
 
-    // Reset unmount flag for new element
-    unmountTriggered = false;
+    // Reset exit flag for new element
+    exitTriggered = false;
+
+    // === Register Activity observer ===
+    // This detects when React Activity hides element with display:none
+    // If Activity hides first, we use Activity mode (no clone)
+    // If DOM unmount happens first, we use traditional clone mode
+    watchActivityHide(element, handleActivityHide);
 
     // === IN transition ===
     if (options?.scope === "local") {


### PR DESCRIPTION
## Summary

Adds implicit support for React 19.2's `<Activity>` component.

Closes #303

## Status

**Work in Progress** - Initial implementation for discussion.

## How It Works

React Activity hides components with `display: none` instead of unmounting.
SSGOI now detects this style change and uses a different exit animation strategy:

| Mode | Trigger | Strategy |
|------|---------|----------|
| Activity | `display: none` detected | reveal → animate → hide |
| Clone (fallback) | DOM removal detected | clone → animate → remove |

## Changes

- `activity-observer.ts` - MutationObserver for `display: none` detection
- `create-transition-callback.ts` - Dual mode support (Activity vs Clone)

## TODO

- [ ] Test with Next.js `cacheComponents` flag
- [ ] Verify effect cleanup timing
- [ ] Handle edge cases (rapid navigation, etc.)

## References

- [Next.js Cache Components](https://nextjs.org/docs/app/getting-started/cache-components#navigation-uses-activity)