### PR TITLE
core: support React Activity (display:none) as exit/enter trigger

### DIFF
--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -19,20 +19,15 @@ const devHosts =
   process.env.NODE_ENV === "development" ? getLocalNetworkHosts() : [];
 const devPort = process.env.PORT ?? "3000";
 
-// Next.js 16 Cache Components wraps every route in <Activity>, so a previous
-// route stays mounted as `display: none` on client-side navigation instead of
-// unmounting. ssgoi's visibility-observer hooks the resulting style toggle
-// and animates the hidden/visible transitions in place.
-//
-// Gated behind SSGOI_ACTIVITY=1 because turning Cache Components on is also a
-// repo-wide migration (every dynamic data access needs to live inside
-// <Suspense>, or behind `use cache`), and the docs site hasn't been ported
-// yet. Set the env var locally to exercise the Activity integration; default
-// builds stay on the unmount-driven path.
-const activityEnabled = process.env.SSGOI_ACTIVITY === "1";
-
 const nextConfig: NextConfig = {
-  ...(activityEnabled ? { cacheComponents: true } : {}),
+  // Wraps every route in <Activity>, so a previous route stays mounted as
+  // `display: none` on client-side navigation instead of unmounting. ssgoi's
+  // visibility-observer hooks the resulting style toggle and animates the
+  // hidden/visible transitions in place.
+  //
+  // Prod build still requires a docs-wide `'use cache'` / <Suspense>
+  // migration; on here for local exploration of the Activity integration.
+  cacheComponents: true,
   allowedDevOrigins: devHosts,
   experimental: {
     serverActions: {

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -19,7 +19,20 @@ const devHosts =
   process.env.NODE_ENV === "development" ? getLocalNetworkHosts() : [];
 const devPort = process.env.PORT ?? "3000";
 
+// Next.js 16 Cache Components wraps every route in <Activity>, so a previous
+// route stays mounted as `display: none` on client-side navigation instead of
+// unmounting. ssgoi's visibility-observer hooks the resulting style toggle
+// and animates the hidden/visible transitions in place.
+//
+// Gated behind SSGOI_ACTIVITY=1 because turning Cache Components on is also a
+// repo-wide migration (every dynamic data access needs to live inside
+// <Suspense>, or behind `use cache`), and the docs site hasn't been ported
+// yet. Set the env var locally to exercise the Activity integration; default
+// builds stay on the unmount-driven path.
+const activityEnabled = process.env.SSGOI_ACTIVITY === "1";
+
 const nextConfig: NextConfig = {
+  ...(activityEnabled ? { cacheComponents: true } : {}),
   allowedDevOrigins: devHosts,
   experimental: {
     serverActions: {

--- a/packages/core/src/lib/ssgoi-transition/create-ssgoi-transition-context.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-ssgoi-transition-context.ts
@@ -15,6 +15,11 @@ import { createSwipeBackDetector } from "./create-swipe-back-detector";
 import { findMatchingTransition } from "./find-matching-transition";
 import { createNavigationDetector } from "./navigation-detector-strategy";
 import { watchUnmount } from "./unmount-observer";
+import {
+  pauseVisibility,
+  resumeVisibility,
+  watchVisibility,
+} from "./visibility-observer";
 import { HostAnimation } from "../animation/host-animation";
 
 function isTransitionGroup(
@@ -41,6 +46,13 @@ type PendingSide = {
   element: HTMLElement;
   parent: Element | null;
   nextSibling: Element | null;
+  /**
+   * True when this side was triggered by a `display: none` toggle (React
+   * Activity / Next.js Cache Components) rather than a real
+   * mount/unmount. The original element stays in the DOM, so the exit path
+   * animates it in place instead of operating on a clone.
+   */
+  isVisibility?: boolean;
 };
 
 type ElementAnchor = {
@@ -127,14 +139,19 @@ export function createSggoiTransitionContext(
   ): void => {
     const fromOriginal = outSide.element;
     const toElement = inSide.element;
+    const isVisibilityOut = outSide.isVisibility === true;
 
     const { parent, nextSibling } = outSide.parent
       ? { parent: outSide.parent, nextSibling: outSide.nextSibling }
       : readAnchor(fromOriginal);
 
-    // Clone while the original is still mounted; the host framework will
-    // detach the original right after `out()` returns.
-    const fromClone = fromOriginal.cloneNode(true) as HTMLElement;
+    // Activity-hidden elements stay in place — animate the original so we
+    // never duplicate React-owned state into a detached clone. The unmount
+    // path still clones because the host framework will detach the original
+    // immediately after `out()` returns.
+    const fromForAnimation: HTMLElement = isVisibilityOut
+      ? fromOriginal
+      : (fromOriginal.cloneNode(true) as HTMLElement);
     const scrollOffset = calculateScrollOffset(fromPath, toPath);
 
     const ssgoiContext: SsgoiTransitionContext = {
@@ -152,11 +169,11 @@ export function createSggoiTransitionContext(
     // Auto-applied for every transition — outgoing page goes absolute so the
     // incoming page can take its slot. Style only; insertion is deferred
     // until after `prepare` so any pre-paint styling settles first.
-    prepareOutgoing(fromClone, ssgoiContext);
+    prepareOutgoing(fromForAnimation, ssgoiContext);
 
     if (!shouldPreserve(fromPath)) evictScrollPosition(fromPath);
 
-    const fromPromise: Promise<HTMLElement> = Promise.resolve(fromClone);
+    const fromPromise: Promise<HTMLElement> = Promise.resolve(fromForAnimation);
     const toPromise: Promise<HTMLElement> = Promise.resolve(toElement);
 
     const createdElements: HTMLElement[] = [];
@@ -189,13 +206,14 @@ export function createSggoiTransitionContext(
       extras: extrasPromise,
     }).then(({ from: resolvedFrom, to: resolvedTo, extras }) => {
       // Now that prepare's microtasks have all run (initial styles, extras
-      // built), drop the outgoing clone into place. Order is:
-      //   prepare → out insert → animation create/play
-      if (parent) {
+      // built), drop the outgoing clone into place. Visibility-out skips
+      // this — the original was never detached, so re-insertion would be a
+      // double-mount. Order is: prepare → out insert → animation create/play
+      if (!isVisibilityOut && parent) {
         if (nextSibling && parent.contains(nextSibling)) {
-          parent.insertBefore(fromClone, nextSibling);
+          parent.insertBefore(fromForAnimation, nextSibling);
         } else {
-          parent.appendChild(fromClone);
+          parent.appendChild(fromForAnimation);
         }
       }
 
@@ -206,14 +224,25 @@ export function createSggoiTransitionContext(
         ...(extras as Record<string, unknown>),
       });
 
-      // Per-transition cleanup (clone removal, prepare-created nodes). Wire
-      // this BEFORE attach — host.attach hooks onComplete itself and chains
-      // through prior hooks, so cleanup still fires once the run settles.
+      // Per-transition cleanup. Wire this BEFORE attach — host.attach hooks
+      // onComplete itself and chains through prior hooks, so cleanup still
+      // fires once the run settles.
       const prevOnComplete = animation.onComplete;
       animation.onComplete = () => {
         prevOnComplete?.();
-        if (fromClone.parentElement) {
-          fromClone.parentElement.removeChild(fromClone);
+        if (isVisibilityOut) {
+          // Original stays mounted — clear the inline positioning we
+          // injected and re-hide the element so React's intended hidden
+          // state holds. resumeVisibility resyncs the observer so a future
+          // React-driven show still triggers the in side.
+          fromForAnimation.style.position = "";
+          fromForAnimation.style.width = "";
+          fromForAnimation.style.top = "";
+          fromForAnimation.style.left = "";
+          fromForAnimation.style.display = "none";
+          resumeVisibility(fromForAnimation);
+        } else if (fromForAnimation.parentElement) {
+          fromForAnimation.parentElement.removeChild(fromForAnimation);
         }
         for (const extra of createdElements) {
           if (extra.parentElement) extra.parentElement.removeChild(extra);
@@ -283,6 +312,39 @@ export function createSggoiTransitionContext(
     handleArrival(currentPath, "out");
   };
 
+  /**
+   * React Activity / Next.js Cache Components hide a subtree by setting
+   * `display: none` on its host element while leaving the DOM intact. Treat
+   * that as the exit trigger: pause the observer (so our own restore writes
+   * don't bounce back through onHide/onShow), clear the inline display so
+   * the element paints during the animation, and stash it as pendingOut
+   * with isVisibility set so runTransition skips the clone path.
+   */
+  const handleHide = (element: HTMLElement, path: string) => {
+    pauseVisibility(element);
+    element.style.display = "";
+    pendingOut = {
+      element,
+      parent: element.parentElement,
+      nextSibling: element.nextElementSibling,
+      isVisibility: true,
+    };
+    const currentPath = element.getAttribute("data-ssgoi-transition") ?? path;
+    handleArrival(currentPath, "out");
+  };
+
+  /** Counterpart to handleHide — `display: none` was just cleared. */
+  const handleShow = (element: HTMLElement, path: string) => {
+    pendingIn = {
+      element,
+      parent: element.parentElement,
+      nextSibling: element.nextElementSibling,
+      isVisibility: true,
+    };
+    const currentPath = element.getAttribute("data-ssgoi-transition") ?? path;
+    handleArrival(currentPath, "in");
+  };
+
   // Dedupe so the dispatcher tolerates repeat registers for the same node —
   // either from React re-firing a ref or a host that bounces in/out under
   // strict-mode double-mount.
@@ -302,6 +364,10 @@ export function createSggoiTransitionContext(
     handleArrival(path, "in");
 
     watchUnmount(element, () => handleRemoval(element, path));
+    watchVisibility(element, {
+      onHide: () => handleHide(element, path),
+      onShow: () => handleShow(element, path),
+    });
   };
 
   // Per-path ref callbacks are cached so adapters can drop `refFor(path)`

--- a/packages/core/src/lib/ssgoi-transition/visibility-observer.ts
+++ b/packages/core/src/lib/ssgoi-transition/visibility-observer.ts
@@ -1,0 +1,95 @@
+/**
+ * Per-element MutationObserver for detecting inline `display: none` toggles.
+ *
+ * React 19.2's <Activity mode="hidden"> doesn't unmount children — it applies
+ * `style="display: none"` to each host child of the Activity boundary while
+ * keeping the DOM and Fiber state alive. The shared unmount-observer cannot
+ * see this (no removedNodes mutation fires), so this module gives the
+ * dispatcher a second trigger surface: visible↔hidden transitions on inline
+ * style.
+ *
+ * Each watched element gets its own MutationObserver scoped to
+ * `attributeFilter: ['style']`. One observer per element is fine — page-level
+ * transition wrappers are a handful per route, and per-element scoping lets
+ * us pause/resume cleanly when we mutate `display` ourselves (otherwise our
+ * own restore-from-hidden write would re-enter as an onShow).
+ */
+
+type VisibilityCallbacks = {
+  onHide: () => void;
+  onShow: () => void;
+};
+
+type Entry = {
+  observer: MutationObserver;
+  wasHidden: boolean;
+  observeOptions: MutationObserverInit;
+  target: HTMLElement;
+};
+
+const watched = new WeakMap<HTMLElement, Entry>();
+
+const isHidden = (el: HTMLElement): boolean => el.style.display === "none";
+
+/**
+ * Register `cb` to fire when `element`'s inline display flips into or out of
+ * `none`. Returns an unwatch function.
+ */
+export function watchVisibility(
+  element: HTMLElement,
+  cb: VisibilityCallbacks,
+): () => void {
+  if (typeof window === "undefined") return () => {};
+  if (watched.has(element)) return () => {};
+
+  const observeOptions: MutationObserverInit = {
+    attributes: true,
+    attributeFilter: ["style"],
+  };
+
+  const entry: Entry = {
+    observer: null as unknown as MutationObserver,
+    wasHidden: isHidden(element),
+    observeOptions,
+    target: element,
+  };
+
+  const observer = new MutationObserver(() => {
+    const hidden = isHidden(element);
+    if (hidden === entry.wasHidden) return;
+    entry.wasHidden = hidden;
+    // Defer to a microtask — mirrors unmount-observer and keeps us from
+    // mutating styles inside the observer callback itself.
+    queueMicrotask(hidden ? cb.onHide : cb.onShow);
+  });
+
+  observer.observe(element, observeOptions);
+  entry.observer = observer;
+  watched.set(element, entry);
+
+  return () => {
+    observer.disconnect();
+    watched.delete(element);
+  };
+}
+
+/**
+ * Temporarily stop reacting to style changes on `element`. Use this around
+ * intentional inline-display writes that ssgoi makes itself (e.g. unhiding
+ * during an exit animation, re-hiding on complete) so they don't bounce back
+ * through onHide/onShow as if React did them.
+ */
+export function pauseVisibility(element: HTMLElement): void {
+  watched.get(element)?.observer.disconnect();
+}
+
+/**
+ * Re-attach the observer after a pause. Resyncs `wasHidden` from the current
+ * inline style so the next external change is judged against reality.
+ */
+export function resumeVisibility(element: HTMLElement): void {
+  const entry = watched.get(element);
+  if (!entry) return;
+  entry.wasHidden = isHidden(element);
+  entry.observer.observe(entry.target, entry.observeOptions);
+}


### PR DESCRIPTION
## Summary

- Adds a per-element `MutationObserver` (`visibility-observer.ts`) that watches inline `style` and fires `onHide` / `onShow` when `display: none` toggles — the trigger surface needed for React 19.2 `<Activity>` and Next.js 16 Cache Components, neither of which unmount the subtree.
- Branches the existing exit path on a new `PendingSide.isVisibility` flag: when the original element stays in the DOM, we animate it in place (no clone), and on `onComplete` we strip the inline position styles we applied and re-hide it. `pauseVisibility` / `resumeVisibility` bracket those writes so our own restores don't bounce back through the observer.
- `apps/docs/next.config.ts` gains an `SSGOI_ACTIVITY=1` opt-in for top-level `cacheComponents: true`. Turning the flag on is also a wider Next 16 migration (every dynamic read needs `<Suspense>` or `use cache`), so the default build still flows through the unmount-driven path until docs is ported.

## Why this shape

The original exit path assumes the element has already been detached (it clones because the original is about to disappear). Activity flips that assumption — the element is intentionally kept alive, with full React state. Cloning it would (a) detach a copy that React-owned effects no longer point at, and (b) leave the original sitting beside the clone, invisible only because we cleared `display`. Animating the original in place is the only thing that keeps Activity's state-preservation guarantee intact.

A small lifecycle tax falls out: while the exit plays, we have to clear `display` ourselves so the user can see the frame they're leaving, then put `display: none` back on completion so React's intended state still holds. The observer pause/resume API exists for exactly that round trip.

`subtree: false` is deliberate: `<Activity>` applies `display: none` to each host child of the boundary, and `SsgoiTransition` always renders a host wrapper, so the watched element is itself the one whose style flips. Watching the subtree would risk false positives from nested transitions.

## Scope of this PR

- Core only — adapter packages (`@ssgoi/react`, svelte, vue, solid, angular) keep their existing `refFor` / `register` API unchanged.
- v1 is the auto-detect track: a separate explicit `<Activity mode>`-aware API is intentionally deferred.
- The original element is used as the exit `from` without any freeze/inert protection. Re-renders mid-animation are accepted; if that surfaces problems in practice, we'll add guarding in a follow-up.
- docs site is not migrated to Cache Components — only the toggle is wired up so contributors can opt in locally.

## Test plan

- [x] `pnpm run core:build` — clean
- [x] `pnpm --filter @ssgoi/core test:run` — 15/15 green
- [x] `pnpm --filter docs build` (default, flag off) — succeeds
- [ ] Manually verify in docs with `SSGOI_ACTIVITY=1 pnpm --filter docs dev` once a representative route is ported to satisfy Cache Components' `<Suspense>` requirement (out of scope here)
- [ ] Confirm the visibility-out branch under an explicit `<Activity mode>` toggle in a small demo app (not added in this PR — keeping scope tight)

## Follow-ups (not in this PR)

- Port docs routes to satisfy `cacheComponents` so the flag can be flipped on by default.
- Add a unit test for `visibility-observer` (hide/show toggle, pause/resume reentry, unwatch).
- Investigate Next.js route-level Activity wrapping: if Next applies `display: none` to an ancestor of the `SsgoiTransition` host, the per-element observer won't see it and we'd need an ancestor watch strategy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)