### PR TITLE
fix(core): publish v4.4.1 with correct build output

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/core",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "description": "Core animation engine for SSGOI - Native app-like page transitions with spring physics",
   "private": false,
   "type": "module",


### PR DESCRIPTION
## Summary
- `@ssgoi/core@4.4.0` was published to npm without the latest build output, causing `skipAnimationOnBack` and other v4.4.0 release features to be missing from the npm package
- Bumped version to `4.4.1` and published with correct build output to npm

Closes #313

## Test plan
- [x] Verified npm `@ssgoi/core@4.4.0` was missing `skipAnimationOnBack` in types
- [x] Built `@ssgoi/core@4.4.1` and verified `skipAnimationOnBack` is present in dist
- [x] Published `@ssgoi/core@4.4.1` to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)