### PR TITLE
release(@ssgoi/core@6.2.1): zoom physics retune

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/core",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "Core animation engine for SSGOI - Native app-like page transitions with spring physics",
   "private": false,
   "type": "module",


### PR DESCRIPTION
## Summary
Patch bump for `@ssgoi/core` only — ships the zoom physics retune from #343 to npm.

- `zoom/static`: stiffness 420→530, add doubleSpring 1
- `zoom/blur`: stiffness 200→430, damping 24→33, add doubleSpring 1

Adapter packages (`react` / `svelte` / `vue` / `solid` / `angular`) stay at `6.2.0` — their `workspace:^` peer pulls the new core transparently for downstream consumers, so no need to ship a new adapter version.

## Merge strategy
Squash merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)