### PR TITLE
fix: update showcase PR submission URL

### DIFF
--- a/apps/docs/src/components/showcase/showcase-grid.tsx
+++ b/apps/docs/src/components/showcase/showcase-grid.tsx
@@ -129,7 +129,7 @@ export function ShowcaseGrid() {
             </p>
           </div>
           <Link
-            href="https://github.com/meursyphus/ssgoi/blob/main/apps/docs/src/components/showcase/showcase-data.ts"
+            href="https://github.com/meursyphus/ssgoi/blob/latest/apps/docs/src/components/showcase/showcase-data.ts"
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex items-center justify-center gap-2 rounded-lg px-6 py-3 text-sm font-medium bg-white text-black hover:bg-neutral-200 transition-colors shrink-0"


### PR DESCRIPTION
# Description

This PR addresses issue #305 by updating the PR submission link on the showcase page to the correct URL.

I noticed that in a previous PR (#306), there was an attempt to use the .../edit/... URL format to provide a "quicker" editing experience. While I understand the intention to improve UX by reducing clicks, I have opted to use the standard file view (.../blob/...) for the following reasons:

## 💡 Why /blob/ over /edit/?

- Developer Workflow: Most contributors prefer to pull the code locally and work within their own IDEs to test changes before submitting. The /blob/ view makes it easier to identify the file path and context within the repository.

- Context & Navigation: The /edit/ view forces the user into a specific web-based editor mode, which can be disorienting. The /blob/ view allows users to see the file in the context of the project structure.

- Flexibility: From the /blob/ page, users can still easily click the "Edit" (pencil) icon if they choose to use the GitHub web editor. However, starting at /edit/ makes it harder to jump back to the repository view.

I believe this approach provides a more flexible and standard experience for both new and experienced contributors.

# Related Issues

Fixes #305

Related to #306