### PR TITLE
feat(core): support React <Activity> / Next.js cacheComponents page transitions

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -7,6 +7,13 @@
       "runtimeArgs": ["run", "docs"],
       "port": 3000,
       "autoPort": false
+    },
+    {
+      "name": "dev",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--filter", "dev", "dev"],
+      "port": 3000,
+      "autoPort": false
     }
   ]
 }

--- a/apps/dev/src/app/activity/page.tsx
+++ b/apps/dev/src/app/activity/page.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { Activity, useState } from "react";
+import type { CSSProperties } from "react";
+import { Ssgoi, type SsgoiConfig } from "@ssgoi/react";
+import { drill } from "@ssgoi/react/view-transitions";
+
+/**
+ * React `<Activity>` smoke test for ssgoi core — using the `drill` transition,
+ * which (like most transitions) leaks inline styles onto the OUTGOING node
+ * (pointer-events:none, z-index, …) and never resets them, because it assumes
+ * that node is a throwaway clone. In hidden mode the outgoing node is the REAL
+ * reused element, so those must be cleaned up or the page comes back
+ * non-interactive / behind everything. The per-page click counters verify the
+ * pages stay interactive after navigating back and forth.
+ */
+
+const A = "/activity/a";
+const B = "/activity/b";
+
+const config: SsgoiConfig = {
+  transitions: drill({ enter: B, exit: A }),
+};
+
+const page = (bg: string): CSSProperties => ({
+  position: "absolute",
+  inset: 0,
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  justifyContent: "center",
+  gap: 16,
+  background: bg,
+  color: "white",
+  fontSize: 24,
+  fontWeight: 600,
+});
+
+const btn: CSSProperties = {
+  padding: "8px 16px",
+  borderRadius: 9999,
+  border: "1px solid rgba(255,255,255,0.25)",
+  background: "rgba(255,255,255,0.12)",
+  color: "white",
+  fontSize: 16,
+  cursor: "pointer",
+};
+
+const navBtn: CSSProperties = { ...btn, fontSize: 14 };
+
+export default function ActivityTestPage() {
+  const [active, setActive] = useState<"a" | "b">("a");
+  const [draft, setDraft] = useState("");
+  const [countA, setCountA] = useState(0);
+  const [countB, setCountB] = useState(0);
+
+  return (
+    <main
+      style={{
+        minHeight: "100dvh",
+        display: "flex",
+        flexDirection: "column",
+        background: "#0a0a0a",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          gap: 8,
+          alignItems: "center",
+          padding: 16,
+          color: "#a3a3a3",
+          fontSize: 14,
+        }}
+      >
+        <button style={navBtn} onClick={() => setActive("a")}>
+          Show A
+        </button>
+        <button style={navBtn} onClick={() => setActive("b")}>
+          Show B
+        </button>
+        <button
+          style={navBtn}
+          onClick={() => setActive((p) => (p === "a" ? "b" : "a"))}
+        >
+          Toggle
+        </button>
+        <span style={{ marginLeft: "auto", fontFamily: "monospace" }}>
+          active: {active}
+        </span>
+      </div>
+
+      <Ssgoi config={config}>
+        <div style={{ position: "relative", flex: 1, overflow: "hidden" }}>
+          <Activity mode={active === "a" ? "visible" : "hidden"}>
+            <div data-ssgoi-transition={A} style={page("#1e3a8a")}>
+              <span>Page A</span>
+              <button style={btn} onClick={() => setCountA((c) => c + 1)}>
+                A clicks: {countA}
+              </button>
+              <input
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
+                placeholder="type, then toggle"
+                style={{
+                  padding: "8px 12px",
+                  borderRadius: 8,
+                  border: "1px solid rgba(255,255,255,0.25)",
+                  background: "rgba(0,0,0,0.25)",
+                  color: "white",
+                  fontSize: 16,
+                  fontWeight: 400,
+                  width: 220,
+                  textAlign: "center",
+                }}
+              />
+            </div>
+          </Activity>
+
+          <Activity mode={active === "b" ? "visible" : "hidden"}>
+            <div data-ssgoi-transition={B} style={page("#7c2d12")}>
+              <span>Page B</span>
+              <button style={btn} onClick={() => setCountB((c) => c + 1)}>
+                B clicks: {countB}
+              </button>
+            </div>
+          </Activity>
+        </div>
+      </Ssgoi>
+    </main>
+  );
+}

--- a/apps/dev/src/app/page.tsx
+++ b/apps/dev/src/app/page.tsx
@@ -11,6 +11,12 @@ const ROUTES: { href: string; title: string; description: string }[] = [
     title: "/animator",
     description: "Animator 테스트용 빈 라우트",
   },
