### PR TITLE
docs: refactor llms.txt — split per-transition pages, lean main entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Using Claude, Cursor, ChatGPT, or other AI assistants? Let them set it up for yo
 
 **Add this to your AI's context:**
 ```
-https://ssgoi.dev/llm.txt
+https://ssgoi.dev/llms.txt
 ```
 
 Contains complete setup guides, all transition types, troubleshooting, and API docs.

--- a/apps/docs/content/en/01.getting-started/02.quick-start.mdx
+++ b/apps/docs/content/en/01.getting-started/02.quick-start.mdx
@@ -5,7 +5,7 @@ nav-title: "Quick Start"
 ---
 
 <Note type="tip">
-**Using an AI assistant?** Reference [ssgoi.dev/llm.txt](https://ssgoi.dev/llm.txt) in your AI's context for comprehensive setup guidance including troubleshooting tips.
+**Using an AI assistant?** Reference [ssgoi.dev/llms.txt](https://ssgoi.dev/llms.txt) in your AI's context for comprehensive setup guidance including troubleshooting tips.
 </Note>
 
 ## Package Installation

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -4,55 +4,46 @@
 
 This document is for AI assistants to help developers set up SSGOI page transitions in Next.js.
 
+**Per-transition reference (options, physics, examples):** see the `Transitions` section below — each entry links to its own page like `https://ssgoi.dev/llms/<name>.txt`.
+
 ---
 
 ## Installation
 
 ```bash
-npm install @ssgoi/react @ssgoi/core
+npm install @ssgoi/react (or @ssgoi/svelt, @ssgoi/vue dependings on your framework)
 ```
-
-Recommend installing both `@ssgoi/react` and `@ssgoi/core` with latest versions.
 
 ---
 
 ## Layout Setup
 
-### Layout Structure
+SSGOI works on any web app. There are only three things to get right:
 
-```
-<Ssgoi config={config}>
-  <div className="relative z-0">  <-- CSS properties here
-    {children}                     <-- SsgoiTransition is inside each page
-  </div>
-</Ssgoi>
-```
+1. **Decide your scroll element** — the element whose scroll position SSGOI should preserve across transitions. Often a `<main>` or a centered content container.
+2. **Apply `relative z-0` (and optionally `overflow-x-clip`) to the element that wraps `<Ssgoi>`.**
+3. **Wrap each page in `<SsgoiTransition id="...">`** (see the next section).
 
-### CSS Properties
+Why those classes:
 
-**`z-index: 0` (Required)**
-- Place on the div that directly wraps `{children}` in layout
-- Creates a stacking context
-- Without this, OUT page disappears behind background color
+| Class | Why |
+|-------|-----|
+| `relative` | OUT page is cloned with `position: absolute` — needs a positioned ancestor |
+| `z-0` | Creates a stacking context so the OUT page doesn't fall behind backgrounds |
+| `overflow-x-clip` | Prevents horizontal overflow flashing during slide/drill (only needed if you use horizontal transitions) |
 
-**`position: relative` (Conditional)**
-- Required when: header/bottom-nav are NOT fixed/sticky
-- Not required when: you have fixed header or bottom nav
+The scroll element and the `<Ssgoi>` wrapper are typically **the same element**, so all four classes (`overflow-y-auto relative z-0 overflow-x-clip`) sit together.
 
-**`overflow-x: clip` (Recommended for web apps)**
-- Prevents horizontal overflow during slide/drill transitions
+### Layout example (mobile-style web app)
 
-### Web App Layout Pattern
+The library is most often used to ship app-like, mobile-width experiences, so this example shows that shape — a centered max-width column where the column itself scrolls. Adapt as needed for desktop layouts.
 
 ```tsx
-// app/layout.tsx
-"use client";
-
+// src/app/layout.tsx
 import { Ssgoi } from "@ssgoi/react";
 import { drill } from "@ssgoi/react/view-transitions";
 
 const config = {
-  preserveScroll: { exclude: ['/post/*'] },  // Preserve scroll except detail pages
   transitions: [
     { from: '*', to: '/post/*', transition: drill({ direction: 'enter' }) },
     { from: '/post/*', to: '*', transition: drill({ direction: 'exit' }) },
@@ -63,45 +54,14 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html>
       <body>
-        <div className="h-dvh flex flex-col">
-          {/* Scroll container ABOVE Ssgoi */}
-          <div className="flex-1 overflow-y-scroll">
-            <div className="max-w-[420px] mx-auto relative z-0 overflow-x-clip">
-              <Ssgoi config={config}>
-                {children}
-              </Ssgoi>
-            </div>
-          </div>
-          <BottomNav />
-        </div>
-      </body>
-    </html>
-  );
-}
-```
-
-### Standard Web Layout Pattern
-
-```tsx
-// app/layout.tsx
-import { Ssgoi } from "@ssgoi/react";
-import { fade } from "@ssgoi/react/view-transitions";
-
-const config = {
-  defaultTransition: fade(),
-};
-
-export default function RootLayout({ children }: { children: React.ReactNode }) {
-  return (
-    <html>
-      <body>
-        <Header />  {/* Fixed header provides positioning context */}
-        <Ssgoi config={config}>
-          <main className="z-0 min-h-screen">
-            {children}
+        <div className="mx-auto max-w-md h-dvh flex flex-col">
+          <main className="flex-1 overflow-y-auto relative z-0 overflow-x-clip">
+            <Ssgoi config={config}>
+              {children}
+            </Ssgoi>
           </main>
-        </Ssgoi>
-        <Footer />
+          {/* Optional: <BottomNav /> outside <main>, fixed-positioned */}
+        </div>
       </body>
     </html>
   );
@@ -157,209 +117,78 @@ type SsgoiConfig = {
   skipAnimationOnBack?: ('ios' | 'android' | 'desktop' | 'all')[];
   // default: ['ios']
 
-  // Auto preserve/restore scroll position. Default: (isMobile) => isMobile.
-  // - true: preserve everywhere
-  // - false: never preserve
-  // - { exclude: [...] }: preserve except these paths (e.g. detail pages)
-  // - (isMobile) => value: any of the above, computed per-navigation
-  preserveScroll?:
-    | boolean
-    | { exclude: string[] }
-    | ((isMobile: boolean) => boolean | { exclude: string[] });
+  // Scroll preservation. Defaults are sensible for mobile + desktop —
+  // typically you don't need to set this. See section below.
+  preserveScroll?: ...;
 };
 ```
 
+### preserveScroll
+
+**Defaults work out of the box.** Mobile viewports automatically preserve scroll position across transitions; desktop does not (browsers handle it). You normally don't need to configure this.
+
+**Customizing — exclude specific paths:**
+
+```ts
+const config = {
+  preserveScroll: { exclude: ["/post/*"] },
+};
+```
+
+**How it works:** When navigating *to* a path matching an `exclude` pattern, the destination page starts at scroll position 0 (typical for detail pages where you want to read from the top). All other navigations keep their preserved scroll position.
+
 ---
 
-## View Transitions
+## Transitions
 
-Import from `@ssgoi/react/view-transitions`
+Browse the list, find the UX you want, then open the per-transition page for full options and examples. Each detail page is self-contained — you only need to read the ones you'll use.
 
-Full documentation: https://ssgoi.dev/en/docs/mobile-transitions, https://ssgoi.dev/en/docs/desktop-transitions
+### `drill` — https://ssgoi.dev/llms/drill.txt
+iOS-style hierarchical navigation. New page slides in from the right; old page eases left underneath. Use for **List → Detail** flows where the user feels they're going deeper into content.
 
-### drill
+### `fade` — https://ssgoi.dev/llms/fade.txt
+Calm cross-fade between pages. No motion, just opacity. Use as a **safe default** for unrelated pages, or anywhere you don't want a directional cue.
 
-iOS-style hierarchical navigation. List -> Detail.
+### `scroll` — https://ssgoi.dev/llms/scroll.txt
+Vertical "page scroll" — old page slides off and new page slides in along the same axis. Use for **sequential content** like onboarding steps or paginated long-form pages.
 
-```ts
-drill({
-  direction: 'enter' | 'exit',
-  opacity?: boolean,
-  physics?: PhysicsOptions,
-})
-```
+### `slide` — https://ssgoi.dev/llms/slide.txt
+Horizontal slide — both pages translate sideways at once, like swiping between tabs. Use for **tab navigation** or swipeable sections.
 
-- `enter`: New page slides in from right (100% -> 0), old page moves left (-20%)
-- `exit`: Current page slides out to right, previous page returns
+### `swap` — https://ssgoi.dev/llms/swap.txt
+Subtle scale + fade. OUT fades, then IN scales up (0.95 → 1) and fades in. Use for **bottom tab navigation** between sibling pages where there's no natural direction.
 
-**Default physics:** `{ spring: { stiffness: 170, damping: 22 } }`
+### `sheet` — https://ssgoi.dev/llms/sheet.txt
+Bottom sheet style. New page slides up from below while the previous page scales down behind it. Use for **modal-like** flows (FAB → compose, "new item" screens) that should feel temporary.
 
-### fade
+### `hero` — https://ssgoi.dev/llms/hero.txt
+Shared element transition. The same logical object (a thumbnail, an avatar) is tweened in size and position from one page to the next. Requires matching `data-hero-key` on both pages — see the detail page.
 
-Cross-fade transition. General purpose.
+### `pinterest` — https://ssgoi.dev/llms/pinterest.txt
+Card expansion. The tapped gallery card grows to fill the detail viewport while the rest fades out; reverses on back. Requires `data-pinterest-gallery-key` / `data-pinterest-detail-key` — see the detail page.
 
-```ts
-fade({
-  transitionDelay?: number,
-  physics?: PhysicsOptions,
-})
-```
+### `instagram` — https://ssgoi.dev/llms/instagram.txt
+Like `pinterest` but only the IN page animates — the gallery just unmounts. Use over `pinterest` when you have **many gallery items** and want lighter animation cost. Requires `data-instagram-gallery-key` / `data-instagram-detail-key`.
 
-**Default physics:** `{ spring: { stiffness: 170, damping: 20, doubleSpring: true } }`
+### `depth` — https://ssgoi.dev/llms/depth.txt
+Material Design Z-axis. Both pages scale + fade in place, suggesting depth (forward/backward) rather than horizontal navigation. Use for **drilling within the same surface** (Settings → sub-setting).
 
-### scroll
+### `snap` — https://ssgoi.dev/llms/snap.txt
+Fast, subtle slide + fade — punchy and decisive (~250ms). Use when you want **feedback that "something changed"** without a full directional animation, especially in chains of quick navigations.
 
-Vertical scroll transition. Sequential content.
-
-```ts
-scroll({
-  direction: 'up' | 'down',
-  physics?: PhysicsOptions,
-})
-```
-
-**Default physics:** `{ spring: { stiffness: 5, damping: 4 } }`
-
-### slide
-
-Horizontal slide transition. Tab navigation.
-
-```ts
-slide({
-  direction: 'left' | 'right',
-  physics?: PhysicsOptions,
-})
-```
-
-**Default physics:** `{ spring: { stiffness: 140, damping: 19, doubleSpring: 0.8 } }`
-
-### sheet
-
-Bottom sheet style. FAB -> Compose screen.
-
-```ts
-sheet({
-  direction: 'enter' | 'exit',
-  physics?: PhysicsOptions,
-})
-```
-
-- `enter`: Sheet slides up from bottom, background scales down (1 -> 0.8) + fades
-- `exit`: Sheet slides down, background scales up + fades in
-
-**Default physics:** `{ inertia: { acceleration: 20, resistance: 1.5 } }` (enter)
-
-### swap
-
-Same-level page swap. Bottom tab navigation.
-
-```ts
-swap({
-  physics?: PhysicsOptions,
-  scaleOffset?: number,  // default: 0.05
-})
-```
-
-- OUT: Fade out only
-- IN: Scale up (0.95 -> 1) + fade in, waits for OUT to complete
-
-**Default physics:** `{ spring: { stiffness: 600, damping: 40 } }`
-
-### hero
-
-Shared element transition. Same object, different views.
-
-```ts
-hero({
-  physics?: PhysicsOptions,
-  maxDistance?: number,  // default: 700
-})
-```
-
-**Requires matching `data-hero-key` on both pages:**
+### Basic usage
 
 ```tsx
-// List page
-<img data-hero-key={`item-${id}`} src={thumbnail} />
+import { drill, fade, scroll } from "@ssgoi/react/view-transitions";
 
-// Detail page
-<img data-hero-key={`item-${id}`} src={fullImage} />
-```
-
-**Default physics:** `{ spring: { stiffness: 300, damping: 30 } }`
-
-### pinterest
-
-Card expansion from gallery to full screen.
-
-```ts
-pinterest({
-  physics?: PhysicsOptions,
-})
-```
-
-**Requires data attributes:**
-- Gallery: `data-pinterest-gallery-key={id}`
-- Detail: `data-pinterest-detail-key={id}`
-
-### instagram
-
-Similar to pinterest but only incoming page animates. Performance optimized.
-
-```ts
-instagram({
-  physics?: PhysicsOptions,
-})
-```
-
-**Requires data attributes:**
-- Gallery: `data-instagram-gallery-key={id}`
-- Detail: `data-instagram-detail-key={id}`
-
-### depth
-
-Depth-based layered navigation.
-
-```ts
-depth({
-  direction: 'enter' | 'exit',
-  physics?: PhysicsOptions,
-})
-```
-
-### snap
-
-Snap-scroll carousel effect.
-
-```ts
-snap({
-  direction: 'up' | 'down' | 'left' | 'right',
-  physics?: PhysicsOptions,
-})
-```
-
----
-
-## Physics Options
-
-```ts
-// Spring (ease-out feel)
-physics: {
-  spring: {
-    stiffness: 300,    // Higher = faster
-    damping: 30,       // Higher = less bounce
-    doubleSpring?: boolean | number,  // Ease-in-out effect
-  }
-}
-
-// Inertia (ease-in feel)
-physics: {
-  inertia: {
-    acceleration: 20,
-    resistance: 1.5,
-    resistanceType?: 'linear' | 'quadratic',
-  }
-}
+const config = {
+  transitions: [
+    { from: '*',       to: '/post/*', transition: drill({ direction: 'enter' }) },
+    { from: '/post/*', to: '*',       transition: drill({ direction: 'exit' }) },
+    { from: '/',       to: '/about',  transition: scroll({ direction: 'up' }) },
+  ],
+  defaultTransition: fade(),
+};
 ```
 
 ---
@@ -382,9 +211,9 @@ physics: {
 - **Cause**: `id` prop doesn't match route pattern
 - **Fix**: Ensure `SsgoiTransition id` matches the actual route path
 
-### Scroll position not preserved (web apps)
-- **Fix**: The default `(isMobile) => isMobile` only preserves on mobile-width viewports. Set `preserveScroll: true` if you want preservation on desktop too.
-- Ensure scroll container is ABOVE Ssgoi component
+### hero / pinterest / instagram transition not running
+- **Cause**: Data attribute keys don't match between pages
+- **Fix**: Verify the same key value is on both source and destination elements
 
 ---
 
@@ -431,6 +260,7 @@ export const prepareOutgoing = (element, context) => {
 
 ## Links
 
+- Per-transition reference (one file per transition): https://ssgoi.dev/llms/<name>.txt
 - Docs: https://ssgoi.dev
 - Mobile Transitions: https://ssgoi.dev/en/docs/mobile-transitions
 - Desktop Transitions: https://ssgoi.dev/en/docs/desktop-transitions

--- a/apps/docs/public/llms/depth.txt
+++ b/apps/docs/public/llms/depth.txt
@@ -1,0 +1,35 @@
+# SSGOI - depth transition
+
+Material Design Z-axis transition. Use for in-place transformations where the user feels they're moving forward or backward through layers of the same surface (e.g., Settings → sub-setting, expanded detail in place).
+
+Setup guide: https://ssgoi.dev/llms.txt
+
+## Behavior
+
+- `enter`: New page scales up slightly + fades in; old page scales down + fades out.
+- `exit`: New page scales down + fades in; old page scales up + fades out.
+
+Both pages remain visible mid-animation, suggesting depth (Z-axis) movement rather than horizontal navigation.
+
+## Signature
+
+```ts
+import { depth } from "@ssgoi/react/view-transitions";
+
+depth({
+  direction: 'enter' | 'exit',
+  scaleOffset?: number,     // how much to scale (default: 0.05 = 5%)
+  physics?: PhysicsOptions, // default: { spring: { stiffness: 280, damping: 30 } }
+})
+```
+
+## Pairing pattern
+
+```ts
+const config = {
+  transitions: [
+    { from: '/settings',   to: '/settings/*', transition: depth({ direction: 'enter' }) },
+    { from: '/settings/*', to: '/settings',   transition: depth({ direction: 'exit' }) },
+  ],
+};
+```

--- a/apps/docs/public/llms/drill.txt
+++ b/apps/docs/public/llms/drill.txt
@@ -1,0 +1,39 @@
+# SSGOI - drill transition
+
+iOS-style hierarchical navigation. Use when going from a list to a detail screen, or any parent → child navigation where the user feels they're drilling deeper into content.
+
+Setup guide: https://ssgoi.dev/llms.txt
+
+## Behavior
+
+- `enter`: New page slides in from the right (100% → 0). Old page slides slightly left (-20%) to suggest it's still there underneath.
+- `exit`: Current page slides out to the right, revealing the previous page underneath.
+
+## Signature
+
+```ts
+import { drill } from "@ssgoi/react/view-transitions";
+
+drill({
+  direction: 'enter' | 'exit',
+  opacity?: boolean,        // fade alongside slide
+  physics?: PhysicsOptions, // default: { spring: { stiffness: 170, damping: 22 } }
+})
+```
+
+## Pairing pattern
+
+```ts
+const config = {
+  transitions: [
+    { from: '*',       to: '/post/*', transition: drill({ direction: 'enter' }) },
+    { from: '/post/*', to: '*',       transition: drill({ direction: 'exit' }) },
+  ],
+};
+```
+
+Or with `symmetric: true`:
+
+```ts
+{ from: '*', to: '/post/*', transition: drill({ direction: 'enter' }), symmetric: true }
+```

--- a/apps/docs/public/llms/fade.txt
+++ b/apps/docs/public/llms/fade.txt
@@ -1,0 +1,30 @@
+# SSGOI - fade transition
+
+General-purpose cross-fade between pages. Use as a safe default for navigation between unrelated pages, or anywhere you want a calm, neutral transition.
+
+Setup guide: https://ssgoi.dev/llms.txt
+
+## Behavior
+
+Both pages cross-fade simultaneously — the OUT page fades out while the IN page fades in. No motion, just opacity.
+
+## Signature
+
+```ts
+import { fade } from "@ssgoi/react/view-transitions";
+
+fade({
+  transitionDelay?: number, // ms delay before IN starts (default: 0)
+  physics?: PhysicsOptions, // default: { spring: { stiffness: 170, damping: 20, doubleSpring: true } }
+})
+```
+
+## Usage
+
+```ts
+const config = {
+  defaultTransition: fade(),
+};
+```
+
+Often used as `defaultTransition` so any unspecified route pair falls back to a fade.

--- a/apps/docs/public/llms/hero.txt
+++ b/apps/docs/public/llms/hero.txt
@@ -1,0 +1,53 @@
+# SSGOI - hero transition
+
+Shared element transition. Use when the same logical object (a thumbnail, an avatar, a card image) appears on both pages and you want to visually connect them by tweening size and position.
+
+Setup guide: https://ssgoi.dev/llms.txt
+
+## Behavior
+
+The element with a given `data-hero-key` on the source page is tweened in position and size to match the element with the same key on the destination page. The rest of the pages cross-fade around it.
+
+## Signature
+
+```ts
+import { hero } from "@ssgoi/react/view-transitions";
+
+hero({
+  maxDistance?: number,     // skip if elements too far apart (default: 700px)
+  physics?: PhysicsOptions, // default: { spring: { stiffness: 300, damping: 30 } }
+})
+```
+
+## Required: matching data attributes
+
+Both pages must mark the shared element with the same `data-hero-key`:
+
+```tsx
+// List page
+{items.map(item => (
+  <Link key={item.id} href={`/items/${item.id}`}>
+    <img data-hero-key={`item-${item.id}`} src={item.thumbnail} />
+  </Link>
+))}
+
+// Detail page (/items/[id])
+<img data-hero-key={`item-${id}`} src={fullImage} />
+```
+
+The key value must be a unique, stable string that matches across the two pages. Use the item's id, not its index.
+
+## Pairing pattern
+
+```ts
+const config = {
+  transitions: [
+    { from: '/items', to: '/items/*', transition: hero(), symmetric: true },
+  ],
+};
+```
+
+## Notes
+
+- If the keys don't match, hero falls back gracefully (no animation on that element).
+- For very long galleries where many items animate simultaneously, consider `instagram` instead.

--- a/apps/docs/public/llms/instagram.txt
+++ b/apps/docs/public/llms/instagram.txt
@@ -1,0 +1,57 @@
+# SSGOI - instagram transition
+
+Card expansion to full-screen, optimized for large galleries. Visually similar to `pinterest`, but only the incoming page animates — the outgoing gallery is left untouched. Use when you have many gallery items and per-frame animation cost matters.
+
+Setup guide: https://ssgoi.dev/llms.txt
+
+## Behavior
+
+- IN: The detail expands from the position of the tapped gallery card to fill the viewport.
+- OUT: No animation on the gallery — it just unmounts. (This is the perf trade-off vs. `pinterest`.)
+
+## Signature
+
+```ts
+import { instagram } from "@ssgoi/react/view-transitions";
+
+instagram({
+  physics?: PhysicsOptions,
+})
+```
+
+## Required: matching data attributes
+
+```tsx
+// Gallery page
+{items.map(item => (
+  <Link key={item.id} href={`/posts/${item.id}`}>
+    <div data-instagram-gallery-key={item.id}>
+      <img src={item.thumbnail} />
+    </div>
+  </Link>
+))}
+
+// Detail page (/posts/[id])
+<div data-instagram-detail-key={id}>
+  <img src={fullImage} />
+</div>
+```
+
+The key on `data-instagram-gallery-key` (source) and `data-instagram-detail-key` (destination) must match.
+
+## Pairing pattern
+
+```ts
+const config = {
+  transitions: [
+    { from: '/posts', to: '/posts/*', transition: instagram(), symmetric: true },
+  ],
+};
+```
+
+## When to use over pinterest
+
+- Gallery has many items (dozens+) and you want a lighter animation.
+- You don't mind the gallery snapping rather than animating on back-navigation.
+
+If you need a smooth bidirectional expand/collapse, use `pinterest`.

--- a/apps/docs/public/llms/pinterest.txt
+++ b/apps/docs/public/llms/pinterest.txt
@@ -1,0 +1,55 @@
+# SSGOI - pinterest transition
+
+Card expansion from gallery to full-screen. Use when a gallery card should appear to expand and fill the detail viewport (Pinterest, photo galleries, image-heavy product grids).
+
+Setup guide: https://ssgoi.dev/llms.txt
+
+## Behavior
+
+The tapped gallery card grows from its grid position to fill the detail viewport while the rest of the gallery fades away. On exit, the detail collapses back into its original card position.
+
+Visually heavier than `hero` — `pinterest` animates the entire card container, not just one shared element.
+
+## Signature
+
+```ts
+import { pinterest } from "@ssgoi/react/view-transitions";
+
+pinterest({
+  physics?: PhysicsOptions,
+})
+```
+
+## Required: matching data attributes
+
+```tsx
+// Gallery page
+{items.map(item => (
+  <Link key={item.id} href={`/photos/${item.id}`}>
+    <div data-pinterest-gallery-key={item.id}>
+      <img src={item.thumbnail} />
+    </div>
+  </Link>
+))}
+
+// Detail page (/photos/[id])
+<div data-pinterest-detail-key={id}>
+  <img src={fullImage} />
+</div>
+```
+
+The key on `data-pinterest-gallery-key` (source) and `data-pinterest-detail-key` (destination) must match.
+
+## Pairing pattern
+
+```ts
+const config = {
+  transitions: [
+    { from: '/photos', to: '/photos/*', transition: pinterest(), symmetric: true },
+  ],
+};
+```
+
+## When to use over instagram
+
+Use `pinterest` when both the OUT (collapsing back) and IN (expanding) animations matter to the UX. If your gallery has many items and you want lighter animation cost, prefer `instagram`.

--- a/apps/docs/public/llms/scroll.txt
+++ b/apps/docs/public/llms/scroll.txt
@@ -1,0 +1,34 @@
+# SSGOI - scroll transition
+
+Vertical scroll-feel transition. Use when navigating between sequential, related pages where it feels natural to "scroll" from one to the next (e.g., onboarding steps, paginated long-form content).
+
+Setup guide: https://ssgoi.dev/llms.txt
+
+## Behavior
+
+- `direction: 'up'`: New page slides up from below, old page slides up and out of view.
+- `direction: 'down'`: New page slides down from above, old page slides down and out of view.
+
+Looks like a vertical page scroll.
+
+## Signature
+
+```ts
+import { scroll } from "@ssgoi/react/view-transitions";
+
+scroll({
+  direction: 'up' | 'down',
+  physics?: PhysicsOptions, // default: { spring: { stiffness: 5, damping: 4 } }
+})
+```
+
+## Pairing pattern
+
+```ts
+const config = {
+  transitions: [
+    { from: '/', to: '/about', transition: scroll({ direction: 'up' }) },
+    { from: '/about', to: '/', transition: scroll({ direction: 'down' }) },
+  ],
+};
+```

--- a/apps/docs/public/llms/sheet.txt
+++ b/apps/docs/public/llms/sheet.txt
@@ -1,0 +1,32 @@
+# SSGOI - sheet transition
+
+Bottom sheet style. Use for modal-like overlays that come up from the bottom — FAB → compose, "new item" flows, secondary screens that should feel temporary.
+
+Setup guide: https://ssgoi.dev/llms.txt
+
+## Behavior
+
+- `enter`: Sheet slides up from the bottom. Background page scales down (1 → 0.8) and fades, suggesting it's pushed back.
+- `exit`: Sheet slides down. Background page scales back up (0.8 → 1) and fades in.
+
+## Signature
+
+```ts
+import { sheet } from "@ssgoi/react/view-transitions";
+
+sheet({
+  direction: 'enter' | 'exit',
+  physics?: PhysicsOptions, // enter default: { inertia: { acceleration: 20, resistance: 1.5 } }
+})
+```
+
+## Pairing pattern
+
+```ts
+const config = {
+  transitions: [
+    { from: '*',           to: '/compose', transition: sheet({ direction: 'enter' }) },
+    { from: '/compose',    to: '*',        transition: sheet({ direction: 'exit' }) },
+  ],
+};
+```

--- a/apps/docs/public/llms/slide.txt
+++ b/apps/docs/public/llms/slide.txt
@@ -1,0 +1,38 @@
+# SSGOI - slide transition
+
+Horizontal slide transition. Use for tab navigation, swipeable section navigation, or any same-level horizontal page change.
+
+Setup guide: https://ssgoi.dev/llms.txt
+
+## Behavior
+
+- `direction: 'left'`: Pages move horizontally to the left — IN comes from right, OUT exits to the left.
+- `direction: 'right'`: Pages move horizontally to the right — IN comes from left, OUT exits to the right.
+
+Both pages translate at once, like swiping between tabs.
+
+## Signature
+
+```ts
+import { slide } from "@ssgoi/react/view-transitions";
+
+slide({
+  direction: 'left' | 'right',
+  physics?: PhysicsOptions, // default: { spring: { stiffness: 140, damping: 19, doubleSpring: 0.8 } }
+})
+```
+
+## Pairing pattern
+
+```ts
+const config = {
+  transitions: [
+    { from: '/tab1', to: '/tab2', transition: slide({ direction: 'left' }) },
+    { from: '/tab2', to: '/tab1', transition: slide({ direction: 'right' }) },
+  ],
+};
+```
+
+## Setup tip
+
+Slide can cause horizontal overflow during the animation. Add `overflow-x-clip` (or equivalent) to the layout container — see the layout guide in https://ssgoi.dev/llms.txt.

--- a/apps/docs/public/llms/snap.txt
+++ b/apps/docs/public/llms/snap.txt
@@ -1,0 +1,40 @@
+# SSGOI - snap transition
+
+Fast, subtle slide + fade. Use when you want a punchy, almost imperceptible page change — quick same-level navigation where any heavier transition would feel like overkill.
+
+Setup guide: https://ssgoi.dev/llms.txt
+
+## Behavior
+
+- OUT: Fades out + slides slightly in the same direction (e.g., 8px left). Waits to complete before IN starts.
+- IN: Fades in + slides from the opposite direction.
+
+Settles fast (~250ms). Decisive, not bouncy.
+
+## Signature
+
+```ts
+import { snap } from "@ssgoi/react/view-transitions";
+
+snap({
+  direction?: 'left' | 'right',  // default: 'left'
+  translateOffset?: number,       // px of slide (default: 8)
+  physics?: PhysicsOptions,       // default: { spring: { stiffness: 400, damping: 30 } }
+})
+```
+
+## Pairing pattern
+
+```ts
+const config = {
+  transitions: [
+    { from: '/feed', to: '/explore', transition: snap({ direction: 'left' }), symmetric: true },
+  ],
+};
+```
+
+## When to use
+
+- You want feedback that "something changed" without a full directional animation.
+- You're chaining many quick navigations and a longer transition would feel slow.
+- Use `swap` instead if you want pure scale + fade with no directional slide.

--- a/apps/docs/public/llms/swap.txt
+++ b/apps/docs/public/llms/swap.txt
@@ -1,0 +1,36 @@
+# SSGOI - swap transition
+
+Same-level page swap with subtle scale + fade. Use for bottom tab navigation where pages are siblings and there's no directional relationship between them.
+
+Setup guide: https://ssgoi.dev/llms.txt
+
+## Behavior
+
+- OUT: Old page fades out (no movement).
+- IN: New page scales up (0.95 → 1) + fades in. The IN waits for OUT to complete first, so the two phases don't overlap visually.
+
+The result is a quick, snappy swap — calmer than a slide, more decisive than a plain fade.
+
+## Signature
+
+```ts
+import { swap } from "@ssgoi/react/view-transitions";
+
+swap({
+  scaleOffset?: number,     // how much to scale up from (default: 0.05 → starts at 0.95)
+  physics?: PhysicsOptions, // default: { spring: { stiffness: 600, damping: 40 } }
+})
+```
+
+## Usage
+
+Often combined with `symmetric: true` since the animation has no direction:
+
+```ts
+const config = {
+  transitions: [
+    { from: '/home', to: '/search', transition: swap(), symmetric: true },
+    { from: '/home', to: '/profile', transition: swap(), symmetric: true },
+  ],
+};
+```


### PR DESCRIPTION
## Summary

- Refactor `apps/docs/public/llms.txt` into a lean entry point: layout + `SsgoiConfig` + transition TOC.
- Move per-transition details to `apps/docs/public/llms/<name>.txt` (drill, fade, scroll, slide, sheet, swap, hero, pinterest, instagram, depth, snap). Each is self-contained — readers only fetch what they need.
- Layout section now frames SSGOI's actual three requirements (define scroll element, `relative z-0` on `<Ssgoi>` wrapper, per-page `<SsgoiTransition>`) with one mobile-style example. Drops the previous standard-web variant; mobile shape is the canonical layout this library is used for.
- `preserveScroll` documentation reduced to "defaults work, customize via `{ exclude: [...] }`" with one example — no longer exposes the full type signature.
- Fix `llm.txt` → `llms.txt` typo in `README.md` and `apps/docs/content/en/01.getting-started/02.quick-start.mdx`.

No code/runtime changes — docs only.

## Test plan
- [ ] Verify `https://ssgoi.dev/llms.txt` and `https://ssgoi.dev/llms/<name>.txt` resolve after deploy
- [ ] Skim the per-transition files for accuracy against `packages/core/src/lib/view-transitions/*`
- [ ] Confirm README and quick-start link to `llms.txt` (not `llm.txt`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)