### PR TITLE
fix(core): settle swipe-back on iOS WKWebView touchend with translated coords

### DIFF
--- a/packages/core/src/lib/ssgoi-transition/create-swipe-back-detector.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-swipe-back-detector.ts
@@ -21,6 +21,14 @@
  *      → settle as a swipe.
  *      touchcancel after horizontal commitment also counts: the browser took the
  *      gesture over, which is exactly what edge-swipe-back does on iOS.
+ *      In some environments (notably iOS WKWebView), the OS commits the gesture
+ *      and dispatches `touchend` instead of `touchcancel`, with `clientX`
+ *      reported in the now document-translated coordinate space — `dx` flips
+ *      sign and fails the in-direction recheck above. When the in-direction
+ *      check fails but `|dx| ≥ FINAL_DISTANCE` and `moved` was set during
+ *      touchmove, treat it as the same takeover signal: the magnitude survives
+ *      translation, while keeping the FINAL_DISTANCE floor rejects weak or
+ *      cancelled gestures, matching pre-patch behavior in normal browsers.
  *
  * Settling arms an "active" flag. The flag auto-expires after EXPIRE_WINDOW so
  * a successful gesture that wasn't actually a navigation (e.g. user dragged a
@@ -162,6 +170,19 @@ export function createSwipeBackDetector() {
     const dx = t.clientX - candidate.startX;
     const inDirection = candidate.fromLeftEdge ? dx > 0 : dx < 0;
     if (candidate.moved && inDirection && Math.abs(dx) >= FINAL_DISTANCE) {
+      settle();
+      candidate = null;
+      return;
+    }
+    // Fallback for environments where the native gesture commits at touchend
+    // rather than dispatching touchcancel — notably iOS WKWebView, which
+    // reports clientX in document-translated coordinates after committing
+    // swipe-back, flipping dx sign even though the finger moved in-direction.
+    // The |dx| magnitude is preserved across the translation (typically far
+    // larger than FINAL_DISTANCE), so we keep that floor as a guard against
+    // weak or cancelled swipes that never crossed FINAL_DISTANCE — those
+    // remain rejected, matching pre-patch behavior.
+    if (candidate.moved && Math.abs(dx) >= FINAL_DISTANCE) {
       settle();
     }
     candidate = null;


### PR DESCRIPTION
## **Summary**
- `onTouchEnd` falls through to the same logic as `onTouchCancel` when the strict in-direction recheck fails, so iOS WKWebView's translated-`clientX` `touchend` no longer slips past the detector. Keeps `|dx| ≥ FINAL_DISTANCE` as a guard so weak or cancelled swipes stay rejected.
- Header docstring updated with the new takeover path.

## **Why**
The detector assumes `touchcancel` is the OS's commit signal (per the existing docstring: *"touchcancel after horizontal commitment also counts: the browser took the gesture over"*). In iOS WKWebView the OS instead dispatches `touchend` with `clientX` reported in document-translated coordinates after committing the back slide — `dx` flips sign even though the finger moved in-direction. The strict path's in-direction recheck rejects the gesture and `settle()` never runs, so `@ssgoi`'s drill-exit animates on top of the OS slide.

Diagnostic capture from a left-edge swipe in iOS WKWebView (Simulator, iPhone 16 Pro / iOS 18.4):

```
t+0ms     touchstart   x=1, fromLeft=true                 → candidate registered
t+49ms    touchmove    dx=+34, dy=5                       → moved=true (pre-translation)
t+218ms   touchend     dx=-189, |dx|=189, inDir=false     → strict recheck fails
```

A 223px `dx` swing in 169ms is the document translation, not a finger. The magnitude `|dx|=189` survives the translation (well above `FINAL_DISTANCE = 30`), so reusing that as the fallback floor admits real swipes while rejecting weak/cancelled ones.

Environment behavior:

| Environment | Sequence on swipe-back | Strict path | Notes |
|---|---|---|---|
| iOS WKWebView (RN, in-app) | touchstart → touchmove(moved=true) → **touchend (dx inverted)** | misses | Fixed by this PR |
| iOS Mobile Safari | (per upstream design) touchcancel | covered by `onTouchCancel` branch | No regression |
| Android Chrome | OS captures gesture; page sees touchstart → touchend(dx≈0), no touchmove | moved=false → no settle | No animation conflict (OS doesn't draw on top of page) |
| Android RN WebView | touchstart → touchcancel, no touchmove | moved=false → no settle | Same as above |

## **Test plan**
- iOS Simulator (iPhone 16 Pro / iOS 18.4) inside RN WebView: native slide is no longer duplicated by drill exit; verified via diagnostic capture above.
- Android Emulator (Pixel 8 / API 35) Chrome and RN WebView: detector remains inactive (no `touchmove` is delivered when the OS captures the system back gesture); behavior unchanged.
- Regressions: header back / `router.back()` still animates; swipe-back followed immediately by a forward navigation still animates the forward transition.
- No existing detector tests; happy to add a unit test reproducing the inverted-`dx` `touchend` if desired.