+  {
+    href: "/activity",
+    title: "/activity",
+    description:
+      "React <Activity> 전환 테스트 — display:none hide/show로 unmount 없이 페이지 전환",
+  },
 ];
 
 export default function Home() {

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -20,6 +20,11 @@ const devHosts =
 
 const nextConfig: NextConfig = {
   allowedDevOrigins: devHosts,
+  // Keep previously-visited routes mounted (hidden via React <Activity>) on
+  // client navigation instead of unmounting them. ssgoi detects the
+  // display:none hide/show and runs page transitions on the real nodes,
+  // so navigation animations work with cached/kept-alive pages.
+  cacheComponents: true,
   async redirects() {
     return [{ source: "/showcase", destination: "/", permanent: true }];
   },

--- a/apps/docs/src/app/blog/rss.xml/route.ts
+++ b/apps/docs/src/app/blog/rss.xml/route.ts
@@ -1,7 +1,8 @@
 import { SITE_DESCRIPTION, SITE_NAME, SITE_URL } from "@/lib/seo";
 import { getAllPosts } from "@/lib/blog";
 
-export const dynamic = "force-static";
+// `dynamic = "force-static"` is incompatible with cacheComponents; the feed is
+// cheap to generate per request from local MDX, so render it dynamically.
 
 function escapeXml(value: string) {
   return value

--- a/apps/docs/src/app/demo/layout.tsx
+++ b/apps/docs/src/app/demo/layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { Suspense, type ReactNode } from "react";
 import { useShowcaseHost } from "@/lib/components/host-context";
 import { FloatingAnimationDock } from "@/lib/components/animation-dock";
 
@@ -16,7 +16,11 @@ export default function DemoLayout({ children }: { children: ReactNode }) {
   const host = useShowcaseHost();
   return (
     <>
-      {children}
+      {/* Demo route pages read runtime-dynamic data (route `params`,
+          `searchParams`) for their interactive content. Under cacheComponents
+          that must sit inside a <Suspense> boundary so the static shell can
+          prerender without it — one boundary here covers every /demo/* page. */}
+      <Suspense>{children}</Suspense>
       <FloatingAnimationDock host={host} />
     </>
   );

--- a/apps/docs/src/app/docs/transitions/[transition]/page.tsx
+++ b/apps/docs/src/app/docs/transitions/[transition]/page.tsx
@@ -9,8 +9,9 @@ import {
   getTransitionDoc,
 } from "@/page/docs/transitions-data";
 
-export const dynamicParams = false;
-
+// `dynamicParams = false` is incompatible with cacheComponents. The known
+// transitions are still prerendered via generateStaticParams; an unknown slug
+// falls through to `notFound()` below, so it 404s either way.
 export function generateStaticParams() {
   return TRANSITION_DOCS.map((t) => ({ transition: t.name }));
 }

--- a/apps/docs/src/components/desktop-frame.tsx
+++ b/apps/docs/src/components/desktop-frame.tsx
@@ -2,7 +2,6 @@
 
 import {
   forwardRef,
-  useEffect,
   useLayoutEffect,
   useRef,
   useState,
@@ -59,9 +58,15 @@ export const DesktopFrame = forwardRef<HTMLIFrameElement, Props>(
     const [screenW, setScreenW] = useState(0);
     const [loaded, setLoaded] = useState(false);
 
-    useEffect(() => {
+    // Reset the loading overlay only when `src` ACTUALLY changes — not on a bare
+    // effect re-run. React <Activity> re-runs passive effects on hidden→visible,
+    // so a `useEffect(..., [src])` would fire on every reveal and re-show the
+    // overlay over an already-loaded iframe that never re-fires `onLoad`.
+    const [trackedSrc, setTrackedSrc] = useState(src);
+    if (src !== trackedSrc) {
+      setTrackedSrc(src);
       setLoaded(false);
-    }, [src]);
+    }
 
     useLayoutEffect(() => {
       if (!scaleViewport) return;

--- a/apps/docs/src/components/phone-frame.tsx
+++ b/apps/docs/src/components/phone-frame.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { IframeLoadingOverlay } from "./iframe-loading-overlay";
 
 type Props = {
@@ -16,9 +16,17 @@ export function PhoneFrame({
 }: Props) {
   const [loaded, setLoaded] = useState(false);
 
-  useEffect(() => {
+  // Reset the loading overlay only when `src` ACTUALLY changes — not on a bare
+  // effect re-run. React <Activity> re-runs passive effects on hidden→visible,
+  // so a `useEffect(..., [src])` would fire on every reveal and re-show the
+  // overlay over an already-loaded iframe that never re-fires `onLoad` (the
+  // iframe state is preserved, so it just sits behind a stuck loader). Deriving
+  // from a tracked src keeps the reset tied to a genuine src change.
+  const [trackedSrc, setTrackedSrc] = useState(src);
+  if (src !== trackedSrc) {
+    setTrackedSrc(src);
     setLoaded(false);
-  }, [src]);
+  }
 
   return (
     <div className={`relative mx-auto shrink-0 ${widthClassName}`}>

--- a/apps/docs/src/components/showcase-phone.tsx
+++ b/apps/docs/src/components/showcase-phone.tsx
@@ -2,7 +2,6 @@
 
 import {
   forwardRef,
-  useEffect,
   useLayoutEffect,
   useRef,
   useState,
@@ -57,9 +56,15 @@ export const ShowcasePhone = forwardRef<HTMLIFrameElement, Props>(
     const [screenW, setScreenW] = useState(0);
     const [loaded, setLoaded] = useState(false);
 
-    useEffect(() => {
+    // Reset the loading overlay only when `src` ACTUALLY changes — not on a bare
+    // effect re-run. React <Activity> re-runs passive effects on hidden→visible,
+    // so a `useEffect(..., [src])` would fire on every reveal and re-show the
+    // overlay over an already-loaded iframe that never re-fires `onLoad`.
+    const [trackedSrc, setTrackedSrc] = useState(src);
+    if (src !== trackedSrc) {
+      setTrackedSrc(src);
       setLoaded(false);
-    }, [src]);
+    }
 
     useLayoutEffect(() => {
       if (!scaleViewport) return;

--- a/packages/core/src/lib/ssgoi-transition/create-ssgoi-transition-context.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-ssgoi-transition-context.ts
@@ -15,6 +15,7 @@ import { createSwipeBackDetector } from "./create-swipe-back-detector";
 import { findMatchingTransition } from "./find-matching-transition";
 import { createNavigationDetector } from "./navigation-detector-strategy";
 import { watchUnmount } from "./unmount-observer";
+import { watchVisibility, type VisibilityHandle } from "./visibility-observer";
 import { HostAnimation } from "../animation/host-animation";
 
 function isTransitionGroup(
@@ -37,10 +38,23 @@ function flattenTransitions(
   return flattened;
 }
 
+type TransitionMode = "unmount" | "hidden";
+
 type PendingSide = {
   element: HTMLElement;
   parent: Element | null;
   nextSibling: Element | null;
+  /**
+   * How the outgoing page left (meaningful on the OUT side only):
+   *  - "unmount": real DOM removal (SPA frameworks, Next without
+   *    cacheComponents). The outgoing page is cloned and the clone is removed on
+   *    settle — the battle-tested baseline path.
+   *  - "hidden":  React `<Activity>` / Next `cacheComponents` toggled it to
+   *    `display:none`. The REAL node is reused (page state preserved) and
+   *    re-hidden on settle.
+   * Absent on the IN side; defaults to "unmount".
+   */
+  mode?: TransitionMode;
 };
 
 type ElementAnchor = {
@@ -118,6 +132,79 @@ export function createSggoiTransitionContext(
     };
   };
 
+  // ── Hidden-mode bookkeeping (React <Activity> / Next cacheComponents) ───────
+  //
+  // In hidden mode a page element is registered ONCE (first mount) and then
+  // toggled between visible and display:none forever; OUT/IN are driven by the
+  // visibility-observer rather than mount/unmount. Repeated, interruptible
+  // navigation stays correct via three pieces of state:
+  //
+  //  - `owner` / `transitionEpoch`: every hidden run stamps the real nodes it
+  //    drives with a monotonically increasing epoch. On settle a run only
+  //    restores a node it STILL owns, so when a follow-up navigation re-claims
+  //    the same nodes mid-flight (A: OUT→IN, B: IN→OUT) the interrupted run's
+  //    cleanup is skipped and the live run owns the final resting state — no
+  //    vanished or stuck-hidden pages.
+  //  - `hiddenState`: per-element resting bookkeeping. `savedCss` is the clean
+  //    inline cssText snapshot taken on idle→active entry (so every style a
+  //    transition leaks onto a reused node is wiped on settle); `intent` is
+  //    React's latest visible/hidden intent; `visibleDisplay` is the inline
+  //    display to restore to when resting visible (possibly "" for class-driven
+  //    display); `computedDisplay` is a concrete value used to reveal a hidden
+  //    node for its out-animation.
+  type HiddenState = {
+    vis: VisibilityHandle;
+    savedCss: string | null;
+    intent: "visible" | "hidden";
+    visibleDisplay: string;
+    computedDisplay: string;
+  };
+  const hiddenState = new WeakMap<HTMLElement, HiddenState>();
+  const owner = new WeakMap<HTMLElement, number>();
+  let transitionEpoch = 0;
+
+  const readComputedDisplay = (el: HTMLElement): string => {
+    const d =
+      typeof getComputedStyle !== "undefined"
+        ? getComputedStyle(el).display
+        : "";
+    return d && d !== "none" ? d : "block";
+  };
+
+  // Capture the element's resting visible display while it IS visible: the
+  // inline value (what React restores on reveal, possibly "") plus a concrete
+  // computed value (needed to reveal it later, where "" is not a legal write).
+  const captureVisibleDisplay = (el: HTMLElement, state: HiddenState): void => {
+    state.visibleDisplay = el.style.getPropertyValue("display");
+    state.computedDisplay = readComputedDisplay(el);
+  };
+
+  // Reconcile a reused (hidden-mode) real node to its final resting state — but
+  // only if this run still owns it (a newer run re-claiming it wins). Wipes all
+  // transition-leaked inline styles via the clean cssText snapshot, then sets
+  // display to match React's latest intent.
+  const reconcileResting = (el: HTMLElement, epoch: number): void => {
+    if (owner.get(el) !== epoch) return; // superseded by a newer run
+    owner.delete(el);
+    const state = hiddenState.get(el);
+    if (!state) return;
+    if (state.savedCss !== null) {
+      el.style.cssText = state.savedCss;
+      state.savedCss = null;
+    }
+    if (state.intent === "hidden") {
+      // Match React's own hidden form so a later React reveal is observable.
+      state.vis.setDisplay("none", true);
+    } else if (state.visibleDisplay) {
+      state.vis.setDisplay(state.visibleDisplay, false);
+      captureVisibleDisplay(el, state);
+    } else {
+      // React drives visibility via a class / UA default (no inline display).
+      state.vis.setDisplay(null);
+      captureVisibleDisplay(el, state);
+    }
+  };
+
   const runTransition = (
     config: AnyTransitionConfig,
     fromPath: string,
@@ -127,15 +214,13 @@ export function createSggoiTransitionContext(
   ): void => {
     const fromOriginal = outSide.element;
     const toElement = inSide.element;
+    const outMode: TransitionMode = outSide.mode ?? "unmount";
+    const isHidden = outMode === "hidden";
 
     const { parent, nextSibling } = outSide.parent
       ? { parent: outSide.parent, nextSibling: outSide.nextSibling }
       : readAnchor(fromOriginal);
 
-    // Clone while the original is still mounted; the host framework will
-    // detach the original right after `out()` returns.
-    const fromClone = fromOriginal.cloneNode(true) as HTMLElement;
-    fromClone.setAttribute("data-ssgoi-clone", "");
     const scrollOffset = calculateScrollOffset(fromPath, toPath);
 
     const ssgoiContext: SsgoiTransitionContext = {
@@ -150,14 +235,49 @@ export function createSggoiTransitionContext(
       },
     };
 
-    // Auto-applied for every transition — outgoing page goes absolute so the
-    // incoming page can take its slot. Style only; insertion is deferred
-    // until after `prepare` so any pre-paint styling settles first.
-    prepareOutgoing(fromClone, ssgoiContext);
+    // The element handed to the animation as `from`:
+    //  - unmount mode: a throwaway deep clone (the real node is being destroyed
+    //    by the host framework), inserted after `prepare` and removed on settle.
+    //  - hidden mode: the REAL outgoing node, already revealed + taken out of
+    //    flow by `handleHide`. Reusing it keeps page state alive AND lets a
+    //    follow-up navigation hand its motion back continuously (matchInto keys
+    //    on element identity) — a fresh clone every nav never could.
+    let fromElement: HTMLElement;
+    if (isHidden) {
+      fromElement = fromOriginal;
+      // scrollOffset is only known now — finish the out-of-flow placement begun
+      // in handleHide so the incoming page lines up with the prior scroll.
+      fromElement.style.top = `${-1 * (scrollOffset?.y ?? 0)}px`;
+      // Snapshot the incoming node's clean inline styles BEFORE `prepare` paints
+      // starting styles onto it, so settle can wipe transition leakage off this
+      // reused real node. (The outgoing node was snapshotted in handleHide.)
+      const toState = hiddenState.get(toElement);
+      if (toState && toState.savedCss === null) {
+        toState.savedCss = toElement.style.cssText;
+      }
+    } else {
+      // Clone while the original is still mounted; the host framework will
+      // detach the original right after `out()` returns.
+      fromElement = fromOriginal.cloneNode(true) as HTMLElement;
+      fromElement.setAttribute("data-ssgoi-clone", "");
+      // Outgoing page goes absolute so the incoming page can take its slot.
+      // Style only; insertion is deferred until after `prepare`.
+      prepareOutgoing(fromElement, ssgoiContext);
+    }
 
     if (!shouldPreserve(fromPath)) evictScrollPosition(fromPath);
 
-    const fromPromise: Promise<HTMLElement> = Promise.resolve(fromClone);
+    // Stamp ownership BEFORE host.attach force-completes any prior run (below):
+    // the prior run's settle checks ownership and must already see THIS run
+    // owning the shared real nodes, so it skips them instead of fighting us.
+    // Only hidden mode reuses/owns real nodes; unmount mode stays clone-based.
+    const epoch = isHidden ? ++transitionEpoch : 0;
+    if (isHidden) {
+      owner.set(toElement, epoch);
+      owner.set(fromOriginal, epoch);
+    }
+
+    const fromPromise: Promise<HTMLElement> = Promise.resolve(fromElement);
     const toPromise: Promise<HTMLElement> = Promise.resolve(toElement);
 
     const createdElements: HTMLElement[] = [];
@@ -192,11 +312,12 @@ export function createSggoiTransitionContext(
       // Now that prepare's microtasks have all run (initial styles, extras
       // built), drop the outgoing clone into place. Order is:
       //   prepare → out insert → animation create/play
-      if (parent) {
+      // Hidden mode skips insertion: the real node is already in place.
+      if (!isHidden && parent) {
         if (nextSibling && parent.contains(nextSibling)) {
-          parent.insertBefore(fromClone, nextSibling);
+          parent.insertBefore(fromElement, nextSibling);
         } else {
-          parent.appendChild(fromClone);
+          parent.appendChild(fromElement);
         }
       }
 
@@ -207,14 +328,21 @@ export function createSggoiTransitionContext(
         ...(extras as Record<string, unknown>),
       });
 
-      // Per-transition cleanup (clone removal, prepare-created nodes). Wire
-      // this BEFORE attach — host.attach hooks onComplete itself and chains
-      // through prior hooks, so cleanup still fires once the run settles.
+      // Per-transition settle. Wire this BEFORE attach — host.attach hooks
+      // onComplete itself and chains through prior hooks, so cleanup still
+      // fires once the run settles (natural finish OR host force-completing it).
       const prevOnComplete = animation.onComplete;
       animation.onComplete = () => {
         prevOnComplete?.();
-        if (fromClone.parentElement) {
-          fromClone.parentElement.removeChild(fromClone);
+        if (isHidden) {
+          // Reuse: re-hide the real outgoing node (or leave it visible if a
+          // follow-up navigation re-claimed it as an incoming page) and wipe
+          // every inline style the transition leaked onto it. Both reconciles
+          // no-op if a newer run now owns the node.
+          reconcileResting(fromOriginal, epoch);
+          reconcileResting(toElement, epoch);
+        } else if (fromElement.parentElement) {
+          fromElement.parentElement.removeChild(fromElement);
         }
         for (const extra of createdElements) {
           if (extra.parentElement) extra.parentElement.removeChild(extra);
@@ -270,12 +398,114 @@ export function createSggoiTransitionContext(
     });
   };
 
-  const handleRemoval = (element: HTMLElement, path: string) => {
+  // React drove `element` to display:none (an <Activity> went mode="hidden").
+  // Reveal the REAL node immediately — synchronously, inside the observer's
+  // microtask, before the browser paints — so it animates out from where it sat
+  // instead of flashing away, and take it out of flow so the incoming page
+  // claims its slot. The run itself starts once the IN side pairs.
+  const handleHide = (element: HTMLElement, path: string) => {
+    const state = hiddenState.get(element);
+    if (!state) return;
+    // React's <Activity> can commit the SAME hide more than once (dev re-commit
+    // / follow-up render). Only the first edge of a given intent starts a
+    // transition; a repeat must NOT enqueue a second OUT, or it corrupts the
+    // navigation detector's pairing for the next real navigation. Real nav
+    // always FLIPS intent, so it is never deduped here.
+    const alreadyHidden = state.intent === "hidden";
+    state.intent = "hidden";
+
+    // Snapshot inline styles once, on idle→active entry, so settle can wipe
+    // transition leakage off this reused node. These are the node's resting
+    // styles except for React's just-applied `display:none` — which is fine,
+    // because reconcileResting always overrides display explicitly afterward.
+    // If already mid-flight (savedCss set), keep the original snapshot.
+    if (state.savedCss === null) state.savedCss = element.style.cssText;
+
+    // (Re-)reveal over React's `display:none !important`, every time — so the
+    // node stays visible for its out-animation even when React re-asserts the
+    // hide. A concrete computed value WITH !important keeps our reveal
+    // observably distinct from React's plain `display:` reveal, so an
+    // interrupting React reveal is still caught.
+    state.vis.setDisplay(state.computedDisplay || "block", true);
+    element.style.position = "absolute";
+    element.style.width = "100%";
+    element.style.left = "0";
+
+    if (alreadyHidden) return; // duplicate hide — kept revealed, don't re-pair
+
     const anchor = readAnchor(element);
     pendingOut = {
       element,
       parent: anchor.parent,
       nextSibling: anchor.nextSibling,
+      mode: "hidden",
+    };
+    const currentPath = element.getAttribute("data-ssgoi-transition") ?? path;
+    handleArrival(currentPath, "out");
+  };
+
+  // React revealed `element` (an <Activity> went mode="visible"): it is entering
+  // again, with its state preserved. Drive an IN exactly like a fresh mount,
+  // minus the mount.
+  const handleShow = (element: HTMLElement, path: string) => {
+    const state = hiddenState.get(element);
+    if (!state) return;
+    // Dedupe redundant reveals (see handleHide): only an intent flip enters.
+    if (state.intent === "visible") return;
+    state.intent = "visible";
+    // Capture React's visible display BEFORE the restore below mutates it.
+    captureVisibleDisplay(element, state);
+
+    // OUT→IN role swap: an in-flight outgoing node (savedCss already taken) is
+    // being re-claimed as the incoming page. It still carries the out-of-flow
+    // positioning handleHide imposed (position:absolute/width/left/top) plus the
+    // out-transition's style leakage — normalize it back to its clean inline
+    // styles so the incoming page re-enters in NORMAL flow, then re-assert the
+    // visible display (the snapshot carries React's display:none from the hide).
+    // savedCss is kept for the eventual settle; the spring handoff (matchInto)
+    // carries motion continuity, so wiping the stale inline transform is fine.
+    if (state.savedCss !== null) {
+      element.style.cssText = state.savedCss;
+      if (state.visibleDisplay) {
+        state.vis.setDisplay(state.visibleDisplay, false);
+      } else {
+        state.vis.setDisplay(null);
+      }
+    }
+
+    initializeContext(element, path);
+    pendingIn = {
+      element,
+      parent: element.parentElement,
+      nextSibling: element.nextElementSibling,
+    };
+    const currentPath = element.getAttribute("data-ssgoi-transition") ?? path;
+    handleArrival(currentPath, "in");
+  };
+
+  const handleRemoval = (element: HTMLElement, path: string) => {
+    const state = hiddenState.get(element);
+    if (state) {
+      state.vis.stop();
+      hiddenState.delete(element);
+      owner.delete(element);
+      // An Activity page evicted WHILE hidden (e.g. dropped from Next's bfcache)
+      // is just GC, not a navigation — don't animate it out. Drop any pending
+      // side that still points at this now-gone node so it can't mis-pair a
+      // later arrival onto a detached element.
+      if (state.intent === "hidden") {
+        if (pendingOut?.element === element) pendingOut = null;
+        if (pendingIn?.element === element) pendingIn = null;
+        return;
+      }
+    }
+
+    const anchor = readAnchor(element);
+    pendingOut = {
+      element,
+      parent: anchor.parent,
+      nextSibling: anchor.nextSibling,
+      mode: "unmount",
     };
     // Read the latest id from the DOM rather than the closure-captured path
     // so a mid-life id change (re-render with a new id prop on the same
@@ -294,13 +524,35 @@ export function createSggoiTransitionContext(
     registered.add(element);
 
     captureAnchor(element);
-    initializeContext(element, path);
-    pendingIn = {
-      element,
-      parent: element.parentElement,
-      nextSibling: element.nextElementSibling,
+
+    // Watch React <Activity> / cacheComponents display toggles for this node for
+    // the rest of its life. The node is registered ONCE; subsequent OUT/IN come
+    // from these handlers (display:none flips), not from mount/unmount.
+    const vis = watchVisibility(element, {
+      onHide: () => handleHide(element, path),
+      onShow: () => handleShow(element, path),
+    });
+    const state: HiddenState = {
+      vis,
+      savedCss: null,
+      intent: vis.isHidden ? "hidden" : "visible",
+      visibleDisplay: "",
+      computedDisplay: "block",
     };
-    handleArrival(path, "in");
+    hiddenState.set(element, state);
+
+    // A node that mounts already hidden (e.g. an inactive Activity sibling) is
+    // not "entering" — set it up but don't fire an IN until React reveals it.
+    if (!vis.isHidden) {
+      captureVisibleDisplay(element, state);
+      initializeContext(element, path);
+      pendingIn = {
+        element,
+        parent: element.parentElement,
+        nextSibling: element.nextElementSibling,
+      };
+      handleArrival(path, "in");
+    }
 
     watchUnmount(element, () => handleRemoval(element, path));
   };

--- a/packages/core/src/lib/ssgoi-transition/unmount-observer.test.ts
+++ b/packages/core/src/lib/ssgoi-transition/unmount-observer.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The shared unmount-observer must fire a node's leave callback ONLY on a real
+ * unmount — never on a MOVE. A `childList` "removed" record also fires when a
+ * node is detached and re-attached within one commit (e.g. Next.js reordering
+ * its bfcache `<Activity>` siblings on back/forward navigation). Firing on a
+ * move would tear down a kept-alive page's tracking and break later
+ * transitions. The package test env is `node`, so we fake the slice the module
+ * touches: HTMLElement, a MutationObserver whose records we dispatch by hand,
+ * and a minimal document.
+ */
+
+class FakeNode {
+  childNodes: FakeNode[] = [];
+  isConnected = false;
+}
+
+let observerCb: ((mutations: unknown[]) => void) | null = null;
+
+class FakeMutationObserver {
+  constructor(cb: (mutations: unknown[]) => void) {
+    observerCb = cb;
+  }
+  observe(): void {}
+  disconnect(): void {}
+  takeRecords(): unknown[] {
+    return [];
+  }
+}
+
+function fireRemoval(node: FakeNode): void {
+  observerCb?.([{ removedNodes: [node] }]);
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  vi.stubGlobal("HTMLElement", FakeNode);
+  vi.stubGlobal("Node", FakeNode);
+  vi.stubGlobal("MutationObserver", FakeMutationObserver);
+  vi.stubGlobal("document", {
+    body: new FakeNode(),
+    addEventListener() {},
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("watchUnmount", () => {
+  it("fires the leave callback on a real unmount (node stays detached)", async () => {
+    const { watchUnmount } = await import("./unmount-observer");
+    const node = new FakeNode();
+    node.isConnected = false;
+    const cb = vi.fn();
+    watchUnmount(node as unknown as HTMLElement, cb);
+
+    fireRemoval(node);
+    await flushMicrotasks();
+
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT fire on a MOVE (node reattached -> isConnected), and keeps watching", async () => {
+    const { watchUnmount } = await import("./unmount-observer");
+    const node = new FakeNode();
+    node.isConnected = true; // re-inserted within the same commit (a reorder)
+    const cb = vi.fn();
+    watchUnmount(node as unknown as HTMLElement, cb);
+
+    fireRemoval(node);
+    await flushMicrotasks();
+    expect(cb).not.toHaveBeenCalled();
+
+    // The watch must survive the move: a later REAL removal still fires.
+    node.isConnected = false;
+    fireRemoval(node);
+    await flushMicrotasks();
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops firing after the returned disposer runs", async () => {
+    const { watchUnmount } = await import("./unmount-observer");
+    const node = new FakeNode();
+    node.isConnected = false;
+    const cb = vi.fn();
+    const dispose = watchUnmount(node as unknown as HTMLElement, cb);
+
+    dispose();
+    fireRemoval(node);
+    await flushMicrotasks();
+    expect(cb).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/lib/ssgoi-transition/unmount-observer.ts
+++ b/packages/core/src/lib/ssgoi-transition/unmount-observer.ts
@@ -19,7 +19,15 @@ let sharedObserver: MutationObserver | null = null;
 let initialized = false;
 
 function checkRemovedSubtree(node: Node): void {
-  if (node instanceof HTMLElement && watched.has(node)) {
+  // A childList "removed" record also fires when a node is MOVED (removed then
+  // re-inserted within the same commit) — e.g. Next.js reorders its bfcache
+  // `<Activity>` siblings on back/forward navigation, so React detaches and
+  // reattaches a kept-alive page's DOM node. By the time this observer callback
+  // runs the move is already complete, so `isConnected` distinguishes a real
+  // unmount (still detached) from a reorder (already reattached). Only a true
+  // unmount may fire the leave callback; a moved node keeps its watch, otherwise
+  // its visibility tracking would be torn down and later transitions break.
+  if (node instanceof HTMLElement && watched.has(node) && !node.isConnected) {
     const cb = watched.get(node)!;
     watched.delete(node);
     // Defer to microtask so we never mutate the DOM inside the observer

--- a/packages/core/src/lib/ssgoi-transition/visibility-observer.test.ts
+++ b/packages/core/src/lib/ssgoi-transition/visibility-observer.test.ts
@@ -1,0 +1,265 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { watchVisibility } from "./visibility-observer";
+
+/**
+ * The visibility-observer's whole job is to surface ONLY React-driven
+ * display:none hide/show edges while swallowing our own display writes (the
+ * reveal/re-hide we do to animate the outgoing page) and the opacity/transform
+ * writes every transition makes. These tests pin that filter.
+ *
+ * The package test env is `node` (no DOM), so we fake exactly the slice the
+ * module touches: a `style` with display get/set/priority/remove, and a
+ * MutationObserver whose records we dispatch by hand. React's writes are modeled
+ * the way they are actually observed: a hide is `display:none !important`, a
+ * reveal is a plain `display:<value>` (no priority).
+ */
+
+let lastObserverCb: MutationCallback | null = null;
+
+class FakeMutationObserver {
+  constructor(cb: MutationCallback) {
+    lastObserverCb = cb;
+  }
+  observe(): void {}
+  disconnect(): void {}
+  takeRecords(): MutationRecord[] {
+    return [];
+  }
+}
+
+type FakeEl = HTMLElement & { __display: string; __priority: string };
+
+function makeEl(initialDisplay = ""): FakeEl {
+  const el = {
+    __display: initialDisplay,
+    __priority: "",
+  } as FakeEl;
+  (el as { style: unknown }).style = {
+    getPropertyValue: (prop: string) =>
+      prop === "display" ? el.__display : "",
+    getPropertyPriority: (prop: string) =>
+      prop === "display" ? el.__priority : "",
+    setProperty: (prop: string, value: string, priority?: string) => {
+      if (prop !== "display") return;
+      el.__display = value;
+      el.__priority = priority === "important" ? "important" : "";
+    },
+    removeProperty: (prop: string) => {
+      if (prop !== "display") return;
+      el.__display = "";
+      el.__priority = "";
+    },
+  };
+  return el;
+}
+
+/** Simulate React's hide: display:none !important. */
+function reactHide(el: FakeEl): void {
+  el.__display = "none";
+  el.__priority = "important";
+}
+
+/** Simulate React's reveal: a plain `display:<value>` with no priority. */
+function reactShow(el: FakeEl, value = "flex"): void {
+  el.__display = value;
+  el.__priority = "";
+}
+
+/** Flush the observer as if the element's `style` attribute mutated. */
+function flush(el: FakeEl): void {
+  lastObserverCb?.(
+    [{ target: el } as unknown as MutationRecord],
+    {} as MutationObserver,
+  );
+}
+
+beforeEach(() => {
+  vi.stubGlobal("MutationObserver", FakeMutationObserver);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("watchVisibility", () => {
+  it("fires onHide when React sets display:none !important", () => {
+    const el = makeEl("flex");
+    const onHide = vi.fn();
+    const onShow = vi.fn();
+    watchVisibility(el, { onHide, onShow });
+
+    reactHide(el);
+    flush(el);
+
+    expect(onHide).toHaveBeenCalledTimes(1);
+    expect(onShow).not.toHaveBeenCalled();
+  });
+
+  it("fires onShow when React reveals a hidden element", () => {
+    const el = makeEl("none");
+    el.__priority = "important"; // mounted hidden
+    const onHide = vi.fn();
+    const onShow = vi.fn();
+    watchVisibility(el, { onHide, onShow });
+
+    reactShow(el, "flex");
+    flush(el);
+
+    expect(onShow).toHaveBeenCalledTimes(1);
+    expect(onHide).not.toHaveBeenCalled();
+  });
+
+  it("ignores our own reveal write (setDisplay), so no feedback loop", () => {
+    const el = makeEl("flex");
+    const onHide = vi.fn();
+    const onShow = vi.fn();
+    const handle = watchVisibility(el, { onHide, onShow });
+
+    // React hides -> onHide (expected)
+    reactHide(el);
+    flush(el);
+    expect(onHide).toHaveBeenCalledTimes(1);
+
+    // We reveal the real node to animate it out. This must NOT read back as a
+    // React show.
+    handle.setDisplay("flex", true); // display:flex !important
+    flush(el);
+    expect(onShow).not.toHaveBeenCalled();
+  });
+
+  it("ignores our own re-hide write (setDisplay none)", () => {
+    const el = makeEl("flex");
+    const onHide = vi.fn();
+    const onShow = vi.fn();
+    const handle = watchVisibility(el, { onHide, onShow });
+
+    reactHide(el);
+    flush(el);
+    handle.setDisplay("flex", true); // reveal
+    flush(el);
+    onHide.mockClear();
+
+    // Settle: we re-hide the reused node ourselves.
+    handle.setDisplay("none", true);
+    flush(el);
+    expect(onHide).not.toHaveBeenCalled();
+    expect(onShow).not.toHaveBeenCalled();
+  });
+
+  it("still catches a React reveal that interrupts our out-animation", () => {
+    // The crux: while we hold the node visible with `!important`, React decides
+    // to show it again (user navigated back). React's plain `display:` differs
+    // from our `!important` string, so the edge is still observable.
+    const el = makeEl("flex");
+    const onHide = vi.fn();
+    const onShow = vi.fn();
+    const handle = watchVisibility(el, { onHide, onShow });
+
+    reactHide(el);
+    flush(el); // onHide
+    handle.setDisplay("flex", true); // our reveal: flex !important
+    flush(el); // ignored
+    onShow.mockClear();
+    onHide.mockClear();
+
+    reactShow(el, "flex"); // React reveal: flex (no priority)
+    flush(el);
+    expect(onShow).toHaveBeenCalledTimes(1);
+    expect(onHide).not.toHaveBeenCalled();
+  });
+
+  it("ignores non-display style mutations (opacity/transform writes)", () => {
+    const el = makeEl("flex");
+    const onHide = vi.fn();
+    const onShow = vi.fn();
+    watchVisibility(el, { onHide, onShow });
+
+    // A transition writes opacity/transform — display is unchanged. Flushing a
+    // style mutation must not classify it as an edge.
+    flush(el);
+    expect(onHide).not.toHaveBeenCalled();
+    expect(onShow).not.toHaveBeenCalled();
+  });
+
+  it("sync() adopts an out-of-band display write without firing", () => {
+    // After restoring cssText (a non-setDisplay channel) the caller calls
+    // sync() so the resulting mutation is not mistaken for a React edge.
+    const el = makeEl("flex");
+    const onHide = vi.fn();
+    const onShow = vi.fn();
+    const handle = watchVisibility(el, { onHide, onShow });
+
+    // cssText restore lands display:none !important directly on the style.
+    el.__display = "none";
+    el.__priority = "important";
+    handle.sync();
+    flush(el);
+    expect(onHide).not.toHaveBeenCalled();
+  });
+
+  it("tracks a full hide -> reveal -> settle -> hide-again cycle", () => {
+    const el = makeEl("flex");
+    const onHide = vi.fn();
+    const onShow = vi.fn();
+    const handle = watchVisibility(el, { onHide, onShow });
+
+    // 1. React hides (nav away)
+    reactHide(el);
+    flush(el);
+    expect(onHide).toHaveBeenCalledTimes(1);
+
+    // 2. We reveal to animate out
+    handle.setDisplay("flex", true);
+    flush(el);
+
+    // 3. We settle: re-hide
+    handle.setDisplay("none", true);
+    flush(el);
+
+    // 4. React reveals (nav back) — must fire onShow
+    reactShow(el, "flex");
+    flush(el);
+    expect(onShow).toHaveBeenCalledTimes(1);
+
+    // 5. React hides again (nav away again) — must fire onHide again
+    reactHide(el);
+    flush(el);
+    expect(onHide).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores a plain display:none (only React's !important signature triggers)", () => {
+    // An app's own conditional `display:none` on a page boundary must NOT be
+    // hijacked into a hidden-mode OUT.
+    const el = makeEl("flex");
+    const onHide = vi.fn();
+    const onShow = vi.fn();
+    watchVisibility(el, { onHide, onShow });
+
+    el.__display = "none"; // plain, no priority
+    el.__priority = "";
+    flush(el);
+    expect(onHide).not.toHaveBeenCalled();
+    expect(onShow).not.toHaveBeenCalled();
+  });
+
+  it("does not fire onShow without a prior React hide (reactHidden latch)", () => {
+    const el = makeEl("flex");
+    const onHide = vi.fn();
+    const onShow = vi.fn();
+    watchVisibility(el, { onHide, onShow });
+
+    // A visible->visible display change (e.g. flex->block) is not a reveal.
+    el.__display = "block";
+    el.__priority = "";
+    flush(el);
+    expect(onShow).not.toHaveBeenCalled();
+  });
+
+  it("isHidden reflects the live inline display", () => {
+    const el = makeEl("flex");
+    const handle = watchVisibility(el, { onHide: vi.fn(), onShow: vi.fn() });
+    expect(handle.isHidden).toBe(false);
+    reactHide(el);
+    expect(handle.isHidden).toBe(true);
+  });
+});

--- a/packages/core/src/lib/ssgoi-transition/visibility-observer.ts
+++ b/packages/core/src/lib/ssgoi-transition/visibility-observer.ts
@@ -1,0 +1,162 @@
+/**
+ * Visibility observer — detects React `<Activity>` / Next `cacheComponents`
+ * hide/show of a registered page element.
+ *
+ * React's `<Activity mode="hidden">` does NOT unmount or wrap its children. It
+ * hides the subtree by writing, on the inline style of the TOP-MOST host node
+ * of that subtree:
+ *
+ *     topHostNode.style.setProperty("display", "none", "important")
+ *
+ * and reveals it again with `topHostNode.style.display = ""` (or the declared
+ * `style.display` prop value — always WITHOUT priority). There is no wrapper
+ * element and no `data-*` marker. (Verified against react-dom 19.2
+ * `ReactFiberConfigDOM.js` `hideInstance` / `unhideInstance`.) So the ONLY
+ * observable signal is a mutation of the element's `style` attribute whose
+ * `display` flips to / from `none`.
+ *
+ * Two design points make the detection robust:
+ *
+ *  1. The hide edge is gated on the EXACT React signature `display:none
+ *     !important`. A plain `display:none` (an app's own CSS-in-JS / conditional
+ *     style on a page boundary) is deliberately ignored — otherwise every
+ *     unrelated `display:none` would be hijacked into a bogus hidden-mode OUT.
+ *     React's reveal is plain `display:<value>`, which we tell apart from our
+ *     own reveal because we always write the override WITH `!important`.
+ *
+ *  2. Decisions key on the `display` VALUE only, and on a per-element
+ *     "accounted" value. A style mutation whose display equals the accounted
+ *     value (our own reveal/re-hide write, or a transition's opacity/transform
+ *     write that left display untouched) is ignored. Only React's writes — which
+ *     we did not account — surface as `onHide` / `onShow` edges. A `reactHidden`
+ *     latch ensures `onShow` only fires for a node we previously saw React hide.
+ */
+
+export type VisibilityHandlers = {
+  /** React drove this element to `display:none !important`. */
+  onHide: () => void;
+  /** React drove this element from its hidden state back to a visible display. */
+  onShow: () => void;
+};
+
+export type VisibilityHandle = {
+  /** Whether the element is currently React-hidden (`display:none !important`). */
+  readonly isHidden: boolean;
+  /**
+   * Write `display` as a LIBRARY-owned change that the observer will ignore.
+   * Pass `null` to remove the inline `display` property entirely. `important`
+   * defaults to false; pass `true` when overriding React's
+   * `display:none !important`.
+   */
+  setDisplay(value: string | null, important?: boolean): void;
+  /**
+   * Re-read the element's current `display` and accept it as the accounted
+   * value WITHOUT firing `onHide` / `onShow`. Call this after writing the
+   * element's style through a channel other than `setDisplay` (e.g. restoring
+   * `cssText`) so the resulting style mutation is not mistaken for a React edge.
+   */
+  sync(): void;
+  /** Stop reacting to this element's style mutations. */
+  stop(): void;
+};
+
+type Rec = {
+  accounted: string;
+  reactHidden: boolean;
+  onHide: () => void;
+  onShow: () => void;
+};
+
+// One shared observer watches every registered element's `style` attribute.
+// MutationObserver holds its observed nodes weakly, so a page element that React
+// removes is still GC-able even though there is no per-target `unobserve` —
+// `stop()` simply drops dispatch by deleting the record.
+const records = new WeakMap<HTMLElement, Rec>();
+let sharedObserver: MutationObserver | null = null;
+
+const HIDDEN = "none !important";
+
+function readDisplay(el: HTMLElement): string {
+  const value = el.style.getPropertyValue("display");
+  const priority = el.style.getPropertyPriority("display");
+  return priority ? `${value} !important` : value;
+}
+
+function ensureObserver(): MutationObserver {
+  if (sharedObserver) return sharedObserver;
+  sharedObserver = new MutationObserver((mutations) => {
+    for (const m of mutations) {
+      const el = m.target as HTMLElement;
+      const rec = records.get(el);
+      if (!rec) continue;
+      const current = readDisplay(el);
+      // Equal to what we last accounted -> our own write, a redundant write, or
+      // a non-display style change. Not a React intent edge.
+      if (current === rec.accounted) continue;
+      rec.accounted = current;
+      if (current === HIDDEN) {
+        // React Activity hide signature. (A plain `display:none` is some other
+        // code's doing — ignore it so we never hijack it into a hidden-mode OUT.)
+        rec.reactHidden = true;
+        rec.onHide();
+      } else if (current !== "none") {
+        // Became visible. Only meaningful if we previously saw React hide it.
+        if (rec.reactHidden) {
+          rec.reactHidden = false;
+          rec.onShow();
+        }
+      }
+    }
+  });
+  return sharedObserver;
+}
+
+/**
+ * Start watching `element` for React-driven `display:none !important` hide/show
+ * edges. Returns a handle that also lets the caller perform library-owned
+ * `display` writes the observer will not mistake for React edges.
+ */
+export function watchVisibility(
+  element: HTMLElement,
+  handlers: VisibilityHandlers,
+): VisibilityHandle {
+  const accounted = readDisplay(element);
+  const rec: Rec = {
+    accounted,
+    reactHidden: accounted === HIDDEN,
+    onHide: handlers.onHide,
+    onShow: handlers.onShow,
+  };
+  records.set(element, rec);
+
+  ensureObserver().observe(element, {
+    attributes: true,
+    attributeFilter: ["style"],
+  });
+
+  return {
+    get isHidden() {
+      return readDisplay(element) === HIDDEN;
+    },
+    setDisplay(value, important = false) {
+      if (value === null) {
+        element.style.removeProperty("display");
+      } else {
+        element.style.setProperty(
+          "display",
+          value,
+          important ? "important" : "",
+        );
+      }
+      // Pre-account our own write so the style mutation it produces is ignored.
+      rec.accounted = readDisplay(element);
+    },
+    sync() {
+      rec.accounted = readDisplay(element);
+      rec.reactHidden = rec.accounted === HIDDEN;
+    },
+    stop() {
+      records.delete(element);
+    },
+  };
+}

--- a/packages/core/src/lib/transitions/axis/transition.ts
+++ b/packages/core/src/lib/transitions/axis/transition.ts
@@ -32,6 +32,17 @@ function clearStyle(el: HTMLElement): void {
   el.style.clipPath = "";
 }
 
+// The outgoing (from) element is now the real, reused page node (React
+// Activity / Next cacheComponents) rather than a throwaway clone, so every
+// inline style we set on it must be cleared when the out animation completes —
+// otherwise the re-hidden node reappears stuck (invisible / translated /
+// non-interactive) on the next navigation. Mirrors `clearStyle` (the in-side
+// template) plus the out-only `pointerEvents` we set in `prepare`.
+function clearFromStyle(el: HTMLElement): void {
+  clearStyle(el);
+  el.style.pointerEvents = "";
+}
+
 export const axis = (options: AxisOptions = {}): TransitionConfig => {
   const direction = options.direction ?? "forward";
   const type = options.type ?? DEFAULT_TYPE;
@@ -65,12 +76,11 @@ export const axis = (options: AxisOptions = {}): TransitionConfig => {
         element: from,
         integrator: IntegratorProvider.from(provider.outPhysics),
         style: (t) => config.out.animate(t),
-        onComplete:
-          type === "z"
-            ? () => {
-                from.style.clipPath = "";
-              }
-            : undefined,
+        // Restore the reused from node's inline styles on complete. This
+        // covers willChange/backfaceVisibility/contain/transform/opacity (from
+        // applyStartStyle + the WAAPI final frame), pointerEvents (set in
+        // prepare), and clipPath (set above for z; harmless no-op otherwise).
+        onComplete: () => clearFromStyle(from),
       });
 
       const inAnim = new WebAnimation({

--- a/packages/core/src/lib/transitions/blind/transition.ts
+++ b/packages/core/src/lib/transitions/blind/transition.ts
@@ -84,6 +84,8 @@ function makeBlinds(
 }
 
 type BlindExtras = {
+  // Threaded through so the OUT cleanup can reach the reused `from` node.
+  fromEl: HTMLElement;
   fromBlinds: HTMLDivElement[];
   fromContainer: HTMLDivElement;
   toBlinds: HTMLDivElement[];
@@ -122,13 +124,20 @@ export const blind = (
         "right",
       );
       return {
+        fromEl,
         fromBlinds: fromData.blinds,
         fromContainer: fromData.container,
         toBlinds: toData.blinds,
         toContainer: toData.container,
       };
     },
-    animation: ({ fromBlinds, fromContainer, toBlinds, toContainer }) => {
+    animation: ({
+      fromEl,
+      fromBlinds,
+      fromContainer,
+      toBlinds,
+      toContainer,
+    }) => {
       // OUT: each blind grows in (t: 0 → 1). IN: each blind shrinks out
       // (`u`: 1 → 0). Default (0, 1) bounds for both.
       const out: Animation[] = fromBlinds.map(
@@ -157,6 +166,14 @@ export const blind = (
                 ? () => {
                     toContainer.remove();
                     fromContainer.remove();
+                    // The OUT (`from`) element is the real, reused page node now
+                    // (React Activity / Next cacheComponents re-show it on the
+                    // next navigation), so strip the inline styles `prepare`
+                    // wrote — `zIndex` (set directly) and `position` (set by
+                    // `makeBlinds` when the host was `static`) — or they stick
+                    // and corrupt the page the next time it appears.
+                    fromEl.style.zIndex = "";
+                    fromEl.style.position = "";
                   }
                 : undefined,
           }),

--- a/packages/core/src/lib/transitions/drill/transition.ts
+++ b/packages/core/src/lib/transitions/drill/transition.ts
@@ -44,6 +44,19 @@ export const drill = (options: DrillOptions = {}): TransitionConfig => {
         element: from,
         integrator: IntegratorProvider.from(physicsOptions),
         style: (t) => config.out.animate(t),
+        // The outgoing node is the real, reused element (re-hidden on navigate),
+        // so clear every inline style we set on it — mirroring the `to` cleanup,
+        // plus the out-only `pointerEvents` / `zIndex`.
+        onComplete: () => {
+          from.style.willChange = "auto";
+          from.style.backfaceVisibility = "";
+          (from.style as CSSStyleDeclaration & { contain: string }).contain =
+            "";
+          from.style.transform = "";
+          from.style.opacity = "";
+          from.style.pointerEvents = "";
+          from.style.zIndex = "";
+        },
       });
 
       const inAnim = new WebAnimation({

--- a/packages/core/src/lib/transitions/fade/transition.ts
+++ b/packages/core/src/lib/transitions/fade/transition.ts
@@ -38,7 +38,12 @@ export const fade = (options: FadeOptions = {}): TransitionConfig => {
         // forward, mapping opacity from fully visible to invisible.
         style: (_t, u) => ({ opacity: u }),
         onComplete: () => {
+          // The outgoing node is the real page and gets reused (re-hidden,
+          // shown again next navigation), so clear every inline style we
+          // wrote — willChange and the final opacity:0 frame — exactly like
+          // the incoming cleanup below, or the page stays invisible.
           from.style.willChange = "auto";
+          from.style.opacity = "";
         },
       });
 

--- a/packages/core/src/lib/transitions/film/transition.ts
+++ b/packages/core/src/lib/transitions/film/transition.ts
@@ -467,8 +467,13 @@ export const film = (
           transform: `translateY(${s.translateY}px) scale(${s.scale})`,
         }),
         () => {
+          // The outgoing node is reused (re-hidden, shown on the next
+          // navigation), so every inline style this transition wrote to `from`
+          // must be reset here — mirroring the `to` cleanup below — or the
+          // stale clip/origin/transform corrupts the page when it reappears.
           from.style.clipPath = "";
           from.style.transformOrigin = "";
+          from.style.transform = "";
         },
       );
 

--- a/packages/core/src/lib/transitions/hero/provider/chrome/static.ts
+++ b/packages/core/src/lib/transitions/hero/provider/chrome/static.ts
@@ -1,4 +1,9 @@
-import type { HeroPrepareCtx, HeroStrategy } from "../../types";
+import type { Animation } from "../../../../animation";
+import type {
+  HeroContributeCtx,
+  HeroPrepareCtx,
+  HeroStrategy,
+} from "../../types";
 
 /**
  * Chrome handling for `type: "static"`.
@@ -10,10 +15,24 @@ import type { HeroPrepareCtx, HeroStrategy } from "../../types";
  * Equivalent to v5/v6 hero default behavior.
  */
 class SnapHideChromeStrategy implements HeroStrategy {
+  private previousFromOpacity = "";
+
   prepare(ctx: HeroPrepareCtx): void {
     ctx.from.then((el) => {
+      this.previousFromOpacity = el.style.opacity;
       el.style.opacity = "0";
     });
+  }
+
+  contribute(ctx: HeroContributeCtx): Animation[] {
+    // `from` is the real outgoing node and gets re-shown on the next
+    // navigation (React Activity / Next cacheComponents), so restore the
+    // opacity we snapped to "0" in `prepare` — otherwise the reused page
+    // stays invisible.
+    ctx.onComplete(() => {
+      ctx.from.style.opacity = this.previousFromOpacity;
+    });
+    return [];
   }
 }
 

--- a/packages/core/src/lib/transitions/jaemin/transition.ts
+++ b/packages/core/src/lib/transitions/jaemin/transition.ts
@@ -69,6 +69,13 @@ export const jaemin = (options: JaeminOptions = {}): TransitionConfig => {
         element: from,
         integrator: IntegratorProvider.from(OUT_PHYSICS),
         style: (_t, u) => ({ opacity: u }),
+        // The outgoing node is reused (re-hidden, shown again on the next
+        // navigation), so reset every inline style we wrote to it — mirroring
+        // the "to" cleanup below. prepare sets opacity and the out style fades
+        // it toward 0, so clear opacity or the reused node stays invisible.
+        onComplete: () => {
+          from.style.opacity = "";
+        },
       });
 
       const inAnim = new WebAnimation({

--- a/packages/core/src/lib/transitions/rotate/transition.ts
+++ b/packages/core/src/lib/transitions/rotate/transition.ts
@@ -37,6 +37,15 @@ export const rotate = (options: RotateOptions = {}): TransitionConfig => {
           transform: `rotate(${t * 180}deg)`,
           opacity: t < 0.5 ? 1 : 0,
         }),
+        // The outgoing node is reused (re-hidden, shown again on the next
+        // navigation), so clear every inline style we wrote to `from`
+        // (prepare + the final WAAPI frame), mirroring the `to` cleanup.
+        onComplete: () => {
+          from.style.willChange = "auto";
+          from.style.transform = "";
+          from.style.transformOrigin = "";
+          from.style.opacity = "";
+        },
       });
 
       const inAnim = new WebAnimation({

--- a/packages/core/src/lib/transitions/scroll/transition.ts
+++ b/packages/core/src/lib/transitions/scroll/transition.ts
@@ -56,6 +56,20 @@ export const scroll = (options: ScrollOptions = {}): TransitionConfig => {
           const translateY = isUp ? -height * t : height * t;
           return { transform: `translate3d(0, ${translateY}px, 0)` };
         },
+        // The outgoing node is the real, reused element (re-hidden then shown
+        // again on the next navigation), so mirror the incoming cleanup and
+        // also reset the out-only props applied in prepare (zIndex,
+        // pointerEvents) — otherwise the leftover inline styles corrupt the
+        // page the next time it appears.
+        onComplete: () => {
+          from.style.willChange = "auto";
+          from.style.backfaceVisibility = "";
+          (from.style as CSSStyleDeclaration & { contain: string }).contain =
+            "";
+          from.style.transform = "";
+          from.style.pointerEvents = "";
+          from.style.zIndex = "";
+        },
       });
 
       const inAnim = new WebAnimation({

--- a/packages/core/src/lib/transitions/sheet/transition.ts
+++ b/packages/core/src/lib/transitions/sheet/transition.ts
@@ -62,6 +62,17 @@ export const sheet = (options: SheetOptions = {}): TransitionConfig => {
         direction === "enter" ? "to" : "from",
       );
 
+      // The outgoing (`from`) node is now reused across navigations (it is
+      // re-hidden with display:none and shown again next time), so any inline
+      // style we leave on it would corrupt the page when it reappears. Reset
+      // the `from`-only prepare props that the per-element onComplete below
+      // does not already clear (the `to`-side cleanup is the template). For
+      // `enter` the `from` is the background; for `exit` it is the sheet.
+      const resetFromInteractionProps = () => {
+        from.style.pointerEvents = "";
+        from.style.zIndex = "";
+      };
+
       // Clip the moving sheet to its visible viewport slice — without this it
       // can paint outside the chrome (top nav / player bar) during translate.
       sheetEl.style.clipPath = `inset(${sheetRect.top}px 0 calc(100% - ${sheetRect.top + sheetRect.height}px) 0)`;
@@ -86,6 +97,11 @@ export const sheet = (options: SheetOptions = {}): TransitionConfig => {
             "";
           sheetEl.style.clipPath = "";
           sheetEl.style.transform = "";
+          // The sheet animation always settles, so use it to clear the
+          // pointerEvents/zIndex that prepare put on the reused `from` node
+          // (the sheet itself on `exit`, the background on `enter`). The rest
+          // of the `from` background props on `enter` are cleared by bgAnim.
+          resetFromInteractionProps();
         },
       });
 
@@ -112,6 +128,12 @@ export const sheet = (options: SheetOptions = {}): TransitionConfig => {
         element: backgroundEl,
         integrator: IntegratorProvider.from(physics),
         style: bgStyle,
+        // On `exit` the background is the incoming (`to`) node; on `enter` it is
+        // the reused outgoing (`from`) node — in both cases its inline styles
+        // must be restored when the animation settles, so the reused node is
+        // not left scaled/faded/clipped the next time it is shown. The `enter`
+        // branch mirrors the `exit` cleanup and additionally clears the
+        // transform/opacity final frame WAAPI leaves behind.
         onComplete:
           direction === "exit"
             ? () => {
@@ -125,7 +147,19 @@ export const sheet = (options: SheetOptions = {}): TransitionConfig => {
                 backgroundEl.style.clipPath = "";
                 backgroundEl.style.transformOrigin = "";
               }
-            : undefined,
+            : () => {
+                backgroundEl.style.willChange = "auto";
+                backgroundEl.style.backfaceVisibility = "";
+                (
+                  backgroundEl.style as CSSStyleDeclaration & {
+                    contain: string;
+                  }
+                ).contain = "";
+                backgroundEl.style.clipPath = "";
+                backgroundEl.style.transformOrigin = "";
+                backgroundEl.style.transform = "";
+                backgroundEl.style.opacity = "";
+              },
       });
 
       return new MultiAnimation([sheetAnim, bgAnim], { mode: "parallel" });

--- a/packages/core/src/lib/transitions/slide/transition.ts
+++ b/packages/core/src/lib/transitions/slide/transition.ts
@@ -48,6 +48,17 @@ export const slide = (options: SlideOptions = {}): TransitionConfig => {
           const translateX = isLeft ? -100 * t : 100 * t;
           return { transform: `translate3d(${translateX}%, 0, 0)` };
         },
+        // The outgoing node is the real Activity page and gets reused on the
+        // next navigation, so reset every inline style we wrote to it (mirror
+        // the incoming cleanup, plus the out-only pointerEvents).
+        onComplete: () => {
+          from.style.willChange = "auto";
+          from.style.backfaceVisibility = "";
+          (from.style as CSSStyleDeclaration & { contain: string }).contain =
+            "";
+          from.style.transform = "";
+          from.style.pointerEvents = "";
+        },
       });
 
       const inAnim = new WebAnimation({

--- a/packages/core/src/lib/transitions/strip/transition.ts
+++ b/packages/core/src/lib/transitions/strip/transition.ts
@@ -47,6 +47,17 @@ export const strip = (options: StripOptions = {}): TransitionConfig => {
             transform: `perspective(${PERSPECTIVE}px) rotateY(${rotate}deg) translate3d(${translateX}%, 0, 0)`,
           };
         },
+        // The outgoing node is reused (Activity/cacheComponents re-hide it),
+        // so restore every inline style we wrote to `from` — mirroring the
+        // incoming cleanup below, plus the out-only `pointerEvents`.
+        onComplete: () => {
+          from.style.transform = "";
+          from.style.willChange = "auto";
+          from.style.backfaceVisibility = "";
+          (from.style as CSSStyleDeclaration & { contain: string }).contain =
+            "";
+          from.style.pointerEvents = "";
+        },
       });
 
       const inAnim = new WebAnimation({

--- a/packages/core/src/lib/transitions/zoom/transition.ts
+++ b/packages/core/src/lib/transitions/zoom/transition.ts
@@ -176,6 +176,24 @@ class TileStrategy implements ZoomStrategy {
       tileEl.style.transformOrigin = "";
       (tileEl.style as CSSStyleDeclaration & { contain: string }).contain = "";
       from.style.zIndex = previousFromZIndex;
+      // `from` is the REAL outgoing page now (React <Activity> / Next
+      // cacheComponents re-hide and reuse this node on the next nav), so any
+      // inline style left on it persists and corrupts the page when it
+      // reappears. Mirror the tile-side (`to`) reset above for every prop the
+      // prepare hook / out animations write to `from`, regardless of mode:
+      //   - prepare(): willChange, backfaceVisibility, contain.
+      //   - background/tile out animations: transformOrigin (set here for the
+      //     `from`-owned config) plus the WAAPI forwards-fill final frame
+      //     (transform on the expand/blur background, transform + clipPath on
+      //     the exit-mode tile). When `tileEl === from` (exit) the resets
+      //     above already cover those props; the lines below make the cleanup
+      //     correct in enter mode too, where `tileEl === to`.
+      from.style.willChange = "auto";
+      from.style.backfaceVisibility = "";
+      from.style.transformOrigin = "";
+      (from.style as CSSStyleDeclaration & { contain: string }).contain = "";
+      from.style.transform = "";
+      from.style.clipPath = "";
     });
 
     return [


### PR DESCRIPTION
## Summary

Page transitions now run for **React `<Activity>`** and **Next.js `cacheComponents`**, where the previous route is kept **mounted** and merely hidden with `display:none` instead of being unmounted. The outgoing page animates out on its **real node** (state preserved), and repeated/interrupted back-and-forth navigation stays correct.

This is a ground-up reimplementation of the earlier attempt on this branch — the core was reset to `latest` and rebuilt after studying the real React 19.2 / Next 16 source.

## The problem

ssgoi detected a page leaving **only via DOM unmount** (a shared `MutationObserver` watching removed nodes). But `<Activity mode="hidden">` / `cacheComponents` keep the route in the DOM and hide it with `display:none !important` to preserve its state. So nothing unmounted → no out/in pair formed → transitions never ran on cached navigation. And the previous attempt broke under **repeated A↔B navigation** ("transition works, then doesn't").

## How React `<Activity>` actually behaves (verified against react-dom 19.2)

- No wrapper element, no `data-*` marker. Hiding sets `style.setProperty("display","none","important")` on the **top-most host node** of the subtree (`hideInstance`). Revealing sets a **plain** `display:<value>` (`unhideInstance`).
- DOM + component state are preserved while hidden; only layout/passive effects detach.
- Next App Router (`cacheComponents`) wraps each cached segment in `<Activity mode={active?'visible':'hidden'}>`, keeping the prior page as a `display:none` sibling and flipping it back on return.

So the only observable signal is a `style`-attribute mutation whose `display` flips to/from `none !important`.

## Design — three pillars

**1. Visibility detection without feedback loops** (`visibility-observer.ts`)
A shared `MutationObserver` watches each boundary's `style`. It:
- fires `onHide` **only** on the exact React signature `display:none !important` — an app's own plain `display:none` is never hijacked into a bogus transition;
- keys every decision on the `display` **value** vs a per-element *accounted* value, so our own reveal/re-hide writes and the transition's `opacity`/`transform` writes never re-trigger it;
- writes our reveal **with `!important`**, keeping it observably distinct from React's plain reveal — so a React reveal that interrupts an in-flight out-animation is still caught.

**2. Real-node reuse — no clone** (`create-ssgoi-transition-context.ts`)
Unmount mode clones the outgoing node (the real one is being destroyed). Hidden mode reuses the **real node**: on hide we snapshot its inline `cssText`, reveal it (override `display` + take it out of flow), and animate the real node out. This preserves live page state **and** keeps motion continuous across interrupts — the pose handoff (`matchInto`) keys on **element identity**, which a fresh clone per navigation can never provide. On settle, the node is re-hidden (`display:none`) instead of removed, and every inline style the transition leaked onto it is wiped via the `cssText` snapshot.

**3. Ownership-epoch reconciliation — correctness under interruption**
Every hidden-mode run stamps the real nodes it drives with a monotonic epoch. On settle a run only reconciles a node it **still owns**, so when a follow-up navigation re-claims the same nodes mid-flight (A: OUT→IN, B: IN→OUT) the interrupted run's cleanup is skipped and the live run owns the final resting state. Nothing is left vanished, stuck-hidden, or non-interactive.

## Why repeated back-and-forth used to break

Two distinct causes, both fixed:

1. **React commits the same hide twice** for an Activity (a follow-up re-commit). The second `onHide` enqueued a second OUT into the navigation detector, whose stale pending entry then mis-paired the *next* navigation as a same-path pair and swallowed the real IN — so the next transition silently never ran. Fixed by **intent-based idempotency**: a redundant same-intent edge re-applies the reveal but does not start a second transition (a real navigation always flips intent, so it is never deduped).

2. **A bfcache reorder is not an unmount** (the one that made the docs showcases vanish from the *second* navigation on). Next orders its kept-alive `<Activity>` siblings most-recently-active first, so navigating **back** to a cached page reorders them and React **moves** that page's DOM node — detaching and reattaching it within one commit. The shared `unmount-observer` (a `childList` MutationObserver on `document.body`) saw the detach as an unmount and tore down the page's visibility tracking, so its transitions silently died. Fixed: `unmount-observer` now ignores a "removed" record whose node is still `isConnected` (a move), firing only on a true unmount. The standalone `<Activity>` demo never hit this because its DOM order is fixed — only Next's bfcache reorders.

## Transitions restore the outgoing node

Now that hidden mode **reuses** the real outgoing node (instead of discarding a clone), every built-in transition resets the inline styles it writes to `from` when its animation completes — mirroring the existing `to` cleanup, plus out-only props (`pointer-events`, `z-index`). Previously the outgoing page was a throwaway clone, so leaked styles never mattered; reused, they would stick (stuck transform, `opacity:0`, non-interactive) the next time the page appears. The context's `cssText` restore is the generic backstop; the per-transition cleanup makes each transition symmetric and correct on its own (e.g. for custom transitions).

## What's unchanged

The unmount/clone path (SPA frameworks, Next without `cacheComponents`) is byte-for-byte the baseline. The visibility watcher is inert unless `display` toggles to/from `none !important`.

## Verification

Driven headless (Chromium) end-to-end:
- **Standalone React `<Activity>`** (`apps/dev/activity`): initial state, single nav both ways, **state preservation** (input + click counters survive navigation), **4× rapid-interrupt stress** (7 toggles each well under the animation duration), and **interactivity after interrupts** (the visible page's counter still increments). All pass; no clones created, exactly one page visible at rest.
- **Real Next App Router + `cacheComponents`** (`apps/docs` gamja-market): a real route navigation shows the outgoing page animating out on the **real node** (`display:flex !important`, `position:absolute`, transform sliding) and settling to a clean hidden state (`display:none !important`, `position:static`, no transform). **Repeated back/forward navigation** (which reorders the bfcache) keeps exactly one page visible and tracking alive across many cycles.
- Unit tests for the visibility filter (`visibility-observer.test.ts`), plus the existing core suite — 26 tests pass.

The implementation was also run through an adversarial multi-agent review; confirmed findings (OUT→IN positioning normalization, plain-`display:none` false positives, dangling pending on same-tick eviction) are fixed in this PR.

## Known limitations / notes

- The `data-ssgoi-transition` boundary should be the **top-most host element** of the Activity subtree (verified true for the docs showcases). If a host element wraps it, React hides the wrapper and the observer won't see the edge — it degrades to *no transition*, never a crash.
- `apps/docs` enables `cacheComponents: true`, with the required `<Suspense>` boundary in `demo/layout.tsx` and the RSS route made dynamic (force-static is incompatible with `cacheComponents`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
