### PR TITLE
feat(docs): add RAG chatbot for documentation site

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -9,9 +9,12 @@
     "lint": "next lint",
     "generate:sandpack": "tsx scripts/generate-sandpack-templates.ts",
     "prepare": "pnpm generate:sandpack",
-    "prebuild": "pnpm generate:sandpack"
+    "prebuild": "pnpm generate:sandpack",
+    "ingest:docs": "tsx scripts/ingest-docs.ts"
   },
   "dependencies": {
+    "@ai-sdk/openai": "^3.0.30",
+    "@ai-sdk/react": "^3.0.99",
     "@codesandbox/sandpack-react": "^2.20.0",
     "@giscus/react": "^3.1.0",
     "@mdx-js/loader": "^3.1.0",
@@ -22,8 +25,10 @@
     "@radix-ui/react-separator": "^1.1.7",
     "@react-three/drei": "^10.7.4",
     "@react-three/fiber": "^9.3.0",
+    "@supabase/supabase-js": "^2.97.0",
     "@types/three": "^0.179.0",
     "@vercel/analytics": "^1.5.0",
+    "ai": "^6.0.97",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "gray-matter": "^4.0.3",
@@ -33,6 +38,7 @@
     "lucide-react": "^0.525.0",
     "next": "15.4.8",
     "next-mdx-remote": "^5.0.0",
+    "openai": "^6.22.0",
     "react": "19.1.2",
     "react-dom": "19.1.2",
     "react-markdown": "^10.1.0",

--- a/apps/docs/scripts/ingest-docs.ts
+++ b/apps/docs/scripts/ingest-docs.ts
@@ -8,7 +8,7 @@ import { createClient } from "@supabase/supabase-js";
 import OpenAI from "openai";
 
 const CONTENT_DIR = path.join(process.cwd(), "content");
-const LANGUAGES = ["en", "ko", "zh", "ja"];
+const LANGUAGES = ["en", "ko", "ja"];
 
 const supabase = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,

--- a/apps/docs/scripts/ingest-docs.ts
+++ b/apps/docs/scripts/ingest-docs.ts
@@ -1,0 +1,200 @@
+import fs from "fs/promises";
+import path from "path";
+import matter from "gray-matter";
+import { createClient } from "@supabase/supabase-js";
+import OpenAI from "openai";
+
+const CONTENT_DIR = path.join(process.cwd(), "content");
+const LANGUAGES = ["en", "ko", "zh", "ja"];
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.SUPABASE_SERVICE_ROLE_KEY!,
+);
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
+
+interface DocChunk {
+  lang: string;
+  doc_path: string;
+  heading: string;
+  content: string;
+  url: string;
+}
+
+async function getMdxFiles(dir: string): Promise<string[]> {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await getMdxFiles(fullPath)));
+    } else if (entry.name.endsWith(".mdx") || entry.name.endsWith(".md")) {
+      files.push(fullPath);
+    }
+  }
+
+  return files;
+}
+
+function stripJsx(text: string): string {
+  // Remove JSX/component tags
+  return text
+    .replace(/<[A-Z][^>]*\/>/g, "")
+    .replace(/<[A-Z][^>]*>[\s\S]*?<\/[A-Z][^>]*>/g, "");
+}
+
+function stripCodeBlocks(text: string): string {
+  return text.replace(/```[\s\S]*?```/g, "");
+}
+
+function splitByHeadings(
+  content: string,
+): { heading: string; content: string }[] {
+  const lines = content.split("\n");
+  const chunks: { heading: string; content: string }[] = [];
+  let currentHeading = "Introduction";
+  let currentContent: string[] = [];
+
+  for (const line of lines) {
+    const headingMatch = line.match(/^#{2,3}\s+(.+)/);
+    if (headingMatch) {
+      if (currentContent.length > 0) {
+        const text = currentContent.join("\n").trim();
+        if (text.length > 20) {
+          chunks.push({ heading: currentHeading, content: text });
+        }
+      }
+      currentHeading = headingMatch[1];
+      currentContent = [];
+    } else {
+      currentContent.push(line);
+    }
+  }
+
+  if (currentContent.length > 0) {
+    const text = currentContent.join("\n").trim();
+    if (text.length > 20) {
+      chunks.push({ heading: currentHeading, content: text });
+    }
+  }
+
+  return chunks;
+}
+
+function buildUrl(lang: string, filePath: string): string {
+  const relative = path.relative(path.join(CONTENT_DIR, lang), filePath);
+  const segments = relative
+    .replace(/\.mdx?$/, "")
+    .split(path.sep)
+    .map((s) => s.replace(/^\d+\./, ""));
+  return `/${lang}/docs/${segments.join("/")}`;
+}
+
+async function embedTexts(texts: string[]): Promise<number[][]> {
+  const batchSize = 100;
+  const embeddings: number[][] = [];
+
+  for (let i = 0; i < texts.length; i += batchSize) {
+    const batch = texts.slice(i, i + batchSize);
+    const res = await openai.embeddings.create({
+      model: "text-embedding-3-small",
+      input: batch,
+    });
+    embeddings.push(...res.data.map((d) => d.embedding));
+  }
+
+  return embeddings;
+}
+
+async function main() {
+  console.log("Starting doc ingestion...");
+
+  const allChunks: DocChunk[] = [];
+
+  for (const lang of LANGUAGES) {
+    const langDir = path.join(CONTENT_DIR, lang);
+    try {
+      await fs.access(langDir);
+    } catch {
+      console.log(`  Skipping ${lang} (directory not found)`);
+      continue;
+    }
+
+    const files = await getMdxFiles(langDir);
+    console.log(`  ${lang}: found ${files.length} files`);
+
+    for (const file of files) {
+      const raw = await fs.readFile(file, "utf-8");
+      const { content } = matter(raw);
+
+      const cleaned = stripCodeBlocks(stripJsx(content));
+      const sections = splitByHeadings(cleaned);
+      const docPath = path.relative(CONTENT_DIR, file);
+      const url = buildUrl(lang, file);
+
+      for (const section of sections) {
+        allChunks.push({
+          lang,
+          doc_path: docPath,
+          heading: section.heading,
+          content: section.content,
+          url,
+        });
+      }
+    }
+  }
+
+  console.log(`Total chunks: ${allChunks.length}`);
+
+  if (allChunks.length === 0) {
+    console.log("No chunks to process. Exiting.");
+    return;
+  }
+
+  // Generate embeddings
+  console.log("Generating embeddings...");
+  const texts = allChunks.map((c) => `${c.heading}\n${c.content}`);
+  const embeddings = await embedTexts(texts);
+
+  // Clear existing data and insert new
+  console.log("Clearing existing doc_chunks...");
+  const { error: deleteError } = await supabase
+    .from("doc_chunks")
+    .delete()
+    .neq("id", 0);
+
+  if (deleteError) {
+    console.error("Delete error:", deleteError);
+    return;
+  }
+
+  console.log("Inserting new chunks...");
+  const rows = allChunks.map((chunk, i) => ({
+    lang: chunk.lang,
+    doc_path: chunk.doc_path,
+    heading: chunk.heading,
+    content: chunk.content,
+    url: chunk.url,
+    embedding: JSON.stringify(embeddings[i]),
+  }));
+
+  // Insert in batches of 50
+  for (let i = 0; i < rows.length; i += 50) {
+    const batch = rows.slice(i, i + 50);
+    const { error: insertError } = await supabase
+      .from("doc_chunks")
+      .insert(batch);
+
+    if (insertError) {
+      console.error(`Insert error at batch ${i}:`, insertError);
+      return;
+    }
+    console.log(`  Inserted ${Math.min(i + 50, rows.length)}/${rows.length}`);
+  }
+
+  console.log("Done! Ingestion complete.");
+}
+
+main().catch(console.error);

--- a/apps/docs/scripts/ingest-docs.ts
+++ b/apps/docs/scripts/ingest-docs.ts
@@ -1,5 +1,8 @@
+import dotenv from "dotenv";
 import fs from "fs/promises";
 import path from "path";
+
+dotenv.config({ path: path.join(process.cwd(), ".env.local") });
 import matter from "gray-matter";
 import { createClient } from "@supabase/supabase-js";
 import OpenAI from "openai";
@@ -38,22 +41,76 @@ async function getMdxFiles(dir: string): Promise<string[]> {
   return files;
 }
 
-function stripJsx(text: string): string {
-  // Remove JSX/component tags
-  return text
-    .replace(/<[A-Z][^>]*\/>/g, "")
-    .replace(/<[A-Z][^>]*>[\s\S]*?<\/[A-Z][^>]*>/g, "");
+function cleanMdx(text: string): string {
+  // Extract code blocks, replace with placeholders, clean, then restore
+  const codeBlocks: string[] = [];
+  const withPlaceholders = text.replace(/(`{3,}[\s\S]*?`{3,})/g, (match) => {
+    codeBlocks.push(match);
+    return `__CODE_BLOCK_${codeBlocks.length - 1}__`;
+  });
+
+  const cleaned = withPlaceholders
+    // Remove import statements
+    .replace(/^import\s+.*$/gm, "")
+    // Remove all JSX/HTML-like tags but keep inner content
+    .replace(/<\/?[A-Za-z][A-Za-z0-9]*[^>]*>/g, "")
+    // Collapse multiple blank lines
+    .replace(/\n{3,}/g, "\n\n");
+
+  // Restore code blocks
+  return cleaned.replace(
+    /__CODE_BLOCK_(\d+)__/g,
+    (_, i) => codeBlocks[Number(i)],
+  );
 }
 
-function stripCodeBlocks(text: string): string {
-  return text.replace(/```[\s\S]*?```/g, "");
+const MAX_CHUNK_LENGTH = 1500;
+
+function splitLongChunk(
+  heading: string,
+  content: string,
+): { heading: string; content: string }[] {
+  if (content.length <= MAX_CHUNK_LENGTH) {
+    return [{ heading, content }];
+  }
+
+  // Split by code blocks as natural boundaries (handles indented code fences)
+  const parts: { heading: string; content: string }[] = [];
+  const segments = content.split(/\n(?=\s*```)/);
+  let current = "";
+  let partIndex = 1;
+
+  for (const segment of segments) {
+    if (
+      current.length + segment.length > MAX_CHUNK_LENGTH &&
+      current.length > 0
+    ) {
+      parts.push({
+        heading: `${heading} (${partIndex})`,
+        content: current.trim(),
+      });
+      partIndex++;
+      current = segment;
+    } else {
+      current += (current ? "\n" : "") + segment;
+    }
+  }
+
+  if (current.trim().length > 20) {
+    parts.push({
+      heading: parts.length > 0 ? `${heading} (${partIndex})` : heading,
+      content: current.trim(),
+    });
+  }
+
+  return parts;
 }
 
 function splitByHeadings(
   content: string,
 ): { heading: string; content: string }[] {
   const lines = content.split("\n");
-  const chunks: { heading: string; content: string }[] = [];
+  const rawChunks: { heading: string; content: string }[] = [];
   let currentHeading = "Introduction";
   let currentContent: string[] = [];
 
@@ -63,7 +120,7 @@ function splitByHeadings(
       if (currentContent.length > 0) {
         const text = currentContent.join("\n").trim();
         if (text.length > 20) {
-          chunks.push({ heading: currentHeading, content: text });
+          rawChunks.push({ heading: currentHeading, content: text });
         }
       }
       currentHeading = headingMatch[1];
@@ -76,11 +133,12 @@ function splitByHeadings(
   if (currentContent.length > 0) {
     const text = currentContent.join("\n").trim();
     if (text.length > 20) {
-      chunks.push({ heading: currentHeading, content: text });
+      rawChunks.push({ heading: currentHeading, content: text });
     }
   }
 
-  return chunks;
+  // Split oversized chunks
+  return rawChunks.flatMap((c) => splitLongChunk(c.heading, c.content));
 }
 
 function buildUrl(lang: string, filePath: string): string {
@@ -127,9 +185,10 @@ async function main() {
 
     for (const file of files) {
       const raw = await fs.readFile(file, "utf-8");
-      const { content } = matter(raw);
+      const { content, data: frontmatter } = matter(raw);
+      const docTitle = frontmatter.title || "";
 
-      const cleaned = stripCodeBlocks(stripJsx(content));
+      const cleaned = cleanMdx(content);
       const sections = splitByHeadings(cleaned);
       const docPath = path.relative(CONTENT_DIR, file);
       const url = buildUrl(lang, file);
@@ -138,7 +197,7 @@ async function main() {
         allChunks.push({
           lang,
           doc_path: docPath,
-          heading: section.heading,
+          heading: `${docTitle} > ${section.heading}`,
           content: section.content,
           url,
         });
@@ -151,6 +210,24 @@ async function main() {
   if (allChunks.length === 0) {
     console.log("No chunks to process. Exiting.");
     return;
+  }
+
+  // Dry run mode: dump chunks to file for inspection
+  if (process.argv.includes("--dry-run")) {
+    const dryLang = process.argv[process.argv.indexOf("--dry-run") + 1] || null;
+    const filtered = dryLang
+      ? allChunks.filter((c) => c.lang === dryLang)
+      : allChunks;
+    const outPath = path.join(process.cwd(), "chunks-preview.md");
+    const lines = filtered.map(
+      (c, i) =>
+        `# Chunk ${i + 1} [${c.lang}] ${c.heading}\n**url:** ${c.url} | **len:** ${c.content.length}\n\n${c.content}\n\n---\n`,
+    );
+    await fs.writeFile(outPath, lines.join("\n"), "utf-8");
+    console.log(`Preview saved to: ${outPath} (${filtered.length} chunks)`);
+    if (process.argv.includes("--preview-only")) {
+      return;
+    }
   }
 
   // Generate embeddings

--- a/apps/docs/src/app/[lang]/layout.tsx
+++ b/apps/docs/src/app/[lang]/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Inter, Space_Grotesk } from "next/font/google";
 import { Header } from "@/components/layout/header";
+import { ChatbotButton } from "@/components/chatbot";
 import TranslationsProvider from "@/i18n/translations-provider";
 import { StructuredData } from "./structured-data";
 import { ConsoleWelcome } from "@/components/console-welcome";
@@ -46,6 +47,7 @@ export default async function RootLayout({
           <ConsoleWelcome />
 
           <Header />
+          <ChatbotButton />
           <main className="relative z-0 overflow-hidden">
             <SsgoiProvider>{children}</SsgoiProvider>
           </main>

--- a/apps/docs/src/app/api/chat/route.ts
+++ b/apps/docs/src/app/api/chat/route.ts
@@ -1,0 +1,76 @@
+import { openai } from "@ai-sdk/openai";
+import { streamText } from "ai";
+import { supabase } from "@/lib/supabase";
+import { rateLimit } from "@/lib/rate-limit";
+import OpenAI from "openai";
+import { headers } from "next/headers";
+
+export const runtime = "nodejs";
+
+const openaiClient = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+export async function POST(req: Request) {
+  const headersList = await headers();
+  const ip =
+    headersList.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+
+  const { success } = rateLimit(ip);
+  if (!success) {
+    return new Response("Too many requests", { status: 429 });
+  }
+
+  const { messages, lang = "en" } = await req.json();
+
+  const lastUserMessage = [...messages]
+    .reverse()
+    .find((m: { role: string }) => m.role === "user");
+
+  if (!lastUserMessage) {
+    return new Response("No user message found", { status: 400 });
+  }
+
+  const embeddingRes = await openaiClient.embeddings.create({
+    model: "text-embedding-3-small",
+    input: lastUserMessage.content,
+  });
+  const queryEmbedding = embeddingRes.data[0].embedding;
+
+  const { data: chunks, error } = await supabase.rpc("match_doc_chunks", {
+    query_embedding: queryEmbedding,
+    match_lang: lang,
+    match_count: 5,
+    match_threshold: 0.3,
+  });
+
+  if (error) {
+    console.error("Supabase RPC error:", error);
+  }
+
+  const context =
+    chunks && chunks.length > 0
+      ? chunks
+          .map(
+            (c: { heading: string; content: string; url: string }) =>
+              `### ${c.heading}\n${c.content}\n(Source: ${c.url})`,
+          )
+          .join("\n\n---\n\n")
+      : "No relevant documentation found.";
+
+  const systemPrompt = `You are an AI assistant for SSGOI (쓱오이), a universal page transition library for web applications.
+Answer questions based on the documentation context below. Be concise and helpful.
+If the context doesn't contain relevant information, say so honestly.
+Respond in the same language as the user's question.
+
+## Documentation Context
+${context}`;
+
+  const result = streamText({
+    model: openai("gpt-4o-mini"),
+    system: systemPrompt,
+    messages,
+    maxOutputTokens: 1024,
+    temperature: 0.1,
+  });
+
+  return result.toUIMessageStreamResponse();
+}

--- a/apps/docs/src/app/api/chat/route.ts
+++ b/apps/docs/src/app/api/chat/route.ts
@@ -1,5 +1,5 @@
 import { openai } from "@ai-sdk/openai";
-import { streamText } from "ai";
+import { streamText, convertToModelMessages } from "ai";
 import { supabase } from "@/lib/supabase";
 import { rateLimit } from "@/lib/rate-limit";
 import OpenAI from "openai";
@@ -23,23 +23,42 @@ export async function POST(req: Request) {
 
   const lastUserMessage = [...messages]
     .reverse()
-    .find((m: { role: string }) => m.role === "user");
+    .find((m: { role: string }) => m.role === "user") as
+    | {
+        role: string;
+        content?: string;
+        parts?: { type: string; text?: string }[];
+      }
+    | undefined;
 
   if (!lastUserMessage) {
     return new Response("No user message found", { status: 400 });
   }
 
+  // AI SDK v6 sends parts array, fallback to content for curl/direct calls
+  const userText =
+    lastUserMessage.content ||
+    lastUserMessage.parts
+      ?.filter((p) => p.type === "text")
+      .map((p) => p.text)
+      .join("") ||
+    "";
+
+  if (!userText) {
+    return new Response("Empty user message", { status: 400 });
+  }
+
   const embeddingRes = await openaiClient.embeddings.create({
     model: "text-embedding-3-small",
-    input: lastUserMessage.content,
+    input: userText,
   });
   const queryEmbedding = embeddingRes.data[0].embedding;
 
   const { data: chunks, error } = await supabase.rpc("match_doc_chunks", {
     query_embedding: queryEmbedding,
     match_lang: lang,
-    match_count: 5,
-    match_threshold: 0.3,
+    match_count: 12,
+    match_threshold: 0.2,
   });
 
   if (error) {
@@ -57,17 +76,25 @@ export async function POST(req: Request) {
       : "No relevant documentation found.";
 
   const systemPrompt = `You are an AI assistant for SSGOI (쓱오이), a universal page transition library for web applications.
-Answer questions based on the documentation context below. Be concise and helpful.
-If the context doesn't contain relevant information, say so honestly.
-Respond in the same language as the user's question.
+
+STRICT RULES:
+- ONLY use information from the Documentation Context below. Do NOT make up code, APIs, or package names.
+- If the context contains code examples, quote them EXACTLY as they appear in the documentation. Never modify, simplify, or invent code.
+- When documentation provides explanations or warnings (e.g., "왜 position: relative가 필요한가요?"), include them as-is from the original text.
+- The correct package names are @ssgoi/react, @ssgoi/svelte, @ssgoi/vue, @ssgoi/solid, @ssgoi/angular — NEVER use "ssgoi" alone.
+- If the context doesn't contain directly relevant information, do your best to answer based on the closest matching context. Only say you can't find information if the context is completely unrelated to the question.
+- At the end of your answer, include the source page URL from the context so the user can read the full documentation.
+- Respond in the same language as the user's question.
 
 ## Documentation Context
 ${context}`;
 
+  const modelMessages = await convertToModelMessages(messages);
+
   const result = streamText({
     model: openai("gpt-4o-mini"),
     system: systemPrompt,
-    messages,
+    messages: modelMessages,
     maxOutputTokens: 1024,
     temperature: 0.1,
   });

--- a/apps/docs/src/components/chatbot/chatbot-button.tsx
+++ b/apps/docs/src/components/chatbot/chatbot-button.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "@/i18n";
+import { MessageSquare } from "lucide-react";
+import { ChatbotDrawer } from "./chatbot-drawer";
+
+export function ChatbotButton() {
+  const t = useTranslations("chatbot");
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        onClick={() => setIsOpen((prev) => !prev)}
+        className="fixed bottom-4 right-4 z-50 flex h-12 w-12 items-center justify-center rounded-full border border-white/10 bg-neutral-900/80 text-neutral-300 shadow-lg backdrop-blur-md transition-all hover:scale-105 hover:bg-neutral-800 hover:text-white md:h-11 md:w-auto md:gap-2 md:rounded-full md:px-4"
+        aria-label={t("buttonLabel")}
+      >
+        <MessageSquare className="h-5 w-5" />
+        <span className="hidden text-sm font-medium md:inline">
+          {t("buttonLabel")}
+        </span>
+      </button>
+
+      <ChatbotDrawer isOpen={isOpen} onClose={() => setIsOpen(false)} />
+    </>
+  );
+}

--- a/apps/docs/src/components/chatbot/chatbot-drawer.tsx
+++ b/apps/docs/src/components/chatbot/chatbot-drawer.tsx
@@ -7,7 +7,7 @@ import { useTranslations } from "@/i18n";
 import { useCurrentLanguage } from "@/i18n";
 import { ChatbotMessages } from "./chatbot-messages";
 import { ChatbotInput } from "./chatbot-input";
-import { X } from "lucide-react";
+import { X, Maximize2, Minimize2 } from "lucide-react";
 
 interface ChatbotDrawerProps {
   isOpen: boolean;
@@ -18,6 +18,7 @@ export function ChatbotDrawer({ isOpen, onClose }: ChatbotDrawerProps) {
   const t = useTranslations("chatbot");
   const lang = useCurrentLanguage();
   const [input, setInput] = useState("");
+  const [expanded, setExpanded] = useState(false);
 
   const transport = useMemo(
     () =>
@@ -54,21 +55,37 @@ export function ChatbotDrawer({ isOpen, onClose }: ChatbotDrawerProps) {
 
       {/* Drawer */}
       <div
-        className={`fixed z-50 flex flex-col overflow-hidden border border-white/10 bg-neutral-900/95 shadow-2xl backdrop-blur-md
+        className={`fixed z-50 flex flex-col overflow-hidden border border-white/10 bg-neutral-900/95 shadow-2xl backdrop-blur-md transition-all duration-200
           inset-2 rounded-2xl
-          md:inset-auto md:bottom-20 md:right-4 md:h-[560px] md:w-96 md:rounded-2xl`}
+          ${
+            expanded
+              ? "md:inset-auto md:bottom-4 md:right-4 md:left-4 md:top-16 md:h-auto md:w-auto md:rounded-2xl"
+              : "md:inset-auto md:bottom-20 md:right-4 md:h-[600px] md:w-[440px] md:rounded-2xl"
+          }`}
       >
         {/* Header */}
         <div className="flex items-center justify-between border-b border-white/10 px-4 py-3">
           <h2 className="text-sm font-semibold text-neutral-100">
             {t("drawerTitle")}
           </h2>
-          <button
-            onClick={onClose}
-            className="flex h-7 w-7 items-center justify-center rounded-lg text-neutral-400 transition-colors hover:bg-white/10 hover:text-neutral-200"
-          >
-            <X className="h-4 w-4" />
-          </button>
+          <div className="flex items-center gap-1">
+            <button
+              onClick={() => setExpanded((prev) => !prev)}
+              className="hidden h-7 w-7 items-center justify-center rounded-lg text-neutral-400 transition-colors hover:bg-white/10 hover:text-neutral-200 md:flex"
+            >
+              {expanded ? (
+                <Minimize2 className="h-3.5 w-3.5" />
+              ) : (
+                <Maximize2 className="h-3.5 w-3.5" />
+              )}
+            </button>
+            <button
+              onClick={onClose}
+              className="flex h-7 w-7 items-center justify-center rounded-lg text-neutral-400 transition-colors hover:bg-white/10 hover:text-neutral-200"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
         </div>
 
         {/* Messages */}

--- a/apps/docs/src/components/chatbot/chatbot-drawer.tsx
+++ b/apps/docs/src/components/chatbot/chatbot-drawer.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useChat } from "@ai-sdk/react";
+import { DefaultChatTransport } from "ai";
+import { useTranslations } from "@/i18n";
+import { useCurrentLanguage } from "@/i18n";
+import { ChatbotMessages } from "./chatbot-messages";
+import { ChatbotInput } from "./chatbot-input";
+import { X } from "lucide-react";
+
+interface ChatbotDrawerProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export function ChatbotDrawer({ isOpen, onClose }: ChatbotDrawerProps) {
+  const t = useTranslations("chatbot");
+  const lang = useCurrentLanguage();
+  const [input, setInput] = useState("");
+
+  const transport = useMemo(
+    () =>
+      new DefaultChatTransport({
+        api: "/api/chat",
+        body: { lang },
+      }),
+    [lang],
+  );
+
+  const { messages, sendMessage, status, error } = useChat({
+    transport,
+  });
+
+  const isLoading = status === "submitted" || status === "streaming";
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const text = input.trim();
+    if (!text || isLoading) return;
+    setInput("");
+    await sendMessage({ text });
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <>
+      {/* Mobile backdrop */}
+      <div
+        className="fixed inset-0 z-50 bg-black/60 backdrop-blur-sm md:hidden"
+        onClick={onClose}
+      />
+
+      {/* Drawer */}
+      <div
+        className={`fixed z-50 flex flex-col overflow-hidden border border-white/10 bg-neutral-900/95 shadow-2xl backdrop-blur-md
+          inset-2 rounded-2xl
+          md:inset-auto md:bottom-20 md:right-4 md:h-[560px] md:w-96 md:rounded-2xl`}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-white/10 px-4 py-3">
+          <h2 className="text-sm font-semibold text-neutral-100">
+            {t("drawerTitle")}
+          </h2>
+          <button
+            onClick={onClose}
+            className="flex h-7 w-7 items-center justify-center rounded-lg text-neutral-400 transition-colors hover:bg-white/10 hover:text-neutral-200"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Messages */}
+        <ChatbotMessages
+          messages={messages}
+          isLoading={isLoading}
+          error={error}
+        />
+
+        {/* Input */}
+        <ChatbotInput
+          input={input}
+          isLoading={isLoading}
+          onInputChange={setInput}
+          onSubmit={handleSubmit}
+        />
+      </div>
+    </>
+  );
+}

--- a/apps/docs/src/components/chatbot/chatbot-input.tsx
+++ b/apps/docs/src/components/chatbot/chatbot-input.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useTranslations } from "@/i18n";
+import { Send } from "lucide-react";
+
+interface ChatbotInputProps {
+  input: string;
+  isLoading: boolean;
+  onInputChange: (value: string) => void;
+  onSubmit: (e: React.FormEvent) => void;
+}
+
+export function ChatbotInput({
+  input,
+  isLoading,
+  onInputChange,
+  onSubmit,
+}: ChatbotInputProps) {
+  const t = useTranslations("chatbot");
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      onSubmit(e);
+    }
+  };
+
+  return (
+    <form onSubmit={onSubmit} className="border-t border-white/10 p-3">
+      <div className="flex items-end gap-2">
+        <textarea
+          value={input}
+          onChange={(e) => onInputChange(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={t("placeholder")}
+          rows={1}
+          className="flex-1 resize-none rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-neutral-100 placeholder-neutral-500 outline-none focus:border-blue-500/50"
+          disabled={isLoading}
+        />
+        <button
+          type="submit"
+          disabled={isLoading || !input.trim()}
+          className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-blue-600 text-white transition-colors hover:bg-blue-500 disabled:opacity-40 disabled:hover:bg-blue-600"
+        >
+          <Send className="h-4 w-4" />
+        </button>
+      </div>
+      <p className="mt-2 text-center text-[10px] text-neutral-500">
+        {t("poweredBy")}
+      </p>
+    </form>
+  );
+}

--- a/apps/docs/src/components/chatbot/chatbot-messages.tsx
+++ b/apps/docs/src/components/chatbot/chatbot-messages.tsx
@@ -55,14 +55,14 @@ export function ChatbotMessages({
                 </div>
               )}
               <div
-                className={`max-w-[80%] rounded-xl px-3.5 py-2.5 text-sm ${
+                className={`min-w-0 max-w-[85%] rounded-xl px-3.5 py-2.5 text-sm ${
                   message.role === "user"
                     ? "bg-blue-600 text-white"
                     : "bg-white/5 text-neutral-200"
                 }`}
               >
                 {message.role === "assistant" ? (
-                  <div className="chatbot-markdown prose prose-sm prose-invert max-w-none">
+                  <div className="chatbot-markdown prose prose-sm prose-invert max-w-none [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:bg-black/30 [&_pre]:p-3 [&_code]:text-xs [&_pre]:my-2 [&_a]:text-blue-400 [&_a]:underline [&_a]:underline-offset-2 hover:[&_a]:text-blue-300">
                     <ReactMarkdown>{text}</ReactMarkdown>
                   </div>
                 ) : (

--- a/apps/docs/src/components/chatbot/chatbot-messages.tsx
+++ b/apps/docs/src/components/chatbot/chatbot-messages.tsx
@@ -63,7 +63,7 @@ export function ChatbotMessages({
                 }`}
               >
                 {message.role === "assistant" ? (
-                  <div className="chatbot-markdown prose prose-sm prose-invert max-w-none [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:bg-black/30 [&_pre]:p-3 [&_code]:text-xs [&_pre]:my-2 [&_a]:text-blue-400 [&_a]:underline [&_a]:underline-offset-2 hover:[&_a]:text-blue-300">
+                  <div className="chatbot-markdown prose prose-sm prose-invert max-w-none [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:bg-black/30 [&_pre]:p-3 [&_code]:text-xs [&_pre]:my-2 [&_.hljs]:!bg-transparent [&_a]:text-blue-400 [&_a]:underline [&_a]:underline-offset-2 hover:[&_a]:text-blue-300">
                     <ReactMarkdown rehypePlugins={[rehypeHighlight]}>
                       {text}
                     </ReactMarkdown>

--- a/apps/docs/src/components/chatbot/chatbot-messages.tsx
+++ b/apps/docs/src/components/chatbot/chatbot-messages.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import type { UIMessage } from "ai";
+import ReactMarkdown from "react-markdown";
+import { useTranslations } from "@/i18n";
+import { Bot, User } from "lucide-react";
+
+function getTextContent(message: UIMessage): string {
+  return message.parts
+    .filter((part) => part.type === "text")
+    .map((part) => part.text)
+    .join("");
+}
+
+interface ChatbotMessagesProps {
+  messages: UIMessage[];
+  isLoading: boolean;
+  error: Error | undefined;
+}
+
+export function ChatbotMessages({
+  messages,
+  isLoading,
+  error,
+}: ChatbotMessagesProps) {
+  const t = useTranslations("chatbot");
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, isLoading]);
+
+  return (
+    <div className="flex-1 overflow-y-auto p-4">
+      {messages.length === 0 && (
+        <div className="flex h-full items-center justify-center">
+          <p className="max-w-[240px] text-center text-sm text-neutral-400">
+            {t("welcomeMessage")}
+          </p>
+        </div>
+      )}
+
+      <div className="space-y-4">
+        {messages.map((message) => {
+          const text = getTextContent(message);
+          return (
+            <div
+              key={message.id}
+              className={`flex gap-2.5 ${message.role === "user" ? "justify-end" : "justify-start"}`}
+            >
+              {message.role === "assistant" && (
+                <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-blue-600/20">
+                  <Bot className="h-3.5 w-3.5 text-blue-400" />
+                </div>
+              )}
+              <div
+                className={`max-w-[80%] rounded-xl px-3.5 py-2.5 text-sm ${
+                  message.role === "user"
+                    ? "bg-blue-600 text-white"
+                    : "bg-white/5 text-neutral-200"
+                }`}
+              >
+                {message.role === "assistant" ? (
+                  <div className="chatbot-markdown prose prose-sm prose-invert max-w-none">
+                    <ReactMarkdown>{text}</ReactMarkdown>
+                  </div>
+                ) : (
+                  <p className="whitespace-pre-wrap">{text}</p>
+                )}
+              </div>
+              {message.role === "user" && (
+                <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-neutral-700">
+                  <User className="h-3.5 w-3.5 text-neutral-300" />
+                </div>
+              )}
+            </div>
+          );
+        })}
+
+        {isLoading && messages[messages.length - 1]?.role === "user" && (
+          <div className="flex gap-2.5">
+            <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-blue-600/20">
+              <Bot className="h-3.5 w-3.5 text-blue-400" />
+            </div>
+            <div className="rounded-xl bg-white/5 px-3.5 py-2.5">
+              <div className="flex gap-1">
+                <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-neutral-400 [animation-delay:0ms]" />
+                <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-neutral-400 [animation-delay:150ms]" />
+                <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-neutral-400 [animation-delay:300ms]" />
+              </div>
+            </div>
+          </div>
+        )}
+
+        {error && (
+          <div className="rounded-lg bg-red-500/10 px-3 py-2 text-sm text-red-400">
+            {error.message.includes("429")
+              ? t("rateLimitMessage")
+              : t("errorMessage")}
+          </div>
+        )}
+      </div>
+
+      <div ref={bottomRef} />
+    </div>
+  );
+}

--- a/apps/docs/src/components/chatbot/chatbot-messages.tsx
+++ b/apps/docs/src/components/chatbot/chatbot-messages.tsx
@@ -63,7 +63,7 @@ export function ChatbotMessages({
                 }`}
               >
                 {message.role === "assistant" ? (
-                  <div className="chatbot-markdown prose prose-sm prose-invert max-w-none [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:bg-black/30 [&_pre]:p-3 [&_code]:text-xs [&_pre]:my-2 [&_.hljs]:!bg-transparent [&_a]:text-blue-400 [&_a]:underline [&_a]:underline-offset-2 hover:[&_a]:text-blue-300">
+                  <div className="chatbot-markdown prose prose-sm prose-invert max-w-none [&_p]:my-2.5 [&_p:first-child]:mt-0 [&_p:last-child]:mb-0 [&_ul]:my-2.5 [&_ol]:my-2.5 [&_li]:my-1 [&_h3]:mt-4 [&_h3]:mb-2 [&_h4]:mt-3 [&_h4]:mb-1.5 [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:bg-black/30 [&_pre]:p-3 [&_code]:text-xs [&_pre]:my-3 [&_.hljs]:!bg-transparent [&_a]:text-blue-400 [&_a]:underline [&_a]:underline-offset-2 hover:[&_a]:text-blue-300">
                     <ReactMarkdown rehypePlugins={[rehypeHighlight]}>
                       {text}
                     </ReactMarkdown>

--- a/apps/docs/src/components/chatbot/chatbot-messages.tsx
+++ b/apps/docs/src/components/chatbot/chatbot-messages.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from "react";
 import type { UIMessage } from "ai";
 import ReactMarkdown from "react-markdown";
+import rehypeHighlight from "rehype-highlight";
 import { useTranslations } from "@/i18n";
 import { Bot, User } from "lucide-react";
 
@@ -63,7 +64,9 @@ export function ChatbotMessages({
               >
                 {message.role === "assistant" ? (
                   <div className="chatbot-markdown prose prose-sm prose-invert max-w-none [&_pre]:overflow-x-auto [&_pre]:rounded-lg [&_pre]:bg-black/30 [&_pre]:p-3 [&_code]:text-xs [&_pre]:my-2 [&_a]:text-blue-400 [&_a]:underline [&_a]:underline-offset-2 hover:[&_a]:text-blue-300">
-                    <ReactMarkdown>{text}</ReactMarkdown>
+                    <ReactMarkdown rehypePlugins={[rehypeHighlight]}>
+                      {text}
+                    </ReactMarkdown>
                   </div>
                 ) : (
                   <p className="whitespace-pre-wrap">{text}</p>

--- a/apps/docs/src/components/chatbot/index.ts
+++ b/apps/docs/src/components/chatbot/index.ts
@@ -1,0 +1,1 @@
+export { ChatbotButton } from "./chatbot-button";

--- a/apps/docs/src/i18n/messages/en/chatbot.ts
+++ b/apps/docs/src/i18n/messages/en/chatbot.ts
@@ -1,0 +1,13 @@
+import { ChatbotMessages } from "../types/chatbot";
+
+export const chatbot: ChatbotMessages = {
+  buttonLabel: "Ask AI",
+  drawerTitle: "SSGOI AI Assistant",
+  welcomeMessage:
+    "Hi! I can answer questions about SSGOI. Ask me about transitions, configuration, installation, and more.",
+  placeholder: "Ask about SSGOI...",
+  sendButton: "Send",
+  errorMessage: "Something went wrong. Please try again.",
+  rateLimitMessage: "Too many requests. Please wait a moment.",
+  poweredBy: "Powered by GPT-4o-mini + RAG",
+};

--- a/apps/docs/src/i18n/messages/en/index.tsx
+++ b/apps/docs/src/i18n/messages/en/index.tsx
@@ -10,6 +10,7 @@ import { homeStructuredData } from "./home-structured-data";
 import { blogStructuredData } from "./blog-structured-data";
 import { docsStructuredData } from "./docs-structured-data";
 import { showcase } from "./showcase";
+import { chatbot } from "./chatbot";
 
 const en: Messages = {
   header,
@@ -23,6 +24,7 @@ const en: Messages = {
   blogStructuredData,
   docsStructuredData,
   showcase,
+  chatbot,
 };
 
 export default en;

--- a/apps/docs/src/i18n/messages/ja/chatbot.ts
+++ b/apps/docs/src/i18n/messages/ja/chatbot.ts
@@ -1,0 +1,13 @@
+import { ChatbotMessages } from "../types/chatbot";
+
+export const chatbot: ChatbotMessages = {
+  buttonLabel: "AIに質問",
+  drawerTitle: "SSGOI AIアシスタント",
+  welcomeMessage:
+    "こんにちは！SSGOIについてお気軽にご質問ください。トランジション、設定、インストール方法などをお手伝いします。",
+  placeholder: "SSGOIについて質問する...",
+  sendButton: "送信",
+  errorMessage: "問題が発生しました。もう一度お試しください。",
+  rateLimitMessage: "リクエストが多すぎます。しばらくしてからお試しください。",
+  poweredBy: "GPT-4o-mini + RAG 搭載",
+};

--- a/apps/docs/src/i18n/messages/ja/index.tsx
+++ b/apps/docs/src/i18n/messages/ja/index.tsx
@@ -10,6 +10,7 @@ import { homeStructuredData } from "./home-structured-data";
 import { blogStructuredData } from "./blog-structured-data";
 import { docsStructuredData } from "./docs-structured-data";
 import { showcase } from "./showcase";
+import { chatbot } from "./chatbot";
 
 const ja: Messages = {
   header,
@@ -23,6 +24,7 @@ const ja: Messages = {
   blogStructuredData,
   docsStructuredData,
   showcase,
+  chatbot,
 };
 
 export default ja;

--- a/apps/docs/src/i18n/messages/ko/chatbot.ts
+++ b/apps/docs/src/i18n/messages/ko/chatbot.ts
@@ -1,0 +1,13 @@
+import { ChatbotMessages } from "../types/chatbot";
+
+export const chatbot: ChatbotMessages = {
+  buttonLabel: "AI에게 질문",
+  drawerTitle: "SSGOI AI 어시스턴트",
+  welcomeMessage:
+    "안녕하세요! SSGOI에 대해 궁금한 점을 물어보세요. 트랜지션, 설정, 설치 방법 등을 도와드릴 수 있습니다.",
+  placeholder: "SSGOI에 대해 질문하세요...",
+  sendButton: "전송",
+  errorMessage: "문제가 발생했습니다. 다시 시도해주세요.",
+  rateLimitMessage: "요청이 너무 많습니다. 잠시 후 다시 시도해주세요.",
+  poweredBy: "GPT-4o-mini + RAG 기반",
+};

--- a/apps/docs/src/i18n/messages/ko/index.tsx
+++ b/apps/docs/src/i18n/messages/ko/index.tsx
@@ -10,6 +10,7 @@ import { homeStructuredData } from "./home-structured-data";
 import { blogStructuredData } from "./blog-structured-data";
 import { docsStructuredData } from "./docs-structured-data";
 import { showcase } from "./showcase";
+import { chatbot } from "./chatbot";
 
 const ko: Messages = {
   header,
@@ -23,6 +24,7 @@ const ko: Messages = {
   blogStructuredData,
   docsStructuredData,
   showcase,
+  chatbot,
 };
 
 export default ko;

--- a/apps/docs/src/i18n/messages/types/chatbot.ts
+++ b/apps/docs/src/i18n/messages/types/chatbot.ts
@@ -1,0 +1,10 @@
+export type ChatbotMessages = {
+  buttonLabel: string;
+  drawerTitle: string;
+  welcomeMessage: string;
+  placeholder: string;
+  sendButton: string;
+  errorMessage: string;
+  rateLimitMessage: string;
+  poweredBy: string;
+};

--- a/apps/docs/src/i18n/messages/types/index.ts
+++ b/apps/docs/src/i18n/messages/types/index.ts
@@ -9,6 +9,7 @@ import { HomeStructuredDataMessages } from "./home-structured-data";
 import { BlogStructuredDataMessages } from "./blog-structured-data";
 import { DocsStructuredDataMessages } from "./docs-structured-data";
 import { ShowcaseMessages } from "./showcase";
+import { ChatbotMessages } from "./chatbot";
 
 export type Messages = {
   header: HeaderMessages;
@@ -22,6 +23,7 @@ export type Messages = {
   blogStructuredData: BlogStructuredDataMessages;
   docsStructuredData: DocsStructuredDataMessages;
   showcase: ShowcaseMessages;
+  chatbot: ChatbotMessages;
 };
 
 export type {
@@ -36,4 +38,5 @@ export type {
   BlogStructuredDataMessages,
   DocsStructuredDataMessages,
   ShowcaseMessages,
+  ChatbotMessages,
 };

--- a/apps/docs/src/i18n/messages/zh/chatbot.ts
+++ b/apps/docs/src/i18n/messages/zh/chatbot.ts
@@ -1,0 +1,13 @@
+import { ChatbotMessages } from "../types/chatbot";
+
+export const chatbot: ChatbotMessages = {
+  buttonLabel: "问AI",
+  drawerTitle: "SSGOI AI 助手",
+  welcomeMessage:
+    "你好！我可以回答关于SSGOI的问题。你可以问我关于过渡效果、配置、安装等方面的问题。",
+  placeholder: "问关于SSGOI的问题...",
+  sendButton: "发送",
+  errorMessage: "出现问题，请重试。",
+  rateLimitMessage: "请求过多，请稍后再试。",
+  poweredBy: "由 GPT-4o-mini + RAG 驱动",
+};

--- a/apps/docs/src/i18n/messages/zh/index.tsx
+++ b/apps/docs/src/i18n/messages/zh/index.tsx
@@ -10,6 +10,7 @@ import { homeStructuredData } from "./home-structured-data";
 import { blogStructuredData } from "./blog-structured-data";
 import { docsStructuredData } from "./docs-structured-data";
 import { showcase } from "./showcase";
+import { chatbot } from "./chatbot";
 
 const zh: Messages = {
   header,
@@ -23,6 +24,7 @@ const zh: Messages = {
   blogStructuredData,
   docsStructuredData,
   showcase,
+  chatbot,
 };
 
 export default zh;

--- a/apps/docs/src/lib/rate-limit.ts
+++ b/apps/docs/src/lib/rate-limit.ts
@@ -1,0 +1,19 @@
+const windowMs = 60 * 1000;
+const maxRequests = 10;
+
+const requests = new Map<string, number[]>();
+
+export function rateLimit(ip: string): { success: boolean } {
+  const now = Date.now();
+  const timestamps = requests.get(ip) ?? [];
+  const valid = timestamps.filter((t) => now - t < windowMs);
+
+  if (valid.length >= maxRequests) {
+    requests.set(ip, valid);
+    return { success: false };
+  }
+
+  valid.push(now);
+  requests.set(ip, valid);
+  return { success: true };
+}

--- a/apps/docs/src/lib/supabase.ts
+++ b/apps/docs/src/lib/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from "@supabase/supabase-js";
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,12 @@ importers:
 
   apps/docs:
     dependencies:
+      '@ai-sdk/openai':
+        specifier: ^3.0.30
+        version: 3.0.30(zod@3.25.76)
+      '@ai-sdk/react':
+        specifier: ^3.0.99
+        version: 3.0.99(react@19.1.2)(zod@3.25.76)
       '@codesandbox/sandpack-react':
         specifier: ^2.20.0
         version: 2.20.0(react-dom@19.1.2(react@19.1.2))(react@19.1.2)
@@ -148,12 +154,18 @@ importers:
       '@react-three/fiber':
         specifier: ^9.3.0
         version: 9.4.0(@types/react@19.2.2)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(three@0.179.1)
+      '@supabase/supabase-js':
+        specifier: ^2.97.0
+        version: 2.97.0
       '@types/three':
         specifier: ^0.179.0
         version: 0.179.0
       '@vercel/analytics':
         specifier: ^1.5.0
-        version: 1.5.0(@sveltejs/kit@2.48.4(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.43.4)(vite@7.2.7(@types/node@20.19.24)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.43.4)(vite@7.2.7(@types/node@20.19.24)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(next@15.4.8(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(sass@1.93.3))(react@19.1.2)(svelte@5.43.4)(vue-router@4.6.3(vue@3.5.26(typescript@5.8.3)))(vue@3.5.26(typescript@5.8.3))
+        version: 1.5.0(@sveltejs/kit@2.48.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.43.4)(vite@7.2.7(@types/node@20.19.24)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.43.4)(vite@7.2.7(@types/node@20.19.24)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(next@15.4.8(@opentelemetry/api@1.9.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(sass@1.93.3))(react@19.1.2)(svelte@5.43.4)(vue-router@4.6.3(vue@3.5.26(typescript@5.8.3)))(vue@3.5.26(typescript@5.8.3))
+      ai:
+        specifier: ^6.0.97
+        version: 6.0.97(zod@3.25.76)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -177,10 +189,13 @@ importers:
         version: 0.525.0(react@19.1.2)
       next:
         specifier: 15.4.8
-        version: 15.4.8(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(sass@1.93.3)
+        version: 15.4.8(@opentelemetry/api@1.9.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(sass@1.93.3)
       next-mdx-remote:
         specifier: ^5.0.0
         version: 5.0.0(@types/react@19.2.2)(react@19.1.2)
+      openai:
+        specifier: ^6.22.0
+        version: 6.22.0(ws@8.18.3)(zod@3.25.76)
       react:
         specifier: 19.1.2
         version: 19.1.2
@@ -259,7 +274,7 @@ importers:
         version: 4.1.16
       next:
         specifier: 15.3.5
-        version: 15.3.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.93.3)
+        version: 15.3.5(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.93.3)
       react:
         specifier: ^19.0.0
         version: 19.1.0
@@ -352,10 +367,10 @@ importers:
     devDependencies:
       '@sveltejs/adapter-auto':
         specifier: ^6.0.0
-        version: 6.1.1(@sveltejs/kit@2.48.4(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.43.4)(vite@7.1.12(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.43.4)(vite@7.1.12(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))
+        version: 6.1.1(@sveltejs/kit@2.48.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.43.4)(vite@7.1.12(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.43.4)(vite@7.1.12(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))
       '@sveltejs/kit':
         specifier: ^2.22.0
-        version: 2.48.4(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.43.4)(vite@7.1.12(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.43.4)(vite@7.1.12(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 2.48.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.43.4)(vite@7.1.12(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.43.4)(vite@7.1.12(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.0.0
         version: 6.2.1(svelte@5.43.4)(vite@7.1.12(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -573,10 +588,10 @@ importers:
         version: 9.39.0
       '@sveltejs/adapter-auto':
         specifier: ^6.0.0
-        version: 6.1.1(@sveltejs/kit@2.48.4(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.43.4)(vite@6.4.1(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.43.4)(vite@6.4.1(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))
+        version: 6.1.1(@sveltejs/kit@2.48.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.43.4)(vite@6.4.1(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.43.4)(vite@6.4.1(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))
       '@sveltejs/kit':
         specifier: ^2.48.4
-        version: 2.48.4(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.43.4)(vite@6.4.1(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.43.4)(vite@6.4.1(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 2.48.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.43.4)(vite@6.4.1(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.43.4)(vite@6.4.1(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
       '@sveltejs/package':
         specifier: ^2.5.4
         version: 2.5.4(svelte@5.43.4)(typescript@5.8.3)
@@ -676,7 +691,7 @@ importers:
         version: link:../../packages/react
       next:
         specifier: 16.1.0
-        version: 16.1.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.93.3)
+        version: 16.1.0(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.93.3)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -794,10 +809,10 @@ importers:
     devDependencies:
       '@sveltejs/adapter-auto':
         specifier: ^6.0.0
-        version: 6.1.1(@sveltejs/kit@2.48.4(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.43.4)(vite@6.4.1(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.43.4)(vite@6.4.1(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))
+        version: 6.1.1(@sveltejs/kit@2.48.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.43.4)(vite@6.4.1(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.43.4)(vite@6.4.1(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))
       '@sveltejs/kit':
         specifier: ^2.16.0
-        version: 2.48.4(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.43.4)(vite@6.4.1(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.43.4)(vite@6.4.1(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 2.48.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.43.4)(vite@6.4.1(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.43.4)(vite@6.4.1(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.0.0
         version: 5.1.1(svelte@5.43.4)(vite@6.4.1(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -864,6 +879,34 @@ importers:
         version: 6.4.1(@types/node@22.19.0)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)
 
 packages:
+
+  '@ai-sdk/gateway@3.0.53':
+    resolution: {integrity: sha512-QT3FEoNARMRlk8JJVR7L98exiK9C8AGfrEJVbRxBT1yIXKs/N19o/+PsjTRVsARgDJNcy9JbJp1FspKucEat0Q==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/openai@3.0.30':
+    resolution: {integrity: sha512-YDht3t7TDyWKP+JYZp20VuYqSjyF2brHYh47GGFDUPf2wZiqNQ263ecL+quar2bP3GZ3BeQA8f0m2B7UwLPR+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.15':
+    resolution: {integrity: sha512-8XiKWbemmCbvNN0CLR9u3PQiet4gtEVIrX4zzLxnCj06AwsEDJwJVBbKrEI4t6qE8XRSIvU2irka0dcpziKW6w==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@3.0.8':
+    resolution: {integrity: sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/react@3.0.99':
+    resolution: {integrity: sha512-xMsp5br4Dpr/3BYq/jrE8q4YLgViU1KHVq8VB0+dzdLJFU3jKA83uoxpbWqzV/edQOBPgGBSb2CgmV5v77rvzA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^18 || ~19.0.1 || ~19.1.2 || ^19.2.1
 
   '@algolia/abtesting@1.1.0':
     resolution: {integrity: sha512-sEyWjw28a/9iluA37KLGu8vjxEIlb60uxznfTUmXImy7H5NvbpSO6yYgmgH5KiD7j+zTUUihiST0jEP12IoXow==}
@@ -3384,6 +3427,10 @@ packages:
   '@open-draft/deferred-promise@2.2.0':
     resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
 
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
   '@oxc-minify/binding-android-arm64@0.102.0':
     resolution: {integrity: sha512-pknM+ttJTwRr7ezn1v5K+o2P4RRjLAzKI10bjVDPybwWQ544AZW6jxm7/YDgF2yUbWEV9o7cAQPkIUOmCiW8vg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -4771,8 +4818,35 @@ packages:
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@stitches/core@1.2.8':
     resolution: {integrity: sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg==}
+
+  '@supabase/auth-js@2.97.0':
+    resolution: {integrity: sha512-2Og/1lqp+AIavr8qS2X04aSl8RBY06y4LrtIAGxat06XoXYiDxKNQMQzWDAKm1EyZFZVRNH48DO5YvIZ7la5fQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/functions-js@2.97.0':
+    resolution: {integrity: sha512-fSaA0ZeBUS9hMgpGZt5shIZvfs3Mvx2ZdajQT4kv/whubqDBAp3GU5W8iIXy21MRvKmO2NpAj8/Q6y+ZkZyF/w==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/postgrest-js@2.97.0':
+    resolution: {integrity: sha512-g4Ps0eaxZZurvfv/KGoo2XPZNpyNtjth9aW8eho9LZWM0bUuBtxPZw3ZQ6ERSpEGogshR+XNgwlSPIwcuHCNww==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/realtime-js@2.97.0':
+    resolution: {integrity: sha512-37Jw0NLaFP0CZd7qCan97D1zWutPrTSpgWxAw6Yok59JZoxp4IIKMrPeftJ3LZHmf+ILQOPy3i0pRDHM9FY36Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/storage-js@2.97.0':
+    resolution: {integrity: sha512-9f6NniSBfuMxOWKwEFb+RjJzkfMdJUwv9oHuFJKfe/5VJR8cd90qw68m6Hn0ImGtwG37TUO+QHtoOechxRJ1Yg==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/supabase-js@2.97.0':
+    resolution: {integrity: sha512-kTD91rZNO4LvRUHv4x3/4hNmsEd2ofkYhuba2VMUPRVef1RCmnHtm7rIws38Fg0yQnOSZOplQzafn0GSiy6GVg==}
+    engines: {node: '>=20.0.0'}
 
   '@sveltejs/acorn-typescript@1.0.6':
     resolution: {integrity: sha512-4awhxtMh4cx9blePWl10HRHj8Iivtqj+2QdDCSMDzxG+XKa9+VCNupQuCuvzEhYPzZSrX+0gC+0lHA/0fFKKQQ==}
@@ -5136,6 +5210,9 @@ packages:
     resolution: {integrity: sha512-EULJ8LApcVEPbrfND0cRQqutIOdiIgJ1Mgrhpy755r14xMohPTEpkV/k28SJvuOs9bHRFW8x+KeDAEPiGQPB9Q==}
     deprecated: This is a stub types definition. parse-path provides its own type definitions, so you do not need this installed.
 
+  '@types/phoenix@1.6.7':
+    resolution: {integrity: sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==}
+
   '@types/qs@6.14.0':
     resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
 
@@ -5410,6 +5487,10 @@ packages:
     resolution: {integrity: sha512-UEq+eF0ocEf9WQCV1gktxKhha36KDs7jln5qii6UpPf5clMqDc0p3E7d9l2Smx0i9Pm1qpq4S4lLfNl97bbv6w==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@vercel/oidc@3.1.0':
+    resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
+    engines: {node: '>= 20'}
 
   '@vinxi/listhen@1.5.6':
     resolution: {integrity: sha512-WSN1z931BtasZJlgPp704zJFnQFRg7yzSjkm3MzAWQYe4uXFXlFr1hc5Ac2zae5/HDOz5x1/zDM5Cb54vTCnWw==}
@@ -5798,6 +5879,12 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  ai@6.0.97:
+    resolution: {integrity: sha512-eZIAcBymwGhBwncRH/v9pillZNMeRCDkc4BwcvwXerXd7sxjVxRis3ZNCNCpP02pVH4NLs81ljm4cElC4vbNcQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ajv-draft-04@1.0.0:
     resolution: {integrity: sha512-mv00Te6nmYbRp5DCwclxtt7yV/joXJPGS7nM+97GdxvuttCOfgI3K4U25zboyeX0O+myI8ERluxQe5wljMmVIw==}
@@ -6668,6 +6755,7 @@ packages:
 
   dax-sh@0.43.2:
     resolution: {integrity: sha512-uULa1sSIHgXKGCqJ/pA0zsnzbHlVnuq7g8O2fkHokWFNwEGIhh5lAJlxZa1POG5En5ba7AU4KcBAvGQWMMf8rg==}
+    deprecated: This package has moved to simply be 'dax' instead of 'dax-sh'
 
   db0@0.3.4:
     resolution: {integrity: sha512-RiXXi4WaNzPTHEOu8UPQKMooIbqOEyqA1t7Z6MsdxSCeb8iUC9ko3LcmsLmeUt2SM5bctfArZKkRQggKZz7JNw==}
@@ -7866,6 +7954,10 @@ packages:
     resolution: {integrity: sha512-Y93lCzHYgGWdrJ66yIktxiaGULYc6oGiABxhcO5AufBeOyoIdZF7bIfLaOrbM0iGIOXQQgxxRrFEnb+Y6w1n4A==}
     engines: {node: '>=10.18'}
 
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
+
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
@@ -8324,6 +8416,9 @@ packages:
 
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -9449,6 +9544,18 @@ packages:
   open@8.4.2:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
+
+  openai@6.22.0:
+    resolution: {integrity: sha512-7Yvy17F33Bi9RutWbsaYt5hJEEJ/krRPOrwan+f9aCPuMat1WVsb2VNSII5W1EksKT6fF69TG/xj4XzodK3JZw==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -10994,6 +11101,11 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  swr@2.4.0:
+    resolution: {integrity: sha512-sUlC20T8EOt1pHmDiqueUWMmRRX03W7w5YxovWX7VR2KHEPCTMly85x05vpkP5i6Bu4h44ePSMD9Tc+G2MItFw==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   system-architecture@0.1.0:
     resolution: {integrity: sha512-ulAk51I9UVUyJgxlv9M6lFot2WP3e7t8Kz9+IS6D4rVba1tR9kON+Ey69f+1R4Q8cd45Lod6a4IcJIxnzGc/zA==}
     engines: {node: '>=18'}
@@ -11030,10 +11142,12 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tar@7.5.2:
     resolution: {integrity: sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   terracotta@1.0.6:
     resolution: {integrity: sha512-yVrmT/Lg6a3tEbeYEJH8ksb1PYkR5FA9k5gr1TchaSNIiA2ZWs5a+koEbePXwlBP0poaV7xViZ/v50bQFcMgqw==}
@@ -11095,6 +11209,10 @@ packages:
 
   three@0.179.1:
     resolution: {integrity: sha512-5y/elSIQbrvKOISxpwXCR4sQqHtGiOI+MKLc3SsBdDXA2hz3Mdp3X59aUp8DyybMa34aeBwbFTpdoLJaUDEWSw==}
+
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
 
   thunky@1.1.0:
     resolution: {integrity: sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==}
@@ -12355,6 +12473,40 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@ai-sdk/gateway@3.0.53(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.15(zod@3.25.76)
+      '@vercel/oidc': 3.1.0
+      zod: 3.25.76
+
+  '@ai-sdk/openai@3.0.30(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.15(zod@3.25.76)
+      zod: 3.25.76
+
+  '@ai-sdk/provider-utils@4.0.15(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.8
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.6
+      zod: 3.25.76
+
+  '@ai-sdk/provider@3.0.8':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/react@3.0.99(react@19.1.2)(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider-utils': 4.0.15(zod@3.25.76)
+      ai: 6.0.97(zod@3.25.76)
+      react: 19.1.2
+      swr: 2.4.0(react@19.1.2)
+      throttleit: 2.1.0
+    transitivePeerDependencies:
+      - zod
 
   '@algolia/abtesting@1.1.0':
     dependencies:
@@ -14506,7 +14658,7 @@ snapshots:
       '@mdx-js/mdx': 3.1.1
       source-map: 0.7.6
     optionalDependencies:
-      webpack: 5.101.2(esbuild@0.25.9)
+      webpack: 5.101.2
     transitivePeerDependencies:
       - supports-color
 
@@ -15567,6 +15719,8 @@ snapshots:
       - yaml
 
   '@open-draft/deferred-promise@2.2.0': {}
+
+  '@opentelemetry/api@1.9.0': {}
 
   '@oxc-minify/binding-android-arm64@0.102.0':
     optional: true
@@ -16670,21 +16824,61 @@ snapshots:
 
   '@standard-schema/spec@1.0.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@stitches/core@1.2.8': {}
+
+  '@supabase/auth-js@2.97.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.97.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/postgrest-js@2.97.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.97.0':
+    dependencies:
+      '@types/phoenix': 1.6.7
+      '@types/ws': 8.18.1
+      tslib: 2.8.1
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@supabase/storage-js@2.97.0':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.97.0':
+    dependencies:
+      '@supabase/auth-js': 2.97.0
+      '@supabase/functions-js': 2.97.0
+      '@supabase/postgrest-js': 2.97.0
+      '@supabase/realtime-js': 2.97.0
+      '@supabase/storage-js': 2.97.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@sveltejs/acorn-typescript@1.0.6(acorn@8.15.0)':
     dependencies:
       acorn: 8.15.0
 
-  '@sveltejs/adapter-auto@6.1.1(@sveltejs/kit@2.48.4(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.43.4)(vite@6.4.1(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.43.4)(vite@6.4.1(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@sveltejs/adapter-auto@6.1.1(@sveltejs/kit@2.48.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.43.4)(vite@6.4.1(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.43.4)(vite@6.4.1(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
-      '@sveltejs/kit': 2.48.4(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.43.4)(vite@6.4.1(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.43.4)(vite@6.4.1(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@sveltejs/kit': 2.48.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.43.4)(vite@6.4.1(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.43.4)(vite@6.4.1(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
 
-  '@sveltejs/adapter-auto@6.1.1(@sveltejs/kit@2.48.4(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.43.4)(vite@7.1.12(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.43.4)(vite@7.1.12(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))':
+  '@sveltejs/adapter-auto@6.1.1(@sveltejs/kit@2.48.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.43.4)(vite@7.1.12(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.43.4)(vite@7.1.12(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))':
     dependencies:
-      '@sveltejs/kit': 2.48.4(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.43.4)(vite@7.1.12(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.43.4)(vite@7.1.12(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@sveltejs/kit': 2.48.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.43.4)(vite@7.1.12(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.43.4)(vite@7.1.12(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
 
-  '@sveltejs/kit@2.48.4(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.43.4)(vite@6.4.1(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.43.4)(vite@6.4.1(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@sveltejs/kit@2.48.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.43.4)(vite@6.4.1(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.43.4)(vite@6.4.1(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@standard-schema/spec': 1.0.0
       '@sveltejs/acorn-typescript': 1.0.6(acorn@8.15.0)
@@ -16702,8 +16896,10 @@ snapshots:
       sirv: 3.0.2
       svelte: 5.43.4
       vite: 6.4.1(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
 
-  '@sveltejs/kit@2.48.4(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.43.4)(vite@7.1.12(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.43.4)(vite@7.1.12(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@sveltejs/kit@2.48.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.43.4)(vite@7.1.12(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.43.4)(vite@7.1.12(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@standard-schema/spec': 1.0.0
       '@sveltejs/acorn-typescript': 1.0.6(acorn@8.15.0)
@@ -16721,8 +16917,10 @@ snapshots:
       sirv: 3.0.2
       svelte: 5.43.4
       vite: 7.1.12(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
 
-  '@sveltejs/kit@2.48.4(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.43.4)(vite@7.2.7(@types/node@20.19.24)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.43.4)(vite@7.2.7(@types/node@20.19.24)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@sveltejs/kit@2.48.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.43.4)(vite@7.2.7(@types/node@20.19.24)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.43.4)(vite@7.2.7(@types/node@20.19.24)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@standard-schema/spec': 1.0.0
       '@sveltejs/acorn-typescript': 1.0.6(acorn@8.15.0)
@@ -16740,6 +16938,8 @@ snapshots:
       sirv: 3.0.2
       svelte: 5.43.4
       vite: 7.2.7(@types/node@20.19.24)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
     optional: true
 
   '@sveltejs/package@2.5.4(svelte@5.43.4)(typescript@5.8.3)':
@@ -16998,7 +17198,7 @@ snapshots:
       '@tanstack/react-router': 1.143.11(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       vite: 6.4.1(@types/node@22.19.0)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)
       vite-plugin-solid: 2.11.10(solid-js@1.9.10)(vite@6.4.1(@types/node@22.19.0)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
-      webpack: 5.101.2(esbuild@0.25.9)
+      webpack: 5.101.2
     transitivePeerDependencies:
       - supports-color
 
@@ -17211,6 +17411,8 @@ snapshots:
   '@types/parse-path@7.1.0':
     dependencies:
       parse-path: 7.1.0
+
+  '@types/phoenix@1.6.7': {}
 
   '@types/qs@6.14.0': {}
 
@@ -17545,10 +17747,10 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 19.1.2
 
-  '@vercel/analytics@1.5.0(@sveltejs/kit@2.48.4(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.43.4)(vite@7.2.7(@types/node@20.19.24)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.43.4)(vite@7.2.7(@types/node@20.19.24)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(next@15.4.8(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(sass@1.93.3))(react@19.1.2)(svelte@5.43.4)(vue-router@4.6.3(vue@3.5.26(typescript@5.8.3)))(vue@3.5.26(typescript@5.8.3))':
+  '@vercel/analytics@1.5.0(@sveltejs/kit@2.48.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.43.4)(vite@7.2.7(@types/node@20.19.24)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.43.4)(vite@7.2.7(@types/node@20.19.24)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(next@15.4.8(@opentelemetry/api@1.9.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(sass@1.93.3))(react@19.1.2)(svelte@5.43.4)(vue-router@4.6.3(vue@3.5.26(typescript@5.8.3)))(vue@3.5.26(typescript@5.8.3))':
     optionalDependencies:
-      '@sveltejs/kit': 2.48.4(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.43.4)(vite@7.2.7(@types/node@20.19.24)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.43.4)(vite@7.2.7(@types/node@20.19.24)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
-      next: 15.4.8(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(sass@1.93.3)
+      '@sveltejs/kit': 2.48.4(@opentelemetry/api@1.9.0)(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.43.4)(vite@7.2.7(@types/node@20.19.24)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)))(svelte@5.43.4)(vite@7.2.7(@types/node@20.19.24)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
+      next: 15.4.8(@opentelemetry/api@1.9.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(sass@1.93.3)
       react: 19.1.2
       svelte: 5.43.4
       vue: 3.5.26(typescript@5.8.3)
@@ -17572,6 +17774,8 @@ snapshots:
       - encoding
       - rollup
       - supports-color
+
+  '@vercel/oidc@3.1.0': {}
 
   '@vinxi/listhen@1.5.6':
     dependencies:
@@ -18236,6 +18440,14 @@ snapshots:
       regex-parser: 2.3.1
 
   agent-base@7.1.4: {}
+
+  ai@6.0.97(zod@3.25.76):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.53(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.8
+      '@ai-sdk/provider-utils': 4.0.15(zod@3.25.76)
+      '@opentelemetry/api': 1.9.0
+      zod: 3.25.76
 
   ajv-draft-04@1.0.0(ajv@8.13.0):
     optionalDependencies:
@@ -19693,8 +19905,8 @@ snapshots:
       '@typescript-eslint/parser': 8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.8.3)
       eslint: 9.39.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.0(jiti@2.6.1))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.0(jiti@2.6.1))
@@ -19713,8 +19925,8 @@ snapshots:
       '@typescript-eslint/parser': 8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.8.3)
       eslint: 9.39.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.0(jiti@2.6.1))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.0(jiti@2.6.1))
@@ -19731,7 +19943,7 @@ snapshots:
       eslint: 9.39.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.0(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.0(jiti@2.6.1))
@@ -19757,21 +19969,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1)):
-    dependencies:
-      '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.3
-      eslint: 9.39.0(jiti@2.6.1)
-      get-tsconfig: 4.13.0
-      is-bun-module: 2.0.0
-      stable-hash: 0.0.5
-      tinyglobby: 0.2.15
-      unrs-resolver: 1.11.1
-    optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1))
-    transitivePeerDependencies:
-      - supports-color
-
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -19783,18 +19980,33 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.0(jiti@2.6.1)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.3
+      eslint: 9.39.0(jiti@2.6.1)
+      get-tsconfig: 4.13.0
+      is-bun-module: 2.0.0
+      stable-hash: 0.0.5
+      tinyglobby: 0.2.15
+      unrs-resolver: 1.11.1
+    optionalDependencies:
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.0(jiti@2.6.1))
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.8.3)
       eslint: 9.39.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -19808,7 +20020,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -19819,7 +20031,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.2(eslint@9.39.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -19837,7 +20049,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -20837,6 +21049,8 @@ snapshots:
 
   hyperdyperid@1.2.0: {}
 
+  iceberg-js@0.8.1: {}
+
   iconv-lite@0.4.24:
     dependencies:
       safer-buffer: 2.1.2
@@ -21238,6 +21452,8 @@ snapshots:
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
+
+  json-schema@0.4.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -22385,7 +22601,7 @@ snapshots:
 
   next-tick@1.1.0: {}
 
-  next@15.3.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.93.3):
+  next@15.3.5(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.93.3):
     dependencies:
       '@next/env': 15.3.5
       '@swc/counter': 0.1.3
@@ -22405,13 +22621,14 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.3.5
       '@next/swc-win32-arm64-msvc': 15.3.5
       '@next/swc-win32-x64-msvc': 15.3.5
+      '@opentelemetry/api': 1.9.0
       sass: 1.93.3
       sharp: 0.34.4
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@15.4.8(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(sass@1.93.3):
+  next@15.4.8(@opentelemetry/api@1.9.0)(react-dom@19.1.2(react@19.1.2))(react@19.1.2)(sass@1.93.3):
     dependencies:
       '@next/env': 15.4.8
       '@swc/helpers': 0.5.15
@@ -22429,13 +22646,14 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.4.8
       '@next/swc-win32-arm64-msvc': 15.4.8
       '@next/swc-win32-x64-msvc': 15.4.8
+      '@opentelemetry/api': 1.9.0
       sass: 1.93.3
       sharp: 0.34.4
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.1.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.93.3):
+  next@16.1.0(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.93.3):
     dependencies:
       '@next/env': 16.1.0
       '@swc/helpers': 0.5.15
@@ -22454,6 +22672,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.1.0
       '@next/swc-win32-arm64-msvc': 16.1.0
       '@next/swc-win32-x64-msvc': 16.1.0
+      '@opentelemetry/api': 1.9.0
       sass: 1.93.3
       sharp: 0.34.4
     transitivePeerDependencies:
@@ -23059,6 +23278,11 @@ snapshots:
       define-lazy-prop: 2.0.0
       is-docker: 2.2.1
       is-wsl: 2.2.0
+
+  openai@6.22.0(ws@8.18.3)(zod@3.25.76):
+    optionalDependencies:
+      ws: 8.18.3
+      zod: 3.25.76
 
   optionator@0.9.4:
     dependencies:
@@ -24965,6 +25189,12 @@ snapshots:
       picocolors: 1.1.1
       sax: 1.4.1
 
+  swr@2.4.0(react@19.1.2):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.1.2
+      use-sync-external-store: 1.6.0(react@19.1.2)
+
   system-architecture@0.1.0: {}
 
   tagged-tag@1.0.0: {}
@@ -25059,6 +25289,16 @@ snapshots:
     optionalDependencies:
       esbuild: 0.25.9
 
+  terser-webpack-plugin@5.3.14(webpack@5.101.2):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      serialize-javascript: 6.0.2
+      terser: 5.43.1
+      webpack: 5.101.2
+    optional: true
+
   terser@5.43.1:
     dependencies:
       '@jridgewell/source-map': 0.3.11
@@ -25106,6 +25346,8 @@ snapshots:
       three: 0.179.1
 
   three@0.179.1: {}
+
+  throttleit@2.1.0: {}
 
   thunky@1.1.0: {}
 
@@ -26507,6 +26749,39 @@ snapshots:
       webpack: 5.101.2(esbuild@0.25.9)
 
   webpack-virtual-modules@0.6.2: {}
+
+  webpack@5.101.2:
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.15.0
+      acorn-import-phases: 1.0.4(acorn@8.15.0)
+      browserslist: 4.27.0
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.18.3
+      es-module-lexer: 1.7.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.1
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.0
+      terser-webpack-plugin: 5.3.14(webpack@5.101.2)
+      watchpack: 2.4.4
+      webpack-sources: 3.3.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
+    optional: true
 
   webpack@5.101.2(esbuild@0.25.9):
     dependencies:


### PR DESCRIPTION
## Summary
- Add RAG-based AI chatbot to the documentation site using Supabase pgvector + OpenAI
- Indexes MDX docs as chunks, performs vector similarity search, and streams responses via gpt-4o-mini
- Supports multilingual queries (en, ko, ja) with IP-based rate limiting (10 req/min)

## Changes
- **Indexing script** (`scripts/ingest-docs.ts`): MDX → chunk splitting → OpenAI embeddings → Supabase storage
- **Chat API** (`app/api/chat/route.ts`): Vector search + gpt-4o-mini streaming response
- **Chatbot UI**: Floating button + drawer (responsive, expand/collapse), Markdown rendering + syntax highlighting
- **i18n**: Added chatbot messages for en/ko/ja/zh
- **Infrastructure**: Supabase client, in-memory rate limiter

## Tech Stack
- Vercel AI SDK v6 (`ai`, `@ai-sdk/openai`, `@ai-sdk/react`)
- Supabase pgvector (text-embedding-3-small, 1536d)
- gpt-4o-mini (temperature: 0.1, maxOutputTokens: 1024)
- rehype-highlight for code syntax highlighting

## Test plan
- [ ] Run `pnpm ingest:docs` to verify document indexing
- [ ] Ask questions in Korean/English/Japanese and verify relevant doc retrieval
- [ ] Verify syntax highlighting and readability in code snippet responses
- [ ] Check mobile responsive layout
- [ ] Verify rate limiting (429 on 11th consecutive request)

🤖 Generated with [Claude Code](https://claude.com/claude-code)