### PR TITLE
Fix Sandpack scroll handling and stabilize preserveScroll restoration

### DIFF
--- a/apps/docs/scripts/generate-sandpack-templates.ts
+++ b/apps/docs/scripts/generate-sandpack-templates.ts
@@ -220,9 +220,14 @@ export default function App() {
 
   return (
     <BrowserContext.Provider value={{ currentPath, navigate, routes }}>
+      {/* Inline styles for overflow/height: Tailwind CDN loads async in
+          Sandpack, so utility classes aren't applied yet when SSGOI's
+          getScrollingElement runs. Inline styles take effect immediately
+          and ensure this div is detected as the scroll container. */}
       <div
         ref={contentRef}
-        className="browser-content z-0 relative bg-[#121212] h-screen overflow-y-scroll"
+        className="browser-content z-0 relative bg-[#121212]"
+        style={{ height: "100vh", overflowY: "scroll", position: "relative" }}
       >
         <Ssgoi config={config}>
           <DemoLayout>

--- a/apps/docs/src/components/mdx/mdx-components/view-transition-demo/depth-demo/layout.tsx
+++ b/apps/docs/src/components/mdx/mdx-components/view-transition-demo/depth-demo/layout.tsx
@@ -11,7 +11,7 @@ interface DemoLayoutProps {
 
 export const DemoLayout = memo(({ children }: DemoLayoutProps) => {
   return (
-    <div className="z-0">
+    <div className="overflow-x-clip overflow-y-scroll relative h-screen z-0">
       <TransitionScope>{children}</TransitionScope>
     </div>
   );

--- a/apps/docs/src/components/mdx/mdx-components/view-transition-demo/depth-demo/layout.tsx
+++ b/apps/docs/src/components/mdx/mdx-components/view-transition-demo/depth-demo/layout.tsx
@@ -10,11 +10,7 @@ interface DemoLayoutProps {
 }
 
 export const DemoLayout = memo(({ children }: DemoLayoutProps) => {
-  return (
-    <div className="overflow-x-clip overflow-y-scroll relative h-screen z-0">
-      <TransitionScope>{children}</TransitionScope>
-    </div>
-  );
+  return <TransitionScope>{children}</TransitionScope>;
 });
 
 DemoLayout.displayName = "DepthDemoLayout";

--- a/apps/docs/src/components/mdx/mdx-components/view-transition-demo/film-demo/layout.tsx
+++ b/apps/docs/src/components/mdx/mdx-components/view-transition-demo/film-demo/layout.tsx
@@ -9,9 +9,7 @@ interface DemoLayoutProps {
 
 export const DemoLayout = memo(({ children }: DemoLayoutProps) => {
   return (
-    <div className="overflow-x-clip overflow-y-scroll relative h-screen z-0 bg-black">
-      {children}
-    </div>
+    <div className="overflow-x-clip relative z-0 bg-black">{children}</div>
   );
 });
 

--- a/apps/docs/src/components/mdx/mdx-components/view-transition-demo/film-demo/layout.tsx
+++ b/apps/docs/src/components/mdx/mdx-components/view-transition-demo/film-demo/layout.tsx
@@ -8,7 +8,11 @@ interface DemoLayoutProps {
 }
 
 export const DemoLayout = memo(({ children }: DemoLayoutProps) => {
-  return <div className="min-h-screen bg-black">{children}</div>;
+  return (
+    <div className="overflow-x-clip overflow-y-scroll relative h-screen z-0 bg-black">
+      {children}
+    </div>
+  );
 });
 
 DemoLayout.displayName = "FilmDemoLayout";

--- a/apps/docs/src/components/mdx/mdx-components/view-transition-demo/jaemin-demo/layout.tsx
+++ b/apps/docs/src/components/mdx/mdx-components/view-transition-demo/jaemin-demo/layout.tsx
@@ -46,7 +46,7 @@ export const DemoLayout = memo(({ children }: DemoLayoutProps) => {
   const { currentPath, navigate, routes } = context;
 
   return (
-    <div className="relative min-h-full">
+    <div className="overflow-x-clip overflow-y-scroll relative h-screen z-0">
       {/* Floating Header - Fixed, centered, doesn't take up space */}
       <header className="fixed top-3 left-1/2 -translate-x-1/2 z-[9999]">
         <div

--- a/apps/docs/src/components/mdx/mdx-components/view-transition-demo/jaemin-demo/layout.tsx
+++ b/apps/docs/src/components/mdx/mdx-components/view-transition-demo/jaemin-demo/layout.tsx
@@ -46,7 +46,7 @@ export const DemoLayout = memo(({ children }: DemoLayoutProps) => {
   const { currentPath, navigate, routes } = context;
 
   return (
-    <div className="overflow-x-clip overflow-y-scroll relative h-screen z-0">
+    <div className="overflow-x-clip relative z-0">
       {/* Floating Header - Fixed, centered, doesn't take up space */}
       <header className="fixed top-3 left-1/2 -translate-x-1/2 z-[9999]">
         <div

--- a/apps/docs/src/components/mdx/mdx-components/view-transition-demo/sheet-demo/layout.tsx
+++ b/apps/docs/src/components/mdx/mdx-components/view-transition-demo/sheet-demo/layout.tsx
@@ -10,7 +10,7 @@ interface DemoLayoutProps {
 
 export const DemoLayout = memo(({ children }: DemoLayoutProps) => {
   return (
-    <div className="z-0">
+    <div className="overflow-x-clip overflow-y-scroll relative h-screen z-0">
       <TransitionScope>{children}</TransitionScope>
     </div>
   );

--- a/apps/docs/src/components/mdx/mdx-components/view-transition-demo/sheet-demo/layout.tsx
+++ b/apps/docs/src/components/mdx/mdx-components/view-transition-demo/sheet-demo/layout.tsx
@@ -10,7 +10,7 @@ interface DemoLayoutProps {
 
 export const DemoLayout = memo(({ children }: DemoLayoutProps) => {
   return (
-    <div className="overflow-x-clip overflow-y-scroll relative h-screen z-0">
+    <div className="overflow-x-clip relative z-0">
       <TransitionScope>{children}</TransitionScope>
     </div>
   );

--- a/apps/docs/src/components/mdx/mdx-components/view-transition-demo/snap-demo/layout.tsx
+++ b/apps/docs/src/components/mdx/mdx-components/view-transition-demo/snap-demo/layout.tsx
@@ -74,7 +74,7 @@ export const DemoLayout = memo(({ children }: DemoLayoutProps) => {
   ];
 
   return (
-    <div className="z-0">
+    <div className="overflow-x-clip overflow-y-scroll relative h-screen z-0">
       <TransitionScope>
         {children}
 

--- a/apps/docs/src/components/mdx/mdx-components/view-transition-demo/snap-demo/layout.tsx
+++ b/apps/docs/src/components/mdx/mdx-components/view-transition-demo/snap-demo/layout.tsx
@@ -74,7 +74,7 @@ export const DemoLayout = memo(({ children }: DemoLayoutProps) => {
   ];
 
   return (
-    <div className="overflow-x-clip overflow-y-scroll relative h-screen z-0">
+    <div className="overflow-x-clip relative z-0">
       <TransitionScope>
         {children}
 

--- a/apps/docs/src/components/mdx/mdx-components/view-transition-demo/swap-demo/layout.tsx
+++ b/apps/docs/src/components/mdx/mdx-components/view-transition-demo/swap-demo/layout.tsx
@@ -74,7 +74,7 @@ export const DemoLayout = memo(({ children }: DemoLayoutProps) => {
   ];
 
   return (
-    <div className="z-0">
+    <div className="overflow-x-clip overflow-y-scroll relative h-screen z-0">
       <TransitionScope>
         {children}
 

--- a/apps/docs/src/components/mdx/mdx-components/view-transition-demo/swap-demo/layout.tsx
+++ b/apps/docs/src/components/mdx/mdx-components/view-transition-demo/swap-demo/layout.tsx
@@ -74,7 +74,7 @@ export const DemoLayout = memo(({ children }: DemoLayoutProps) => {
   ];
 
   return (
-    <div className="overflow-x-clip overflow-y-scroll relative h-screen z-0">
+    <div className="">
       <TransitionScope>
         {children}
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "solid:watch": "pnpm --filter @ssgoi/solid watch",
     "docs": "pnpm --filter docs dev",
     "docs:build": "pnpm --filter docs build",
+    "sandpack-sync": "pnpm --filter docs generate:sandpack",
     "angular-demo": "pnpm --filter angular-demo dev",
     "react-demo": "pnpm --filter react-demo dev",
     "solid-demo": "pnpm --filter solid-demo dev",

--- a/packages/core/eslint.config.js
+++ b/packages/core/eslint.config.js
@@ -9,10 +9,10 @@ export default tseslint.config(
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     languageOptions: {
       ecmaVersion: 2020,
-      globals: globals.browser, // DOM API usage (window, document, HTMLElement)
+      globals: { ...globals.browser, ...globals.node },
       parserOptions: {
         tsconfigRootDir: import.meta.dirname,
-        project: './tsconfig.json',
+        project: "./tsconfig.json",
       },
     },
   },

--- a/packages/core/src/lib/ssgoi-transition/create-context-manager.test.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-context-manager.test.ts
@@ -1,0 +1,245 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createContextManager } from "./create-context-manager";
+
+type FakeElement = HTMLElement & {
+  parentElement: HTMLElement | null;
+  clientWidth: number;
+  clientHeight: number;
+  scrollWidth: number;
+  scrollHeight: number;
+  scrollLeft: number;
+  scrollTop: number;
+  scrollTo: ReturnType<typeof vi.fn>;
+};
+
+type ListenerMap = Map<string, Set<EventListenerOrEventListenerObject>>;
+
+const emitEvent = (listeners: ListenerMap, type: string) => {
+  const event = { type } as Event;
+  for (const listener of listeners.get(type) ?? []) {
+    if (typeof listener === "function") {
+      listener(event);
+    } else {
+      listener.handleEvent(event);
+    }
+  }
+};
+
+const createFakeElement = (
+  overrides: Partial<FakeElement> = {},
+): FakeElement => {
+  const element = {
+    parentElement: null,
+    clientWidth: 1024,
+    clientHeight: 600,
+    scrollWidth: 1024,
+    scrollHeight: 2000,
+    scrollLeft: 0,
+    scrollTop: 0,
+    scrollTo: vi.fn(function (this: FakeElement, options: ScrollToOptions) {
+      this.scrollLeft = options.left ?? this.scrollLeft;
+      this.scrollTop = options.top ?? this.scrollTop;
+    }),
+    ...overrides,
+  } as unknown as FakeElement;
+
+  return element;
+};
+
+describe("createContextManager", () => {
+  let now = 0;
+  let nextAnimationFrameId = 0;
+  let animationFrameQueue = new Map<number, FrameRequestCallback>();
+  let windowListeners: ListenerMap;
+  let documentElement: FakeElement;
+  let body: FakeElement;
+
+  const flushAnimationFrames = (count = 1) => {
+    for (let index = 0; index < count; index += 1) {
+      const callbacks = [...animationFrameQueue.values()];
+      animationFrameQueue = new Map();
+      now += 16;
+
+      for (const callback of callbacks) {
+        callback(now);
+      }
+    }
+  };
+
+  const emitWindowScroll = () => {
+    emitEvent(windowListeners, "scroll");
+  };
+
+  beforeEach(() => {
+    now = 0;
+    nextAnimationFrameId = 0;
+    animationFrameQueue = new Map();
+    windowListeners = new Map();
+
+    documentElement = createFakeElement({
+      clientWidth: 1024,
+      clientHeight: 600,
+      scrollWidth: 1024,
+      scrollHeight: 2000,
+    });
+    body = createFakeElement();
+
+    vi.spyOn(performance, "now").mockImplementation(() => now);
+
+    vi.stubGlobal(
+      "requestAnimationFrame",
+      vi.fn((callback: FrameRequestCallback) => {
+        const id = nextAnimationFrameId;
+        nextAnimationFrameId += 1;
+        animationFrameQueue.set(id, callback);
+        return id;
+      }),
+    );
+    vi.stubGlobal(
+      "cancelAnimationFrame",
+      vi.fn((id: number) => {
+        animationFrameQueue.delete(id);
+      }),
+    );
+    vi.stubGlobal("window", {
+      innerWidth: 1024,
+      addEventListener: vi.fn(
+        (type: string, listener: EventListenerOrEventListenerObject) => {
+          if (!windowListeners.has(type)) {
+            windowListeners.set(type, new Set());
+          }
+          windowListeners.get(type)!.add(listener);
+        },
+      ),
+      removeEventListener: vi.fn(
+        (type: string, listener: EventListenerOrEventListenerObject) => {
+          windowListeners.get(type)?.delete(listener);
+        },
+      ),
+      getComputedStyle: vi.fn(() => ({
+        overflow: "visible",
+        overflowX: "visible",
+        overflowY: "visible",
+      })),
+    } as unknown as Window);
+    vi.stubGlobal("document", {
+      body,
+      documentElement,
+    } as unknown as Document);
+    vi.stubGlobal("ResizeObserver", undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("does not restore scroll on the initial mount", () => {
+    const manager = createContextManager({
+      preserveScroll: true,
+    });
+    const page = createFakeElement({
+      parentElement: body,
+    });
+
+    documentElement.scrollTop = 320;
+
+    manager.initializeContext(page, "/feed");
+    manager.activateContext("/feed");
+    flushAnimationFrames(5);
+
+    expect(documentElement.scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("freezes the outgoing path until the incoming page is activated", () => {
+    const manager = createContextManager({
+      preserveScroll: true,
+    });
+    const feedPage = createFakeElement({
+      parentElement: body,
+    });
+    const detailPage = createFakeElement({
+      parentElement: body,
+    });
+    const feedPageAgain = createFakeElement({
+      parentElement: body,
+    });
+
+    manager.initializeContext(feedPage, "/feed");
+    manager.activateContext("/feed");
+
+    documentElement.scrollTop = 480;
+    emitWindowScroll();
+    expect(manager.getScrollPosition("/feed")).toEqual({
+      x: 0,
+      y: 480,
+    });
+
+    manager.initializeContext(detailPage, "/detail");
+
+    documentElement.scrollTop = 0;
+    emitWindowScroll();
+
+    expect(manager.getScrollPosition("/feed")).toEqual({
+      x: 0,
+      y: 480,
+    });
+
+    manager.activateContext("/detail", {
+      restoreScroll: true,
+    });
+    flushAnimationFrames(2);
+    expect(documentElement.scrollTop).toBe(0);
+
+    manager.initializeContext(feedPageAgain, "/feed");
+    manager.activateContext("/feed", {
+      restoreScroll: true,
+    });
+    flushAnimationFrames(2);
+
+    expect(documentElement.scrollTop).toBe(480);
+  });
+
+  it("keeps retrying until the saved target becomes reachable", () => {
+    const manager = createContextManager({
+      preserveScroll: true,
+    });
+    const feedPage = createFakeElement({
+      parentElement: body,
+    });
+    const detailPage = createFakeElement({
+      parentElement: body,
+    });
+    const returningFeedPage = createFakeElement({
+      parentElement: body,
+    });
+
+    manager.initializeContext(feedPage, "/feed");
+    manager.activateContext("/feed");
+
+    documentElement.scrollTop = 900;
+    emitWindowScroll();
+
+    manager.initializeContext(detailPage, "/detail");
+    manager.activateContext("/detail", {
+      restoreScroll: true,
+    });
+    flushAnimationFrames(2);
+
+    documentElement.scrollHeight = 760;
+    documentElement.scrollTop = 0;
+
+    manager.initializeContext(returningFeedPage, "/feed");
+    manager.activateContext("/feed", {
+      restoreScroll: true,
+    });
+
+    flushAnimationFrames(10);
+    expect(documentElement.scrollTop).toBe(160);
+
+    documentElement.scrollHeight = 2000;
+    flushAnimationFrames(1);
+
+    expect(documentElement.scrollTop).toBe(900);
+  });
+});

--- a/packages/core/src/lib/ssgoi-transition/create-context-manager.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-context-manager.ts
@@ -4,6 +4,15 @@ import { getPositionedParent } from "../utils/get-positioned-parent";
 import { matchPath } from "./find-matching-transition";
 
 const MOBILE_BREAKPOINT_PX = 768;
+const RESTORE_RETRY_WINDOW_MS = 1000;
+
+type ScrollPosition = { x: number; y: number };
+
+type PendingRestoreState = {
+  container: HTMLElement;
+  path: string;
+  position: ScrollPosition;
+};
 
 export type ContextManagerOptions = {
   /**
@@ -61,29 +70,132 @@ export function createContextManager(options: ContextManagerOptions = {}) {
     return !value.exclude.some((pattern) => matchPath(path, pattern));
   };
   let contextElement: HTMLElement | null = null;
-  const scrollPositions: Map<string, { x: number; y: number }> = new Map();
+  let pendingContextElement: HTMLElement | null = null;
+  const scrollPositions: Map<string, ScrollPosition> = new Map();
   let currentPath: string | null = null;
+  let lockedOutgoingPath: string | null = null;
+  let restoringPath: string | null = null;
+  let pendingRestoreFrame: number | null = null;
+  let pendingRestoreState: PendingRestoreState | null = null;
+
+  const getNow = () =>
+    typeof performance !== "undefined" ? performance.now() : Date.now();
+  let pendingRestoreDeadline = 0;
 
   const scrollListener = () => {
     if (!scrollContainer || !currentPath) return;
+    if (currentPath === lockedOutgoingPath || currentPath === restoringPath) {
+      return;
+    }
     scrollPositions.set(currentPath, {
       x: scrollContainer.scrollLeft,
       y: scrollContainer.scrollTop,
     });
   };
 
-  const restoreScrollPosition = (path: string) => {
+  const captureScrollPosition = (path: string) => {
     if (!scrollContainer) return;
-    const savedPosition = scrollPositions.get(path) ?? { x: 0, y: 0 };
-    scrollContainer.scrollTo({
-      top: savedPosition.y,
-      left: savedPosition.x,
+    scrollPositions.set(path, {
+      x: scrollContainer.scrollLeft,
+      y: scrollContainer.scrollTop,
     });
   };
 
-  // Initialize context with element - sets up scroll tracking and stores element for later use
+  const cancelPendingRestore = (
+    options: { commitCurrentScroll?: boolean } = {},
+  ) => {
+    const { commitCurrentScroll = true } = options;
+
+    if (pendingRestoreFrame !== null) {
+      cancelAnimationFrame(pendingRestoreFrame);
+      pendingRestoreFrame = null;
+    }
+
+    if (
+      commitCurrentScroll &&
+      restoringPath &&
+      currentPath === restoringPath &&
+      scrollContainer
+    ) {
+      captureScrollPosition(restoringPath);
+    }
+
+    pendingRestoreState = null;
+    pendingRestoreDeadline = 0;
+    restoringPath = null;
+  };
+
+  const applyScrollPosition = (
+    container: HTMLElement,
+    position: ScrollPosition,
+  ) => {
+    const maxX = Math.max(0, container.scrollWidth - container.clientWidth);
+    const maxY = Math.max(0, container.scrollHeight - container.clientHeight);
+    const targetX = Math.max(0, Math.min(position.x, maxX));
+    const targetY = Math.max(0, Math.min(position.y, maxY));
+
+    if (container.scrollLeft === targetX && container.scrollTop === targetY) {
+      return;
+    }
+
+    container.scrollTo({
+      left: targetX,
+      top: targetY,
+    });
+  };
+
+  const restoreScrollPosition = (path: string) => {
+    if (!scrollContainer) return;
+    cancelPendingRestore();
+
+    const container = scrollContainer;
+    const savedPosition =
+      shouldPreserve(path) && scrollPositions.has(path)
+        ? scrollPositions.get(path)!
+        : { x: 0, y: 0 };
+
+    scrollPositions.set(path, savedPosition);
+    restoringPath = path;
+    pendingRestoreState = {
+      container,
+      path,
+      position: savedPosition,
+    };
+    pendingRestoreDeadline = getNow() + RESTORE_RETRY_WINDOW_MS;
+
+    // Some frameworks mount the new page before layout is final or apply
+    // their own scroll reset a little later. Keep asserting the target scroll
+    // for a short window so both out-first and in-first adapters converge.
+    const keepRestoring = () => {
+      const restoreState = pendingRestoreState;
+      if (!restoreState) return;
+
+      if (
+        scrollContainer !== restoreState.container ||
+        currentPath !== restoreState.path
+      ) {
+        cancelPendingRestore({ commitCurrentScroll: false });
+        return;
+      }
+
+      applyScrollPosition(restoreState.container, restoreState.position);
+
+      if (getNow() >= pendingRestoreDeadline) {
+        cancelPendingRestore();
+        return;
+      }
+
+      pendingRestoreFrame = requestAnimationFrame(keepRestoring);
+    };
+
+    pendingRestoreFrame = requestAnimationFrame(keepRestoring);
+  };
+
+  // Prepare incoming context with element. Activation is deferred until the
+  // navigation pair is resolved so frameworks with different out/in ordering
+  // still preserve the correct outgoing scroll state.
   const initializeContext = (element: HTMLElement, path: string) => {
-    contextElement = element;
+    pendingContextElement = element;
 
     if (!scrollContainer) {
       scrollContainer = getScrollingElement(element);
@@ -110,9 +222,37 @@ export function createContextManager(options: ContextManagerOptions = {}) {
         passive: true,
       });
     }
+    if (currentPath && currentPath !== path) {
+      captureScrollPosition(currentPath);
+      lockedOutgoingPath = currentPath;
+    }
+  };
 
+  const activateContext = (
+    path: string,
+    options: { restoreScroll?: boolean } = {},
+  ) => {
+    if (
+      currentPath &&
+      currentPath !== path &&
+      currentPath !== lockedOutgoingPath
+    ) {
+      captureScrollPosition(currentPath);
+    }
+
+    cancelPendingRestore();
+
+    if (pendingContextElement) {
+      contextElement = pendingContextElement;
+      pendingContextElement = null;
+    }
+
+    lockedOutgoingPath = null;
     currentPath = path;
-    restoreScrollPosition(path);
+
+    if (options.restoreScroll) {
+      restoreScrollPosition(path);
+    }
   };
 
   // Calculate scroll offset - computes difference between pages' scroll positions
@@ -162,6 +302,7 @@ export function createContextManager(options: ContextManagerOptions = {}) {
 
   return {
     initializeContext,
+    activateContext,
     calculateScrollOffset,
     evictScrollPosition,
     shouldPreserve,

--- a/packages/core/src/lib/ssgoi-transition/create-context-manager.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-context-manager.ts
@@ -63,68 +63,28 @@ export function createContextManager(options: ContextManagerOptions = {}) {
   let contextElement: HTMLElement | null = null;
   const scrollPositions: Map<string, { x: number; y: number }> = new Map();
   let currentPath: string | null = null;
-  let isTransitioning = false; // Prevent saving scroll during transition
 
-  // Scroll listener - captures current scroll position
   const scrollListener = () => {
-    // Don't save scroll position during page transition
-    if (scrollContainer && currentPath && !isTransitioning) {
-      scrollPositions.set(currentPath, {
-        x: scrollContainer.scrollLeft,
-        y: scrollContainer.scrollTop,
-      });
-    }
+    if (!scrollContainer || !currentPath) return;
+    scrollPositions.set(currentPath, {
+      x: scrollContainer.scrollLeft,
+      y: scrollContainer.scrollTop,
+    });
   };
 
-  // Restore scroll position for the given path. Always runs scrollTo —
-  // whether the saved value persists across navigations is decided by
-  // eviction, not by gating restore.
   const restoreScrollPosition = (path: string) => {
     if (!scrollContainer) return;
-
-    const savedPosition = scrollPositions.get(path);
-    if (!savedPosition) {
-      // No saved value (first visit, or evicted as non-preserved) — start at 0.
-      scrollContainer.scrollTo({ top: 0, left: 0 });
-      return;
-    }
-
-    const maxRetries = 10;
-    let retryCount = 0;
-
-    const tryRestore = () => {
-      if (!scrollContainer) return;
-
-      scrollContainer.scrollTo({
-        top: savedPosition.y,
-        left: savedPosition.x,
-      });
-
-      // Retry if scroll position wasn't applied (DOM might not be ready)
-      const currentY = scrollContainer.scrollTop;
-      const currentX = scrollContainer.scrollLeft;
-      const targetReached =
-        Math.abs(currentY - savedPosition.y) < 1 &&
-        Math.abs(currentX - savedPosition.x) < 1;
-
-      if (!targetReached && retryCount < maxRetries) {
-        retryCount++;
-        requestAnimationFrame(tryRestore);
-      }
-    };
-
-    requestAnimationFrame(tryRestore);
+    const savedPosition = scrollPositions.get(path) ?? { x: 0, y: 0 };
+    scrollContainer.scrollTo({
+      top: savedPosition.y,
+      left: savedPosition.x,
+    });
   };
 
   // Initialize context with element - sets up scroll tracking and stores element for later use
   const initializeContext = (element: HTMLElement, path: string) => {
-    // Prevent scroll listener from saving during transition
-    isTransitioning = true;
-
-    // Store the element for positioned parent calculation
     contextElement = element;
 
-    // Initialize scroll container once - finds the scrollable element
     if (!scrollContainer) {
       scrollContainer = getScrollingElement(element);
 
@@ -151,26 +111,8 @@ export function createContextManager(options: ContextManagerOptions = {}) {
       });
     }
 
-    // Update current path for scroll position tracking
     currentPath = path;
-
-    // Restore scroll position if preserveScroll is enabled
     restoreScrollPosition(path);
-
-    // Re-enable scroll listener after transition settles
-    const maxTransitionRetries = 10;
-    let transitionRetryCount = 0;
-
-    const tryEnableListener = () => {
-      transitionRetryCount++;
-      if (transitionRetryCount >= maxTransitionRetries) {
-        isTransitioning = false;
-      } else {
-        requestAnimationFrame(tryEnableListener);
-      }
-    };
-
-    requestAnimationFrame(tryEnableListener);
   };
 
   // Calculate scroll offset - computes difference between pages' scroll positions

--- a/packages/core/src/lib/ssgoi-transition/create-ssgoi-transition-context.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-ssgoi-transition-context.ts
@@ -76,6 +76,7 @@ export function createSggoiTransitionContext(
   // Initialize context manager with preserveScroll option
   const {
     initializeContext,
+    activateContext,
     calculateScrollOffset,
     evictScrollPosition,
     shouldPreserve,
@@ -104,6 +105,12 @@ export function createSggoiTransitionContext(
     // Trigger and wait for navigation pair
     detector.trigger(path, type);
     const pair = await detector.get(type);
+
+    if (type === "in") {
+      activateContext(path, {
+        restoreScroll: Boolean(pair),
+      });
+    }
 
     if (!pair) return () => ({});
 

--- a/packages/core/src/lib/ssgoi-transition/create-ssgoi-transition-context.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-ssgoi-transition-context.ts
@@ -1,9 +1,4 @@
-import type {
-  SsgoiConfig,
-  SsgoiContext,
-  SsgoiInternalOptions,
-  Platform,
-} from "../types";
+import type { SsgoiConfig, SsgoiContext, SsgoiInternalOptions } from "../types";
 import {
   TRANSITION_STRATEGY,
   createPageTransitionStrategy,
@@ -60,26 +55,12 @@ export function createSggoiTransitionContext(
     transitions = [],
     defaultTransition,
     middleware = (from, to) => ({ from, to }), // Identity function as default
-    skipOnIosSwipe,
-    skipAnimationOnBack,
-    preserveScroll,
+    skipAnimationOnBack = ["ios"],
+    preserveScroll = (isMobile: boolean) => isMobile,
   } = options;
 
-  // Handle deprecated skipOnIosSwipe option
-  if (skipOnIosSwipe !== undefined) {
-    console.warn(
-      "[SSGOI] skipOnIosSwipe is deprecated. Use skipAnimationOnBack: ['ios'] instead.",
-    );
-  }
-
-  // Resolve skipAnimationOnBack platforms (with backward compatibility)
-  // - undefined: default to ['ios']
-  // - skipOnIosSwipe: false → [], true/undefined → ['ios']
-  const resolvedPlatforms: Platform[] =
-    skipAnimationOnBack ?? (skipOnIosSwipe === false ? [] : ["ios"]);
-
   // Determine if we should skip on back navigation based on current platform
-  const shouldSkipOnBack = matchPlatform(resolvedPlatforms);
+  const shouldSkipOnBack = matchPlatform(skipAnimationOnBack);
 
   // Internal options (set by framework adapters)
   const { outFirst = true } = internalOptions || {};

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -25,5 +25,5 @@
     "declarationMap": true,
     "outDir": "./dist"
   },
-  "include": ["src", "src/lib", "vitest.config.ts"]
+  "include": ["src", "src/lib", "vite.config.ts", "vitest.config.ts"]
 }

--- a/templates/nextjs/tsconfig.json
+++ b/templates/nextjs/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
## Summary

This PR rolls up the current `new-transition-config` branch as-is.

- Fix Sandpack scroll container detection by moving the critical `height` / `overflowY` styles to inline styles in the generated wrapper, so the correct scroll container is detected before Tailwind CDN styles finish loading.
- Remove duplicate scroll-container classes from the Sandpack demo layouts, since the outer wrapper already owns scrolling.
- Add a root-level `pnpm sandpack-sync` script that proxies to the docs Sandpack generation task.
- Clean up the core transition config path by removing the deprecated `skipOnIosSwipe` branch and relying on `skipAnimationOnBack`.
- Stabilize `preserveScroll` restoration across different adapter lifecycles by separating incoming context initialization from activation, delaying restoration until the navigation pair is resolved, freezing the outgoing scroll snapshot during handoff, and retrying restoration until the target offset becomes reachable.
- Add regression coverage for the new scroll restoration flow.
- Update the Next.js template `tsconfig` JSX mode to `react-jsx`.

## Core logic

The previous scroll restoration flow assumed that the incoming page was ready as soon as its `in` hook ran. That was not reliable across adapters, because some frameworks behave as `out -> in`, while others behave more like `in -> out`, and some also apply layout or scroll resets after the incoming page mounts.

The new flow separates **incoming context initialization** from **page activation**:

- `initializeContext()` only prepares the incoming page and captures the outgoing page's scroll state.
- `activateContext()` runs only after the navigation pair is actually resolved.
- Scroll restoration now runs from `activateContext()`, not from the initial incoming mount.
- While the handoff is in progress, the outgoing page's saved scroll position is temporarily locked so late scroll events cannot overwrite it.
- Restoration is retried for a short window so the saved position is applied once the new page has enough scrollable height to reach that offset.

That makes scroll restoration consistent across both out-first and in-first adapters.

## Test plan

- `pnpm --filter @ssgoi/core lint`
- `pnpm --filter @ssgoi/core exec tsc --noEmit`
- `pnpm --filter @ssgoi/core test:run`
