### PR TITLE
fix(core): client-space zoom tile measurement + WAAPI fill release

### DIFF
--- a/apps/docs/src/demo/air-bnb/page/home/listing-row.tsx
+++ b/apps/docs/src/demo/air-bnb/page/home/listing-row.tsx
@@ -1,5 +1,6 @@
 import { Link } from "@/lib/link";
 import { ChevronRight, Heart } from "lucide-react";
+import { DragScroller } from "@/lib/components/drag-scroller";
 import type { ListingSimple } from "@/demo/air-bnb/state/listing";
 
 export function ListingRow({
@@ -17,7 +18,7 @@ export function ListingRow({
         <h2 className="text-[20px] font-bold text-neutral-900">{title}</h2>
         <ChevronRight className="h-5 w-5 text-neutral-500" />
       </div>
-      <div className="scrollbar-hide flex gap-3 overflow-x-auto px-4 pt-3">
+      <DragScroller className="pt-3" trackClassName="gap-3 px-4">
         {loading
           ? Array.from({ length: 3 }).map((_, idx) => (
               <div
@@ -26,7 +27,7 @@ export function ListingRow({
               />
             ))
           : listings.map((l) => <RowCard key={l.id} listing={l} />)}
-      </div>
+      </DragScroller>
     </section>
   );
 }

--- a/apps/docs/src/lib/components/drag-scroller.tsx
+++ b/apps/docs/src/lib/components/drag-scroller.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import {
+  useEffect,
+  useRef,
+  type ComponentPropsWithoutRef,
+  type ReactNode,
+} from "react";
+import { cn } from "@/lib/utils";
+
+const FRICTION = 0.95; // decel per 16ms frame (pointer-flick momentum)
+const MIN_VELOCITY = 0.02; // px/ms — momentum stops below this
+const DRAG_THRESHOLD = 8; // px — move past this to be a "drag" (swallow click + capture); below = tap
+const LINE_HEIGHT = 16; // px, normalizes wheel deltaMode=line
+const KEY_STEP_RATIO = 0.8; // arrow key steps this fraction of the viewport width
+const CLICK_SWALLOW_MS = 350; // window after a drag in which the next click is swallowed
+
+type Props = ComponentPropsWithoutRef<"div"> & {
+  /** class for the track (the item row) — gap/padding etc. */
+  trackClassName?: string;
+  children: ReactNode;
+};
+
+/**
+ * translateX-based MANUAL horizontal scroller — mouse / trackpad / touch / keyboard.
+ *
+ * Why transform instead of native overflow:
+ *  - The position lives in the track's inline transform — not a layout-derived
+ *    value — so it isn't lost when the node is hidden. This docs app runs Next
+ *    `cacheComponents`, which wraps route segments in <Activity>: navigating away
+ *    (home → listing detail) hides the page with display:none rather than
+ *    unmounting it, so the node stays alive and the transform position is
+ *    preserved for free → no restore logic needed. (A native overflow scrollLeft
+ *    is React-invisible state that Activity can't keep, which is exactly why it
+ *    would need restoring.) The offset is applied imperatively, so re-renders
+ *    never clobber it.
+ *  - getBoundingClientRect reflects the transform, so ssgoi's zoom measures a
+ *    tile's true on-screen rect even when the row is scrolled — a card scrolled
+ *    out of its starting spot zooms from where it actually is.
+ *
+ * Re-implements what native gave for free: pointer drag + flick momentum (capture
+ * only past the threshold so taps still navigate; pointerId isolates multitouch;
+ * touch-action: pan-y yields vertical swipes to the page), wheel/trackpad
+ * (non-passive listener, deltaMode-normalized, consumes horizontal intent only),
+ * keyboard (←/→) + focus-into-view for a11y, and a ResizeObserver that re-clamps
+ * on size changes (skips display:none so the offset is preserved while hidden).
+ */
+export function DragScroller({
+  trackClassName,
+  children,
+  className,
+  ...rest
+}: Props) {
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const trackRef = useRef<HTMLDivElement>(null);
+
+  const offset = useRef(0); // current scroll amount (px); transform = translateX(-offset)
+  const vel = useRef(0); // px/ms (pointer momentum)
+  const max = useRef(0); // max scroll amount
+  const raf = useRef(0); // momentum rAF id
+  const dragging = useRef(false); // past threshold, actively dragging (= captured)
+  const start = useRef({ x: 0, off: 0, t: 0, pointerId: -1, pending: false });
+
+  const apply = () => {
+    const t = trackRef.current;
+    if (t) t.style.transform = `translate3d(${-offset.current}px,0,0)`;
+  };
+  const clamp = (v: number) => (v < 0 ? 0 : v > max.current ? max.current : v);
+  const computeMax = () => {
+    const vp = viewportRef.current;
+    const t = trackRef.current;
+    if (!vp || !t || !vp.clientWidth) return; // not rendered (display:none) → keep max so offset is preserved
+    max.current = Math.max(0, t.scrollWidth - vp.clientWidth);
+  };
+  const setOffset = (v: number) => {
+    offset.current = clamp(v);
+    apply();
+  };
+  const stopMomentum = () => {
+    if (raf.current) cancelAnimationFrame(raf.current);
+    raf.current = 0;
+  };
+  const momentum = () => {
+    let last = performance.now();
+    const step = (now: number) => {
+      const dt = now - last;
+      last = now;
+      if (Math.abs(vel.current) < MIN_VELOCITY) return void (raf.current = 0);
+      const next = clamp(offset.current + vel.current * dt);
+      if (next === offset.current)
+        return void ((vel.current = 0), (raf.current = 0)); // hit the edge
+      offset.current = next;
+      apply();
+      vel.current *= Math.pow(FRICTION, dt / 16); // framerate-independent decel
+      raf.current = requestAnimationFrame(step);
+    };
+    raf.current = requestAnimationFrame(step);
+  };
+
+  // Swallow the one click (a child <Link> nav) that fires right after a drag /
+  // momentum-stop. Auto-releases after 350ms. One-shot listener so the guard
+  // can't get stuck on pointercancel etc.
+  const swallowNextClick = () => {
+    const vp = viewportRef.current;
+    if (!vp) return;
+    let timer = 0;
+    const done = () => {
+      window.clearTimeout(timer);
+      vp.removeEventListener("click", swallow, true);
+    };
+    const swallow = (ev: MouseEvent) => {
+      ev.preventDefault();
+      ev.stopPropagation();
+      done();
+    };
+    vp.addEventListener("click", swallow, true);
+    timer = window.setTimeout(done, CLICK_SWALLOW_MS);
+  };
+
+  // ── pointer drag ──────────────────────────────────────────────
+  const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (e.button !== 0) return; // primary button / touch / pen only
+    if (dragging.current || start.current.pending) return; // another pointer owns it → multitouch isolation
+    const wasMoving = raf.current !== 0;
+    stopMomentum();
+    computeMax();
+    vel.current = 0;
+    dragging.current = false;
+    start.current = {
+      x: e.clientX,
+      off: offset.current,
+      t: performance.now(),
+      pointerId: e.pointerId,
+      pending: true,
+    };
+    if (wasMoving) swallowNextClick(); // tap during momentum = intent to stop, not navigate
+  };
+  const onPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    const s = start.current;
+    if (e.pointerId !== s.pointerId) return;
+    if (!s.pending && !dragging.current) return;
+    if (!dragging.current) {
+      if (Math.abs(e.clientX - s.x) < DRAG_THRESHOLD) return;
+      // capture only once past the threshold — so a tap still fires as a click
+      dragging.current = true;
+      s.pending = false;
+      s.x = e.clientX; // rebase to the current point to avoid a jump
+      s.off = offset.current;
+      s.t = performance.now();
+      viewportRef.current?.setPointerCapture(e.pointerId);
+      if (viewportRef.current) viewportRef.current.style.cursor = "grabbing";
+      return;
+    }
+    const now = performance.now();
+    const next = clamp(s.off - (e.clientX - s.x));
+    const dt = now - s.t;
+    if (dt > 0) vel.current = (next - offset.current) / dt;
+    offset.current = next;
+    apply();
+    s.t = now;
+  };
+  const onPointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
+    const s = start.current;
+    if (e.pointerId !== s.pointerId) return;
+    if (dragging.current) {
+      dragging.current = false;
+      viewportRef.current?.releasePointerCapture?.(e.pointerId);
+      if (viewportRef.current) viewportRef.current.style.cursor = "";
+      swallowNextClick(); // swallow the click that would navigate
+      if (Math.abs(vel.current) >= MIN_VELOCITY) momentum();
+    }
+    s.pending = false;
+    s.pointerId = -1;
+  };
+  const onPointerCancel = (e: React.PointerEvent<HTMLDivElement>) => {
+    const s = start.current;
+    if (e.pointerId !== s.pointerId) return;
+    // cancel doesn't produce a click, so no swallow — just release the guard.
+    dragging.current = false;
+    viewportRef.current?.releasePointerCapture?.(e.pointerId);
+    if (viewportRef.current) viewportRef.current.style.cursor = "";
+    s.pending = false;
+    s.pointerId = -1;
+  };
+
+  // ── keyboard (←/→) ────────────────────────────────────────────
+  const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+    const t = e.target as HTMLElement;
+    if (
+      t.tagName === "INPUT" ||
+      t.tagName === "TEXTAREA" ||
+      t.tagName === "SELECT" ||
+      t.isContentEditable
+    )
+      return;
+    const vp = viewportRef.current;
+    if (!vp) return;
+    e.preventDefault();
+    stopMomentum();
+    computeMax();
+    setOffset(
+      offset.current +
+        (e.key === "ArrowRight" ? 1 : -1) * vp.clientWidth * KEY_STEP_RATIO,
+    );
+  };
+
+  // ── focus-into-view (Tab onto an off-screen link) ─────────────
+  const onFocus = (e: React.FocusEvent<HTMLDivElement>) => {
+    const vp = viewportRef.current;
+    const t = trackRef.current;
+    const child = e.target as HTMLElement;
+    if (!vp || !t || !t.contains(child)) return;
+    computeMax();
+    const c = child.getBoundingClientRect();
+    const v = vp.getBoundingClientRect();
+    let delta = 0;
+    if (c.left < v.left)
+      delta = c.left - v.left; // off the left → move content right
+    else if (c.right > v.right) delta = c.right - v.right; // off the right → move content left
+    if (delta !== 0) setOffset(offset.current + delta);
+  };
+
+  // ── wheel/trackpad + resize: native (non-passive) listeners ───
+  useEffect(() => {
+    const vp = viewportRef.current;
+    if (!vp) return;
+
+    const onWheel = (e: WheelEvent) => {
+      const unit =
+        e.deltaMode === 1
+          ? LINE_HEIGHT
+          : e.deltaMode === 2
+            ? vp.clientWidth
+            : 1;
+      let dx = e.deltaX * unit;
+      let dy = e.deltaY * unit;
+      if (e.shiftKey && dx === 0) {
+        dx = dy; // shift+wheel → horizontal (when the browser doesn't translate it)
+        dy = 0;
+      }
+      if (Math.abs(dx) <= Math.abs(dy)) return; // vertical intent → let the page scroll
+      e.preventDefault(); // consume horizontal intent only
+      stopMomentum();
+      computeMax();
+      setOffset(offset.current + dx);
+    };
+    vp.addEventListener("wheel", onWheel, { passive: false });
+
+    const ro = new ResizeObserver(() => {
+      if (!vp.clientWidth) return; // display:none → keep the offset
+      computeMax();
+      setOffset(offset.current); // re-clamp to the new max
+    });
+    ro.observe(vp);
+    if (trackRef.current) ro.observe(trackRef.current);
+
+    return () => {
+      vp.removeEventListener("wheel", onWheel);
+      ro.disconnect();
+      stopMomentum();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div
+      ref={viewportRef}
+      className={cn(
+        "cursor-grab touch-pan-y select-none overflow-hidden overscroll-x-contain",
+        className,
+      )}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerCancel}
+      onKeyDown={onKeyDown}
+      onFocus={onFocus}
+      onDragStart={(e) => e.preventDefault()}
+      {...rest}
+    >
+      <div ref={trackRef} className={cn("flex w-max", trackClassName)}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/core",
-  "version": "6.5.0-beta.0",
+  "version": "6.5.0-beta.2",
   "description": "Core animation engine for SSGOI - Native app-like page transitions with spring physics",
   "private": false,
   "type": "module",

--- a/packages/core/src/lib/animation/web-animation.ts
+++ b/packages/core/src/lib/animation/web-animation.ts
@@ -111,6 +111,17 @@ export class WebAnimation extends Animation {
     this.onComplete?.();
   }
 
+  /**
+   * Drop the WAAPI forwards-fill after the run has settled, letting inline
+   * styles govern the resting visual. Call only from `onComplete` (the run is
+   * already finished) — otherwise it cancels mid-flight. Unlike `complete()`,
+   * it writes no final frame, so a caller can reset the element to its natural
+   * state without the lingering fill clobbering it.
+   */
+  releaseFill(): void {
+    this.clearWaapi();
+  }
+
   get isAnimating(): boolean {
     return this.running;
   }

--- a/packages/core/src/lib/transitions/zoom/transition.ts
+++ b/packages/core/src/lib/transitions/zoom/transition.ts
@@ -1,5 +1,5 @@
 import type { PhysicsOptions, TransitionConfig } from "@types";
-import { getRect } from "@utils";
+import { getClientRect } from "@utils";
 import {
   IntegratorProvider,
   MultiAnimation,
@@ -106,11 +106,11 @@ function buildInput(
   scrollOffset: { x: number; y: number },
 ): ZoomAnimationInput {
   return {
-    enterRect: getRect(
+    enterRect: getClientRect(
       resolved.mode === "enter" ? toNode : fromNode,
       resolved.enterEl,
     ),
-    exitRect: getRect(
+    exitRect: getClientRect(
       resolved.mode === "enter" ? fromNode : toNode,
       resolved.exitEl,
     ),
@@ -393,6 +393,24 @@ export const zoom = (
               console.error("[zoom] cleanup error", e);
             }
           }
+        };
+      }
+
+      // Release each animation's WAAPI forwards-fill once its OWN run settles,
+      // so the inline styles (cleared during playback, reset by the cleanups
+      // above) govern the resting visual instead of a lingering fill. Wrapped on
+      // each animation's own onComplete — which fires after its onfinish but
+      // before MultiAnimation's completion count — so every child is still
+      // counted as done. Without this the exit tile stays shrunk to the card and
+      // the background stays scaled; React <Activity> / Next cacheComponents then
+      // preserve that on the real node, so the NEXT transition measures (and
+      // renders) the page at the wrong size.
+      for (const anim of anims) {
+        if (!(anim instanceof WebAnimation)) continue;
+        const prev = anim.onComplete;
+        anim.onComplete = () => {
+          prev?.();
+          anim.releaseFill();
         };
       }
 

--- a/packages/core/src/lib/utils/get-client-rect.ts
+++ b/packages/core/src/lib/utils/get-client-rect.ts
@@ -1,0 +1,37 @@
+/**
+ * Viewport-accurate counterpart to {@link getRect}: `el`'s position relative to
+ * `root`, measured with getBoundingClientRect. Same `(root, el)` shape and
+ * meaning as `getRect`, but because gBCR is the on-screen box it REFLECTS any
+ * transform / nested-scroll BETWEEN `root` and `el` — e.g. a translate-based
+ * horizontal scroller — which is the position the zoom tile must animate from.
+ * `getRect` walks the offsetParent chain and ignores transforms, so the
+ * page-edge transitions (film, and sheet/jaemin/axis via getViewportRect) keep
+ * using it.
+ *
+ * Safety net: it also normalizes out any scale on `root` itself. The completion
+ * cleanup releases each animation's WAAPI fill, so a SETTLED page is back at its
+ * natural transform before the next transition measures it — but a page can
+ * still be mid-scale when measured by an INTERRUPTED transition (a back-tap
+ * before the previous one settles): `buildInput` runs before the orchestrator
+ * completes the prior transition, so the zoom background tween may still be
+ * scaling the page. gBCR is post-transform while `offsetWidth/Height` is the
+ * untransformed layout size, so their ratio is the live scale; dividing returns
+ * the rect in `root`'s layout space — the space the zoom translate operates in.
+ * An in-page translate (a scrolled row) is scaled by the same factor and so
+ * survives the division. (No-op when `root` is at scale 1.)
+ *
+ * Page-level scroll OUTSIDE `root` cancels in the `el − root` subtraction; the
+ * per-page scroll delta is reintroduced separately via context.scrollOffset.
+ */
+export function getClientRect(root: HTMLElement, el: HTMLElement): DOMRect {
+  const rootRect = root.getBoundingClientRect();
+  const elRect = el.getBoundingClientRect();
+  const sx = root.offsetWidth > 0 ? rootRect.width / root.offsetWidth : 1;
+  const sy = root.offsetHeight > 0 ? rootRect.height / root.offsetHeight : 1;
+  return new DOMRect(
+    (elRect.left - rootRect.left) / sx,
+    (elRect.top - rootRect.top) / sy,
+    elRect.width / sx,
+    elRect.height / sy,
+  );
+}

--- a/packages/core/src/lib/utils/index.ts
+++ b/packages/core/src/lib/utils/index.ts
@@ -3,6 +3,7 @@ export { getScrollingElement } from "./get-scrolling-element";
 export { getPositionedParent } from "./get-positioned-parent";
 export { sleep } from "./sleep";
 export { getRect } from "./get-rect";
+export { getClientRect } from "./get-client-rect";
 export { getViewportRect } from "./get-viewport-rect";
 export { round, floor, ceil, toFixed } from "./number";
 export { withResolvers } from "./with-resolvers";

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/react",
-  "version": "6.5.0-beta.0",
+  "version": "6.5.0-beta.2",
   "description": "React bindings for SSGOI - Native app-like page transitions for React applications",
   "private": false,
   "type": "module",


### PR DESCRIPTION
## Summary
Fixes zoom tile positioning when the source/target lives inside an in-page transform (a translate-based horizontal scroller), and a fill leak that broke zoom from the **2nd transition onward** under React `<Activity>` / Next `cacheComponents`. Adds a translate-based horizontal scroller to the air-bnb demo to exercise it. Ships `@ssgoi/core` + `@ssgoi/react` `6.5.0-beta.2`.

## Problem
1. **Mis-positioned tile.** `getRect` walks the `offsetParent` chain and ignores CSS transforms, so a card scrolled inside a horizontal row (or behind any in-page transform) was measured at its *unscrolled* layout position — the zoom tile animated from the wrong spot.
2. **Clip/scale "not applied" from the 2nd transition.** `WebAnimation` kept its WAAPI `fill: forwards` after settling. The outgoing zoom tile therefore stayed shrunk to the card (and the background stayed scaled). `<Activity>` / `cacheComponents` preserve the real DOM node, so the *next* transition measured **and rendered** the page at the wrong (shrunk) size.

## Root cause & fix (core)
- **Measurement** — new `getClientRect(root, el)`: `getBoundingClientRect`-based and page-relative, so in-page transforms / nested scroll are reflected. It also normalizes out any scale on the page root, so an *interrupted* transition that re-measures a mid-scaled page still resolves to layout space. `getRect` is left untouched — the page-edge transitions (film, and sheet/jaemin/axis via `getViewportRect`) rely on its transform-ignoring behavior. `context.scrollOffset` handling is unchanged (page-relative, single symmetric correction).
- **Fill leak** — add `WebAnimation.releaseFill()`; the zoom dispatcher releases each animation's WAAPI fill on its **own** completion (after `onfinish`, before `MultiAnimation`'s completion count, so every child is still counted as done). The inline resets then govern → a settled or `<Activity>`-preserved page returns to its natural transform.

## Demo (docs)
- air-bnb "Recently viewed" row: native `overflow-x` → `DragScroller` (imperative `translateX`; pointer drag + flick momentum, wheel/trackpad, keyboard, focus-into-view). The position lives in the node's inline transform, so it survives `<Activity>` `display:none` preservation without restore logic, and `getBoundingClientRect` reflects it so the zoom lands on the real on-screen card.

## Release
- `@ssgoi/core` and `@ssgoi/react` bumped to `6.5.0-beta.2`, published to the npm `beta` tag (`latest` untouched). `@ssgoi/react@6.5.0-beta.2` → `@ssgoi/core@^6.5.0-beta.2`.

## Test plan
- [x] `@ssgoi/core` build + unit tests (29 passing)
- [x] `apps/docs` typecheck (clean)
- [x] Manual (author): home → detail → home → detail — zoom lands on the tapped card, including after scrolling the row, and clip/scale apply on every transition (not just the first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
