### PR TITLE
UX timing tweaks: zoom physics retune + showcase card cap

### DIFF
--- a/apps/docs/src/page/showcase/list/index.tsx
+++ b/apps/docs/src/page/showcase/list/index.tsx
@@ -273,7 +273,7 @@ function ShowcaseCard({
             ref={iframeRef}
             src={previewPath}
             title={`${showcase.name} preview`}
-            widthClassName="w-[78%]"
+            widthClassName="w-[78%] max-w-[380px]"
             interactive={false}
           />
         )}

--- a/packages/core/src/lib/transitions/fade/index.ts
+++ b/packages/core/src/lib/transitions/fade/index.ts
@@ -6,11 +6,8 @@ import type { FadeOptions, FadeType, FadeVariant } from "./types";
 export type { FadeOptions, FadeType, FadeVariant } from "./types";
 
 /**
- * Fade preset configuration.
- *
- * Default `type` is `"fade-through"` (sequential fade-out → fade-in).
- * The `"cross-fade"` type and `"smooth"` variant are tracked on the TODO
- * board and intentionally not part of the public type yet.
+ * Fade preset configuration. Default `type` is `"fade-through"` —
+ * sequential fade-out → fade-in.
  */
 export type FadeConfig = PresetConfig<
   { paths: readonly string[] },

--- a/packages/core/src/lib/transitions/fade/types.ts
+++ b/packages/core/src/lib/transitions/fade/types.ts
@@ -1,12 +1,6 @@
 /**
- * Public option shapes for the fade preset.
- *
- * Default `type` is `"fade-through"` — the current sequential
- * fade-out → fade-in behavior.
- *
- * Not yet exposed (tracked separately on the TODO board):
- *   - `type: "cross-fade"` (simultaneous fade)
- *   - `variant: "smooth"`
+ * Public option shapes for the fade preset. Default `type` is
+ * `"fade-through"` — the sequential fade-out → fade-in behavior.
  */
 
 export type FadeType = "fade-through";

--- a/packages/core/src/lib/transitions/zoom/provider/blur.ts
+++ b/packages/core/src/lib/transitions/zoom/provider/blur.ts
@@ -8,11 +8,19 @@ import type {
   ZoomProvider,
   ZoomStrategy,
 } from "../types";
-import { Animation, IntegratorProvider, WebAnimation } from "../../../animation";
+import {
+  Animation,
+  IntegratorProvider,
+  WebAnimation,
+} from "../../../animation";
 import { createZoomIn, createZoomOut } from "../zoom-element";
 
 export const BLUR_PHYSICS: PhysicsOptions = {
-  spring: { stiffness: 200, damping: 24 },
+  spring: {
+    stiffness: 430,
+    damping: 33,
+    doubleSpring: 1,
+  },
 };
 
 // Background page shrinks to (1 - SCALE_OFFSET) at peak.

--- a/packages/core/src/lib/transitions/zoom/provider/static.ts
+++ b/packages/core/src/lib/transitions/zoom/provider/static.ts
@@ -9,7 +9,11 @@ import { Animation } from "../../../animation";
 import { createZoomIn, createZoomOut } from "../zoom-element";
 
 export const STATIC_PHYSICS: PhysicsOptions = {
-  spring: { stiffness: 420, damping: 34 },
+  spring: {
+    stiffness: 530,
+    damping: 34,
+    doubleSpring: 1,
+  },
 };
 
 function noopAnimation(): ZoomAnimationConfig {


### PR DESCRIPTION
## Summary
- **zoom/static**: `stiffness 420→530`, added `doubleSpring: 1` — tighter snap with the doubleSpring smoothing the overshoot tail.
- **zoom/blur**: `stiffness 200→430`, `damping 24→33`, added `doubleSpring: 1` — noticeably faster ramp on the blur variant. The blur overlay's backdrop-filter and the background page's scale share the same spring, so timing stays locked across both layers.
- **Showcase list card**: cap `ShowcasePhone` at `max-w-[380px]` so the phone stops growing past the mobile grid column's specified min size (`380px`) when the `1fr` part expands the column on wider viewports. Other `ShowcasePhone` callsites (clip-player, etc.) are untouched.
- **fade preset JSDoc**: drop the "cross-fade / smooth tracked on TODO" hints in `fade/index.ts` and `fade/types.ts` — those variants were removed from the planning board, so the comments were lying.

No public surface change. Physics retunes affect the existing zoom static / blur showcases (instagram, airbnb).

## Merge strategy
Squash merge — one tuning unit.

## Test plan
- [ ] Instagram showcase (zoom static, default variant) feels tighter without ringing
- [ ] Airbnb showcase (zoom blur, fade variant) feels faster; blur ramp stays locked to bg scale
- [ ] Pinterest showcase (zoom expand) unchanged
- [ ] Showcase list at >1200px viewport: phone cards stop growing past 380px max width
- [ ] Showcase detail clip player unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)