### PR TITLE
axis: loosen settle thresholds 10× across all providers

### DIFF
--- a/packages/core/src/lib/transitions/axis/provider/x/fluid.ts
+++ b/packages/core/src/lib/transitions/axis/provider/x/fluid.ts
@@ -20,12 +20,15 @@ import type {
 // The sibling `snappy` x is the KakaoTalk-style flavor — parallel cross-fade.
 const TRANSLATE_PX = 30;
 
+// All axis providers loosen settle thresholds 10× over the integrator
+// defaults (0.01 → 0.1) so the imperceptible tail of each phase doesn't
+// hold up the sequence handoff or the page lifecycle.
 const FLUID_OUT_PHYSICS: PhysicsOptions = {
-  inertia: { acceleration: 150, resistance: 1.5 },
+  inertia: { acceleration: 150, resistance: 1.5, restDelta: 0.1 },
 };
 
 const FLUID_IN_PHYSICS: PhysicsOptions = {
-  spring: { stiffness: 180, damping: 34 },
+  spring: { stiffness: 180, damping: 34, restDelta: 0.1, restSpeed: 0.1 },
 };
 
 function buildFluidX({

--- a/packages/core/src/lib/transitions/axis/provider/x/snappy.ts
+++ b/packages/core/src/lib/transitions/axis/provider/x/snappy.ts
@@ -21,8 +21,19 @@ import type {
 //   - Very stiff spring — lands around ~160 ms.
 const KAKAO_SLIDE_PX = 8;
 
+// Loosen the settle thresholds 10× over the integrator defaults
+// (0.01 → 0.1 for both position and velocity). With a very stiff spring the
+// tail past ~98% is visually indistinguishable but still simulates for a few
+// extra frames; bumping the thresholds lets the snappy x land sooner without
+// changing the perceived motion.
 const SNAPPY_PHYSICS: PhysicsOptions = {
-  spring: { stiffness: 1000, damping: 40, doubleSpring: 1.2 },
+  spring: {
+    stiffness: 1000,
+    damping: 40,
+    doubleSpring: 1.2,
+    restDelta: 0.1,
+    restSpeed: 0.1,
+  },
 };
 
 function buildSnappyX({

--- a/packages/core/src/lib/transitions/axis/provider/y/directional.ts
+++ b/packages/core/src/lib/transitions/axis/provider/y/directional.ts
@@ -17,12 +17,13 @@ import type {
 // its own without tugging the x feel.
 const TRANSLATE_PX = 8;
 
+// See x/fluid.ts — settle thresholds loosened 10× across all axis providers.
 const Y_DIRECTIONAL_OUT_PHYSICS: PhysicsOptions = {
-  inertia: { acceleration: 150, resistance: 1.5 },
+  inertia: { acceleration: 150, resistance: 1.5, restDelta: 0.1 },
 };
 
 const Y_DIRECTIONAL_IN_PHYSICS: PhysicsOptions = {
-  spring: { stiffness: 180, damping: 34 },
+  spring: { stiffness: 180, damping: 34, restDelta: 0.1, restSpeed: 0.1 },
 };
 
 function buildDirectionalY({

--- a/packages/core/src/lib/transitions/axis/provider/y/non-directional.ts
+++ b/packages/core/src/lib/transitions/axis/provider/y/non-directional.ts
@@ -15,12 +15,13 @@ import type {
 // needs its own tuning later.
 const TRANSLATE_PX = 8;
 
+// See x/fluid.ts — settle thresholds loosened 10× across all axis providers.
 const Y_NON_DIRECTIONAL_OUT_PHYSICS: PhysicsOptions = {
-  inertia: { acceleration: 150, resistance: 1.5 },
+  inertia: { acceleration: 150, resistance: 1.5, restDelta: 0.1 },
 };
 
 const Y_NON_DIRECTIONAL_IN_PHYSICS: PhysicsOptions = {
-  spring: { stiffness: 180, damping: 34 },
+  spring: { stiffness: 180, damping: 34, restDelta: 0.1, restSpeed: 0.1 },
 };
 
 function buildNonDirectionalY(

--- a/packages/core/src/lib/transitions/axis/provider/z/directional.ts
+++ b/packages/core/src/lib/transitions/axis/provider/z/directional.ts
@@ -8,8 +8,9 @@ import type {
 // Material shared Z-axis. Spring is near-critical (damping 30 vs ~33.5
 // critical → ratio ≈ 0.9), so progress is effectively monotonic — safe to
 // piecewise-map opacity inside the same tick as the scale.
+// See x/fluid.ts — settle thresholds loosened 10× across all axis providers.
 const Z_PHYSICS: PhysicsOptions = {
-  spring: { stiffness: 280, damping: 30 },
+  spring: { stiffness: 280, damping: 30, restDelta: 0.1, restSpeed: 0.1 },
 };
 
 const SCALE_OFFSET = 0.1;

--- a/packages/core/src/lib/transitions/axis/provider/z/non-directional.ts
+++ b/packages/core/src/lib/transitions/axis/provider/z/non-directional.ts
@@ -3,8 +3,9 @@ import type { AxisAnimationConfig, AxisProvider } from "../../types";
 
 // Same physics as directional z so the fade-through timing aligns regardless
 // of which feel is picked. See directional.ts for the damping rationale.
+// See x/fluid.ts — settle thresholds loosened 10× across all axis providers.
 const Z_PHYSICS: PhysicsOptions = {
-  spring: { stiffness: 280, damping: 30 },
+  spring: { stiffness: 280, damping: 30, restDelta: 0.1, restSpeed: 0.1 },
 };
 
 const SCALE_OFFSET = 0.1;


### PR DESCRIPTION
## Summary
- The axis transition family (x snappy / x fluid / y directional / y non-directional / z directional / z non-directional) leans on the spring and inertia integrators' default settle thresholds (`restDelta = restSpeed = 0.01`). With the stiffness/damping each provider already uses, the visible motion is done well before the integrator considers the system settled — the tail past ~98% is imperceptible but still costs frames and delays the sequence handoff / page lifecycle.
- Add explicit `restDelta: 0.1` (and `restSpeed: 0.1` for springs) to every axis provider's physics — 10× the integrator defaults. No stiffness/damping/translate changes, so the perceived motion is unchanged; only the imperceptible tail is cut.

## Files touched
- `packages/core/src/lib/transitions/axis/provider/x/snappy.ts`
- `packages/core/src/lib/transitions/axis/provider/x/fluid.ts`
- `packages/core/src/lib/transitions/axis/provider/y/directional.ts`
- `packages/core/src/lib/transitions/axis/provider/y/non-directional.ts`
- `packages/core/src/lib/transitions/axis/provider/z/directional.ts`
- `packages/core/src/lib/transitions/axis/provider/z/non-directional.ts`

## Test plan
- [ ] Showcase each axis feel (snappy x, fluid x, directional y, non-directional y, directional z, non-directional z) and confirm front-edge motion is unchanged.
- [ ] Confirm the back-edge tail is shorter — chained navigations should hand off faster, no lingering sub-pixel settle.
- [ ] Sanity-check that non-axis transitions (sheet, hero, bubble, scroll, etc.) are unaffected — none were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)