### PR TITLE
fix(core): sheet scroll-offset miscompensation when both pages have non-zero scroll

### DIFF
--- a/apps/docs/src/components/mdx/mdx-components/view-transition-demo/sheet-demo/content.ts
+++ b/apps/docs/src/components/mdx/mdx-components/view-transition-demo/sheet-demo/content.ts
@@ -55,4 +55,93 @@ export const sentEmails = [
     date: "Dec 17",
     time: "11:30 AM",
   },
+  {
+    id: "7",
+    to: "Tom Wilson",
+    email: "tom@example.com",
+    subject: "Q4 budget review",
+    preview: "Attached the revised numbers for next quarter — the marketing...",
+    date: "Dec 16",
+    time: "4:12 PM",
+  },
+  {
+    id: "8",
+    to: "Rachel Green",
+    email: "rachel@example.com",
+    subject: "Onboarding checklist",
+    preview:
+      "Here's everything you need for your first week. Let me know if...",
+    date: "Dec 15",
+    time: "9:48 AM",
+  },
+  {
+    id: "9",
+    to: "David Lee",
+    email: "david@example.com",
+    subject: "Re: Contract amendment",
+    preview:
+      "I've reviewed the changes and have a few comments on section 4...",
+    date: "Dec 14",
+    time: "2:33 PM",
+  },
+  {
+    id: "10",
+    to: "Nina Patel",
+    email: "nina@example.com",
+    subject: "Customer feedback summary",
+    preview:
+      "This week's NPS came in at 62 — the trend is up across mobile and...",
+    date: "Dec 13",
+    time: "6:07 PM",
+  },
+  {
+    id: "11",
+    to: "Chris Bennett",
+    email: "chris@example.com",
+    subject: "Sprint retrospective notes",
+    preview:
+      "Great session today. Key takeaways: shorter standups, more pairing...",
+    date: "Dec 12",
+    time: "11:55 AM",
+  },
+  {
+    id: "12",
+    to: "Hannah Wright",
+    email: "hannah@example.com",
+    subject: "Speaker confirmation — Spring Summit",
+    preview:
+      "Excited to confirm your keynote slot. I'll send the technical brief...",
+    date: "Dec 11",
+    time: "8:21 AM",
+  },
+  {
+    id: "13",
+    to: "Marco Rossi",
+    email: "marco@example.com",
+    subject: "Partnership proposal",
+    preview:
+      "Following up on our call last week — drafted a one-pager covering...",
+    date: "Dec 10",
+    time: "3:14 PM",
+  },
+  {
+    id: "14",
+    to: "Olivia Stone",
+    email: "olivia@example.com",
+    subject: "Re: Brand guidelines v3",
+    preview:
+      "Logo lockups look sharp. Two small notes on the type scale before...",
+    date: "Dec 9",
+    time: "10:02 AM",
+  },
+  {
+    id: "15",
+    to: "Ben Carter",
+    email: "ben@example.com",
+    subject: "Hiring update",
+    preview:
+      "Two strong candidates from the recent loop — happy to walk you...",
+    date: "Dec 8",
+    time: "5:39 PM",
+  },
 ];

--- a/apps/docs/src/components/mdx/mdx-components/view-transition-demo/sheet-demo/pages.tsx
+++ b/apps/docs/src/components/mdx/mdx-components/view-transition-demo/sheet-demo/pages.tsx
@@ -109,11 +109,19 @@ export function ComposeEmailPage() {
     navigate("/sent");
   };
 
