### PR TITLE
fix(core): clip sheet background scale to viewport slice

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/core",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "Core animation engine for SSGOI - Native app-like page transitions with spring physics",
   "private": false,
   "type": "module",

--- a/packages/core/src/lib/view-transitions/sheet.ts
+++ b/packages/core/src/lib/view-transitions/sheet.ts
@@ -128,6 +128,9 @@ export const sheet = (options: SheetOptions = {}): SggoiTransition => {
             ).contain = "layout paint";
             element.style.pointerEvents = "none";
             element.style.transformOrigin = `${centerX}px ${centerY}px`;
+            // Clip to the viewport-aligned slice so scaling doesn't pull
+            // off-viewport content (above/below the scroll position) into view.
+            element.style.clipPath = `inset(${rect.top}px 0 calc(100% - ${rect.top + rect.height}px) 0)`;
           },
           css: (progress): StyleObject => ({
             transform: `scale(${1 - scaleOffset + progress * scaleOffset})`,
@@ -154,6 +157,9 @@ export const sheet = (options: SheetOptions = {}): SggoiTransition => {
               element.style as CSSStyleDeclaration & { contain: string }
             ).contain = "layout paint";
             element.style.transformOrigin = `${centerX}px ${centerY}px`;
+            // Clip to the viewport-aligned slice so scaling doesn't pull
+            // off-viewport content (above/below the scroll position) into view.
+            element.style.clipPath = `inset(${rect.top}px 0 calc(100% - ${rect.top + rect.height}px) 0)`;
           },
           css: (progress): StyleObject => ({
             transform: `scale(${1 - scaleOffset + progress * scaleOffset})`,
@@ -166,6 +172,7 @@ export const sheet = (options: SheetOptions = {}): SggoiTransition => {
               element.style as CSSStyleDeclaration & { contain: string }
             ).contain = "";
             element.style.transformOrigin = "";
+            element.style.clipPath = "";
           },
         };
       },


### PR DESCRIPTION
## Summary
- Apply `clip-path: inset()` to the sheet transition's scale-with-fade backgrounds (enter `out` and exit `in`) so scaling no longer pulls off-viewport content into view.
- Bump `@ssgoi/core` to 5.0.2.

## Why
The slide halves of `sheet` (enter `in`, exit `out`) were already clipped to the user's last-viewed viewport slice in #327. The scale halves were not. Because the scale uses `transformOrigin` at the visible center, scaling shrinks/grows the entire page around that point — content above and below the scroll position gets pulled in through the viewport edges and becomes briefly visible, especially on long pages.

This applies the same `inset(${rect.top}px 0 calc(100% - ${rect.top + rect.height}px) 0)` clip the slide halves use, so both halves of the transition only ever expose the slice the user was looking at.

## Test plan
- [ ] Verify sheet enter (forward nav): background scales down and fades without revealing off-viewport content.
- [ ] Verify sheet exit (back nav): background scales up and fades without revealing off-viewport content.
- [ ] Confirm with non-zero scroll on both pages — the scenario fixed in #327 — that the visible slice stays consistent during the scale.
- [ ] Confirm slide halves still clip correctly (regression check on #327).

🤖 Generated with [Claude Code](https://claude.com/claude-code)