+  const suggestedRecipients = [
+    { name: "Sarah Johnson", email: "sarah@example.com", initial: "S" },
+    { name: "Mike Chen", email: "mike@example.com", initial: "M" },
+    { name: "Emily Davis", email: "emily@example.com", initial: "E" },
+    { name: "Alex Kim", email: "alex@example.com", initial: "A" },
+    { name: "Lisa Park", email: "lisa@example.com", initial: "L" },
+  ];
+
   return (
     <>
       <DemoPage path="/compose">
-        <div className="min-h-screen bg-[#121212] flex flex-col">
-          {/* Header */}
+        <div className="bg-[#121212]">
+          {/* Header — sticky app bar */}
           <div className="sticky top-0 z-10 bg-[#121212]/95 backdrop-blur-md border-b border-white/10">
             <div className="px-4 py-3 flex items-center justify-between">
               <button
@@ -135,90 +143,159 @@ export function ComposeEmailPage() {
             </div>
           </div>
 
-          {/* Compose Form */}
-          <div className="flex-1 flex flex-col">
-            {/* To Field */}
-            <div className="px-4 py-3 border-b border-white/5 flex items-center gap-3">
-              <span className="text-sm text-neutral-500 w-14">To:</span>
-              <input
-                type="email"
-                value={to}
-                onChange={(e) => setTo(e.target.value)}
-                placeholder="recipient@email.com"
-                className="flex-1 bg-transparent text-sm text-white placeholder-neutral-600 outline-none"
-              />
-            </div>
+          {/* To Field */}
+          <div className="px-4 py-3 border-b border-white/5 flex items-center gap-3">
+            <span className="text-sm text-neutral-500 w-14">To:</span>
+            <input
+              type="email"
+              value={to}
+              onChange={(e) => setTo(e.target.value)}
+              placeholder="recipient@email.com"
+              className="flex-1 bg-transparent text-sm text-white placeholder-neutral-600 outline-none"
+            />
+          </div>
 
-            {/* Subject Field */}
-            <div className="px-4 py-3 border-b border-white/5 flex items-center gap-3">
-              <span className="text-sm text-neutral-500 w-14">Subject:</span>
-              <input
-                type="text"
-                value={subject}
-                onChange={(e) => setSubject(e.target.value)}
-                placeholder="Email subject"
-                className="flex-1 bg-transparent text-sm text-white placeholder-neutral-600 outline-none"
-              />
-            </div>
+          {/* Subject Field */}
+          <div className="px-4 py-3 border-b border-white/5 flex items-center gap-3">
+            <span className="text-sm text-neutral-500 w-14">Subject:</span>
+            <input
+              type="text"
+              value={subject}
+              onChange={(e) => setSubject(e.target.value)}
+              placeholder="Email subject"
+              className="flex-1 bg-transparent text-sm text-white placeholder-neutral-600 outline-none"
+            />
+          </div>
 
-            {/* Body */}
-            <div className="flex-1 p-4">
-              <textarea
-                value={body}
-                onChange={(e) => setBody(e.target.value)}
-                placeholder="Write your message..."
-                className="w-full h-full min-h-[200px] bg-transparent text-sm text-white placeholder-neutral-600 outline-none resize-none leading-relaxed"
-              />
-            </div>
+          {/* Body */}
+          <div className="p-4">
+            <textarea
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              placeholder="Write your message..."
+              className="w-full min-h-[520px] bg-transparent text-sm text-white placeholder-neutral-600 outline-none resize-none leading-relaxed"
+            />
+          </div>
 
-            {/* Toolbar */}
-            <div className="border-t border-white/10 px-4 py-3 flex items-center gap-4 bg-[#0a0a0a]">
-              <button className="p-2 text-neutral-400 hover:text-white hover:bg-white/5 rounded-lg transition-colors">
-                <svg
-                  className="w-5 h-5"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
+          {/* Suggested recipients */}
+          <div className="border-t border-white/10 px-5 py-4">
+            <h3 className="text-xs uppercase tracking-wider text-neutral-500 mb-3">
+              Suggested
+            </h3>
+            <div className="space-y-2">
+              {suggestedRecipients.map((r) => (
+                <button
+                  key={r.email}
+                  onClick={() => setTo(r.email)}
+                  className="w-full flex items-center gap-3 py-2 hover:bg-white/5 rounded-md transition-colors"
                 >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={1.5}
-                    d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13"
-                  />
-                </svg>
-              </button>
-              <button className="p-2 text-neutral-400 hover:text-white hover:bg-white/5 rounded-lg transition-colors">
-                <svg
-                  className="w-5 h-5"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={1.5}
-                    d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
-                  />
-                </svg>
-              </button>
-              <button className="p-2 text-neutral-400 hover:text-white hover:bg-white/5 rounded-lg transition-colors">
-                <svg
-                  className="w-5 h-5"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={1.5}
-                    d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
-                  />
-                </svg>
-              </button>
+                  <div className="w-8 h-8 rounded-full bg-gradient-to-br from-violet-500 to-fuchsia-500 flex items-center justify-center text-white font-semibold text-xs flex-shrink-0">
+                    {r.initial}
+                  </div>
+                  <div className="flex-1 min-w-0 text-left">
+                    <div className="text-sm text-white truncate">{r.name}</div>
+                    <div className="text-xs text-neutral-500 truncate">
+                      {r.email}
+                    </div>
+                  </div>
+                </button>
+              ))}
             </div>
+          </div>
+
+          {/* Recent drafts */}
+          <div className="border-t border-white/10 px-5 py-4">
+            <h3 className="text-xs uppercase tracking-wider text-neutral-500 mb-3">
+              Recent drafts
+            </h3>
+            <div className="space-y-3">
+              {[
+                {
+                  subject: "Re: Quarterly review",
+                  preview:
+                    "Thanks for the detailed breakdown — I'll review and...",
+                  date: "Yesterday",
+                },
+                {
+                  subject: "Out of office — Dec 24-27",
+                  preview:
+                    "I'll be out of the office and slow to respond. For urgent...",
+                  date: "Dec 18",
+                },
+                {
+                  subject: "Project Mercury kickoff notes",
+                  preview:
+                    "Here are the action items from today's kickoff. Owners are...",
+                  date: "Dec 15",
+                },
+              ].map((d) => (
+                <div
+                  key={d.subject}
+                  className="px-3 py-3 bg-white/[0.03] hover:bg-white/[0.06] rounded-lg cursor-pointer transition-colors"
+                >
+                  <div className="flex items-center justify-between mb-1">
+                    <h4 className="text-sm font-medium text-white truncate">
+                      {d.subject}
+                    </h4>
+                    <span className="text-xs text-neutral-500 ml-2 flex-shrink-0">
+                      {d.date}
+                    </span>
+                  </div>
+                  <p className="text-xs text-neutral-500 truncate">
+                    {d.preview}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Toolbar */}
+          <div className="border-t border-white/10 px-4 py-3 flex items-center gap-4 bg-[#0a0a0a]">
+            <button className="p-2 text-neutral-400 hover:text-white hover:bg-white/5 rounded-lg transition-colors">
+              <svg
+                className="w-5 h-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={1.5}
+                  d="M15.172 7l-6.586 6.586a2 2 0 102.828 2.828l6.414-6.586a4 4 0 00-5.656-5.656l-6.415 6.585a6 6 0 108.486 8.486L20.5 13"
+                />
+              </svg>
+            </button>
+            <button className="p-2 text-neutral-400 hover:text-white hover:bg-white/5 rounded-lg transition-colors">
+              <svg
+                className="w-5 h-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={1.5}
+                  d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+                />
+              </svg>
+            </button>
+            <button className="p-2 text-neutral-400 hover:text-white hover:bg-white/5 rounded-lg transition-colors">
+              <svg
+                className="w-5 h-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={1.5}
+                  d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
+                />
+              </svg>
+            </button>
           </div>
         </div>
       </DemoPage>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/core",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Core animation engine for SSGOI - Native app-like page transitions with spring physics",
   "private": false,
   "type": "module",

--- a/packages/core/src/lib/view-transitions/sheet.ts
+++ b/packages/core/src/lib/view-transitions/sheet.ts
@@ -47,11 +47,17 @@ function getSheetRect(context: SggoiTransitionContext) {
   const viewportHeight =
     context.scrollingElement.offsetHeight - containerRect.top;
 
-  return {
+  const rect = {
     top,
     left: 0,
     width: containerRect.width,
     height: viewportHeight,
+  };
+
+  return {
+    ...rect,
+    centerX: rect.left + rect.width / 2,
+    centerY: rect.top + rect.height / 2,
   };
 }
 
@@ -78,8 +84,6 @@ export const sheet = (options: SheetOptions = {}): SggoiTransition => {
       // Entering sheet: slides up from bottom
       in: (element, context) => {
         const rect = getSheetRect(context);
-        const viewportHeight = rect.height;
-        const visibleTop = context.scroll.y;
 
         return {
           physics: physicsOptions,
@@ -91,10 +95,10 @@ export const sheet = (options: SheetOptions = {}): SggoiTransition => {
             ).contain = "layout paint";
             // Clip the sheet to its viewport-aligned slice so translate3d only
             // shows the slice the user was looking at, not the rest of the page.
-            element.style.clipPath = `inset(${visibleTop}px 0 calc(100% - ${visibleTop + viewportHeight}px) 0)`;
+            element.style.clipPath = `inset(${rect.top}px 0 calc(100% - ${rect.top + rect.height}px) 0)`;
           },
           css: (progress): StyleObject => ({
-            transform: `translate3d(0, ${(1 - progress) * viewportHeight}px, 0)`,
+            transform: `translate3d(0, ${(1 - progress) * rect.height}px, 0)`,
           }),
           onEnd: () => {
             element.style.willChange = "auto";
@@ -110,11 +114,6 @@ export const sheet = (options: SheetOptions = {}): SggoiTransition => {
       out: (element, context) => {
         const rect = getSheetRect(context);
         const centerX = rect.left + rect.width / 2;
-        // After prepareOutgoing applies top:-scrollOffset.y, the element's
-        // visible slice in element-local coords is S_from..S_from+viewportH;
-        // its center is rect.top+rect.height/2 (rect.top = context.scroll.y =
-        // S_from). Adding scrollOffset.y here would double-count the same
-        // compensation prepareOutgoing already does.
         const centerY = rect.top + rect.height / 2;
 
         return {
@@ -142,10 +141,9 @@ export const sheet = (options: SheetOptions = {}): SggoiTransition => {
     return {
       // Entering background: scales up with fade
       in: (element, context) => {
-        const centerX = (() => {
-          const rect = getSheetRect(context);
-          return rect.left + rect.width / 2;
-        })();
+        const rect = getSheetRect(context);
+        const centerX = rect.left + rect.width / 2;
+        const centerY = rect.top + rect.height / 2;
 
         return {
           physics: physicsOptions,
@@ -155,11 +153,7 @@ export const sheet = (options: SheetOptions = {}): SggoiTransition => {
             (
               element.style as CSSStyleDeclaration & { contain: string }
             ).contain = "layout paint";
-            // Read live geometry so the origin stays at viewport center even if
-            // scroll restoration to S_to hasn't landed yet at prepare time.
-            const visualRect = element.getBoundingClientRect();
-            const localCenterY = window.innerHeight / 2 - visualRect.top;
-            element.style.transformOrigin = `${centerX}px ${localCenterY}px`;
+            element.style.transformOrigin = `${centerX}px ${centerY}px`;
           },
           css: (progress): StyleObject => ({
             transform: `scale(${1 - scaleOffset + progress * scaleOffset})`,

--- a/packages/core/src/lib/view-transitions/sheet.ts
+++ b/packages/core/src/lib/view-transitions/sheet.ts
@@ -43,8 +43,9 @@ function getSheetRect(context: SggoiTransitionContext) {
   const containerRect = getRect(document.body, context.positionedParent);
   const top = context.scroll.y;
 
-  // Calculate viewport height considering container offset (like jaemin.ts)
-  const viewportHeight = window.innerHeight - containerRect.top;
+  // Calculate viewport height considering container offset
+  const viewportHeight =
+    context.scrollingElement.offsetHeight - containerRect.top;
 
   return {
     top,
@@ -78,6 +79,7 @@ export const sheet = (options: SheetOptions = {}): SggoiTransition => {
       in: (element, context) => {
         const rect = getSheetRect(context);
         const viewportHeight = rect.height;
+        const visibleTop = context.scroll.y;
 
         return {
           physics: physicsOptions,
@@ -87,6 +89,9 @@ export const sheet = (options: SheetOptions = {}): SggoiTransition => {
             (
               element.style as CSSStyleDeclaration & { contain: string }
             ).contain = "layout paint";
+            // Clip the sheet to its viewport-aligned slice so translate3d only
+            // shows the slice the user was looking at, not the rest of the page.
+            element.style.clipPath = `inset(${visibleTop}px 0 calc(100% - ${visibleTop + viewportHeight}px) 0)`;
           },
           css: (progress): StyleObject => ({
             transform: `translate3d(0, ${(1 - progress) * viewportHeight}px, 0)`,
@@ -97,6 +102,7 @@ export const sheet = (options: SheetOptions = {}): SggoiTransition => {
             (
               element.style as CSSStyleDeclaration & { contain: string }
             ).contain = "";
+            element.style.clipPath = "";
           },
         };
       },
@@ -104,7 +110,12 @@ export const sheet = (options: SheetOptions = {}): SggoiTransition => {
       out: (element, context) => {
         const rect = getSheetRect(context);
         const centerX = rect.left + rect.width / 2;
-        const centerY = rect.top + rect.height / 2 + context.scrollOffset.y;
+        // After prepareOutgoing applies top:-scrollOffset.y, the element's
+        // visible slice in element-local coords is S_from..S_from+viewportH;
+        // its center is rect.top+rect.height/2 (rect.top = context.scroll.y =
+        // S_from). Adding scrollOffset.y here would double-count the same
+        // compensation prepareOutgoing already does.
+        const centerY = rect.top + rect.height / 2;
 
         return {
           physics: physicsOptions,
@@ -131,9 +142,10 @@ export const sheet = (options: SheetOptions = {}): SggoiTransition => {
     return {
       // Entering background: scales up with fade
       in: (element, context) => {
-        const rect = getSheetRect(context);
-        const centerX = rect.left + rect.width / 2;
-        const centerY = rect.top + rect.height / 2;
+        const centerX = (() => {
+          const rect = getSheetRect(context);
+          return rect.left + rect.width / 2;
+        })();
 
         return {
           physics: physicsOptions,
@@ -143,7 +155,11 @@ export const sheet = (options: SheetOptions = {}): SggoiTransition => {
             (
               element.style as CSSStyleDeclaration & { contain: string }
             ).contain = "layout paint";
-            element.style.transformOrigin = `${centerX}px ${centerY}px`;
+            // Read live geometry so the origin stays at viewport center even if
+            // scroll restoration to S_to hasn't landed yet at prepare time.
+            const visualRect = element.getBoundingClientRect();
+            const localCenterY = window.innerHeight / 2 - visualRect.top;
+            element.style.transformOrigin = `${centerX}px ${localCenterY}px`;
           },
           css: (progress): StyleObject => ({
             transform: `scale(${1 - scaleOffset + progress * scaleOffset})`,
@@ -163,6 +179,7 @@ export const sheet = (options: SheetOptions = {}): SggoiTransition => {
       out: (element, context) => {
         const rect = getSheetRect(context);
         const viewportHeight = rect.height;
+        const visibleTop = context.scroll.y;
 
         return {
           physics: physicsOptions,
@@ -175,6 +192,7 @@ export const sheet = (options: SheetOptions = {}): SggoiTransition => {
               element.style as CSSStyleDeclaration & { contain: string }
             ).contain = "layout paint";
             element.style.pointerEvents = "none";
+            element.style.clipPath = `inset(${visibleTop}px 0 calc(100% - ${visibleTop + viewportHeight}px) 0)`;
           },
           css: (progress): StyleObject => ({
             transform: `translate3d(0, ${(1 - progress) * viewportHeight}px, 0)`,


### PR DESCRIPTION
## Summary

Closes #319 — `sheet({ direction: 'exit' })` with `experimentalPreserveScroll: true` failed to land at the correct visual state when both `from` and `to` pages had non-zero saved scroll. Root cause was scroll-offset compensation in the **scaling** side of the sheet (the background page), plus the **sliding** side rendering content outside the user's last-viewed slice. The slide and scale halves needed independent fixes.

### Diagnosis

`scrollOffset = fromY - toY` is a cross-page delta. The sheet transition mixed it into transform math without distinguishing slide vs. scale roles:

- **Enter OUT (background scale-down)** added `+scrollOffset.y` to `transformOrigin.centerY` *and* `prepareOutgoing` already shifted the element by `top:-scrollOffset.y` — same compensation applied twice.
- **Exit IN (background scale-up)** computed centerY assuming the container was at `S_to`, which can be off depending on geometry.
- **Enter IN / Exit OUT (sheet slide)** translated the entire page-tall element. Without clipping, the slide revealed content above/below the user's last-viewed viewport slice instead of sliding only that slice.

### Fix

`packages/core/src/lib/view-transitions/sheet.ts`
- Drop `+ context.scrollOffset.y` from enter-OUT `centerY`.
- Use `getSheetRect`'s `centerY` (post-scroll-restore visible center) for exit-IN origin.
- Add `clip-path: inset(${context.scroll.y}px 0 calc(100% - ${context.scroll.y + viewportH}px) 0)` to the sheet element on enter IN and exit OUT, with `onEnd` cleanup on enter IN (exit OUT element is unmounted).
- `getSheetRect` now returns `centerX`/`centerY` and uses `context.scrollingElement.offsetHeight` so nested scroll containers measure correctly.

Published as `@ssgoi/core@5.0.1`.

## Test plan

- [ ] /sent → scroll down → tap compose → sheet enters; background page scales down with origin at viewport center (not shifted by scroll delta)
- [ ] In compose → scroll down → tap Cancel → sheet exits; background scales up with origin at viewport center; sheet slides showing the slice the user was last viewing (not the top of the page bleeding through)
- [ ] Repeat with various combinations of zero / non-zero scroll on both pages — visual position remains stable
- [ ] Other sheet/translate transitions unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)