### PR TITLE
feat(core): motion-matching pose protocol, keyframe compression, and interruption continuity

### DIFF
--- a/packages/core/src/lib/animation/capture-pose.test.ts
+++ b/packages/core/src/lib/animation/capture-pose.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it, vi } from "vitest";
+import { capturePoseFrom } from "./capture-pose";
+
+type FakeExternalAnimation = {
+  playState: AnimationPlayState;
+  currentTime: number | null;
+  playbackRate: number;
+  cancel: ReturnType<typeof vi.fn>;
+};
+
+const createFakeAnimation = (
+  currentTime: number,
+  playState: AnimationPlayState = "running",
+  playbackRate = 1,
+): FakeExternalAnimation => ({
+  playState,
+  currentTime,
+  playbackRate,
+  cancel: vi.fn(),
+});
+
+const createElementWithAnimations = (
+  animations: FakeExternalAnimation[],
+): HTMLElement =>
+  ({
+    getAnimations: () => animations as unknown as globalThis.Animation[],
+  }) as unknown as HTMLElement;
+
+describe("capturePoseFrom", () => {
+  it("returns null when the element has no running animations", () => {
+    const finished = createFakeAnimation(500, "finished");
+    expect(
+      capturePoseFrom(createElementWithAnimations([]), { read: () => 0 }),
+    ).toBeNull();
+    expect(
+      capturePoseFrom(createElementWithAnimations([finished]), {
+        read: () => 0,
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when getAnimations is unavailable", () => {
+    const element = {} as HTMLElement;
+    expect(capturePoseFrom(element, { read: () => 0 })).toBeNull();
+  });
+
+  it("captures value and estimates velocity by rewinding playback", () => {
+    const animation = createFakeAnimation(500);
+    const element = createElementWithAnimations([animation]);
+    // The external animation moves the value at 1 unit/sec: value = time/1000.
+    const read = () => (animation.currentTime ?? 0) / 1000;
+
+    const pose = capturePoseFrom(element, { read, key: "out" });
+
+    expect(pose).not.toBeNull();
+    expect(pose!.value).toBeCloseTo(0.5);
+    expect(pose!.velocity).toBeCloseTo(1);
+    expect(pose!.key).toBe("out");
+    expect(pose!.lowerBound).toBe(0);
+    expect(pose!.upperBound).toBe(1);
+    // Playback position must be restored.
+    expect(animation.currentTime).toBe(500);
+    expect(animation.cancel).not.toHaveBeenCalled();
+  });
+
+  it("inverts the velocity sign for reversed playback", () => {
+    // animation.reverse() → playbackRate -1: currentTime DECREASES over
+    // wall time, so the visual past lives at a LATER local time.
+    const animation = createFakeAnimation(500, "running", -1);
+    const element = createElementWithAnimations([animation]);
+    const read = () => (animation.currentTime ?? 0) / 1000;
+
+    const pose = capturePoseFrom(element, { read });
+
+    // On-screen value falls at 1 unit/sec.
+    expect(pose!.velocity).toBeCloseTo(-1);
+    expect(animation.currentTime).toBe(500);
+  });
+
+  it("scales velocity by the playback rate", () => {
+    const animation = createFakeAnimation(500, "running", 2);
+    const element = createElementWithAnimations([animation]);
+    const read = () => (animation.currentTime ?? 0) / 1000;
+
+    const pose = capturePoseFrom(element, { read });
+
+    // Local value moves 1 unit/local-sec; at rate 2 that is 2 units/wall-sec.
+    expect(pose!.velocity).toBeCloseTo(2);
+  });
+
+  it("treats rate-0 (frozen) animations as motionless", () => {
+    // playbackRate = 0 freezes playback but playState still reports
+    // "running" — sampling it would fake a velocity for a static element.
+    const animation = createFakeAnimation(500, "running", 0);
+    const element = createElementWithAnimations([animation]);
+    const pose = capturePoseFrom(element, { read: () => 0.5 });
+
+    expect(pose!.value).toBe(0.5);
+    expect(pose!.velocity).toBe(0);
+    expect(animation.currentTime).toBe(500);
+  });
+
+  it("skips future-scheduled animations (negative currentTime)", () => {
+    // A future startTime gives a negative currentTime while "running";
+    // seeking it forward would sample keyframes that were never on screen.
+    const scheduled = createFakeAnimation(-1000);
+    const element = createElementWithAnimations([scheduled]);
+    const pose = capturePoseFrom(element, { read: () => 0.5 });
+
+    expect(pose!.velocity).toBe(0);
+    expect(scheduled.currentTime).toBe(-1000);
+  });
+
+  it("uses the achievable rewind window near the animation start", () => {
+    const animation = createFakeAnimation(4);
+    const element = createElementWithAnimations([animation]);
+    const read = () => (animation.currentTime ?? 0) / 1000;
+
+    const pose = capturePoseFrom(element, { read, sampleMs: 8 });
+
+    // Only 4ms of rewind was possible — velocity still ~1 unit/sec.
+    expect(pose!.velocity).toBeCloseTo(1);
+    expect(animation.currentTime).toBe(4);
+  });
+
+  it("cancels the captured animations when asked", () => {
+    const animation = createFakeAnimation(500);
+    const element = createElementWithAnimations([animation]);
+    const pose = capturePoseFrom(element, {
+      read: () => 0.5,
+      cancel: true,
+    });
+    expect(pose).not.toBeNull();
+    expect(animation.cancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes custom bounds through to the pose", () => {
+    const animation = createFakeAnimation(500);
+    const element = createElementWithAnimations([animation]);
+    const pose = capturePoseFrom(element, {
+      read: () => 120,
+      lowerBound: 0,
+      upperBound: 240,
+    });
+    expect(pose!.lowerBound).toBe(0);
+    expect(pose!.upperBound).toBe(240);
+    expect(pose!.value).toBe(120);
+  });
+});

--- a/packages/core/src/lib/animation/capture-pose.ts
+++ b/packages/core/src/lib/animation/capture-pose.ts
@@ -1,0 +1,114 @@
+import type { Pose } from "@types";
+
+export type CapturePoseOptions = {
+  /**
+   * Read the element's current visual value from computed styles, in the
+   * same scale as `lowerBound`/`upperBound` (e.g. parse opacity for a 0→1
+   * fade). Called twice — once at the live playback position and once a few
+   * milliseconds rewound — to estimate velocity.
+   */
+  read: (element: HTMLElement) => number;
+  /** Bounds the read value lives in. @default 0 / 1 */
+  lowerBound?: number;
+  upperBound?: number;
+  /** Role/identity key to attach to the captured pose (see pose-matching). */
+  key?: string;
+  /**
+   * How far (ms) to rewind the running animations for the velocity sample.
+   * @default 8
+   */
+  sampleMs?: number;
+  /**
+   * Cancel the captured animations after sampling so they stop competing
+   * with the handoff target. @default false
+   */
+  cancel?: boolean;
+};
+
+const DEFAULT_SAMPLE_MS = 8;
+
+/**
+ * Capture a motion-matching `Pose` from animations ssgoi does NOT drive —
+ * CSS animations/transitions or WAAPI runs started by other code ("host"
+ * animations). Feed the result into `animation.matchInto([pose])` so a
+ * ssgoi transition takes over an in-flight external motion continuously
+ * instead of restarting from rest.
+ *
+ * Velocity is estimated by seeking every running animation to the local
+ * time that was on screen `sampleMs` of wall-clock ago (i.e. rewinding by
+ * `sampleMs × playbackRate`, which also handles reversed playback),
+ * re-reading the visual value, and restoring playback position — all
+ * synchronous within one task, so the visible playback never moves.
+ * Animations that contribute no live motion are excluded from the sample:
+ * rate-0 animations are visually frozen (yet still report playState
+ * "running"), and future-scheduled animations (negative currentTime) would
+ * be seeked forward into keyframe states that were never on screen. When an
+ * animation is too young to rewind the full window the largest achievable
+ * wall-clock window is used as the divisor, which can only under-estimate
+ * speed.
+ *
+ * Returns `null` when nothing is running on the element.
+ */
+export function capturePoseFrom(
+  element: HTMLElement,
+  options: CapturePoseOptions,
+): Pose | null {
+  if (typeof element.getAnimations !== "function") return null;
+  const running = element
+    .getAnimations()
+    .filter((animation) => animation.playState === "running");
+  if (running.length === 0) return null;
+
+  const value = options.read(element);
+  const sampleMs = options.sampleMs ?? DEFAULT_SAMPLE_MS;
+
+  const rewound: {
+    animation: globalThis.Animation;
+    time: number;
+    rate: number;
+  }[] = [];
+  let velocity = 0;
+  try {
+    for (const animation of running) {
+      const time = animation.currentTime;
+      const rate = animation.playbackRate;
+      if (typeof time !== "number" || time <= 0 || rate === 0) continue;
+      rewound.push({ animation, time, rate });
+      // The visual state `sampleMs` of wall-clock ago lives at local time
+      // `time - rate × sampleMs` — a reversed animation's past is at a
+      // LATER local time.
+      animation.currentTime = Math.max(0, time - rate * sampleMs);
+    }
+    if (rewound.length > 0) {
+      // Achieved wall-clock window per animation (the clamp above can
+      // shrink it near the start); divide by the largest so the estimate
+      // stays conservative.
+      const actualMs = Math.max(
+        ...rewound.map((r) =>
+          Math.abs((r.time - (r.animation.currentTime as number)) / r.rate),
+        ),
+      );
+      if (actualMs > 0) {
+        const earlier = options.read(element);
+        velocity = ((value - earlier) / actualMs) * 1000;
+      }
+    }
+  } finally {
+    for (const { animation, time } of rewound) {
+      animation.currentTime = time;
+    }
+  }
+
+  if (options.cancel) {
+    for (const animation of running) animation.cancel();
+  }
+
+  return {
+    element,
+    value,
+    velocity,
+    key: options.key,
+    lowerBound: options.lowerBound ?? 0,
+    upperBound: options.upperBound ?? 1,
+  };
+}

--- a/packages/core/src/lib/animation/host-animation.test.ts
+++ b/packages/core/src/lib/animation/host-animation.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import type { Pose, Timeline } from "@types";
+import { Animation } from "./animation";
+import { HostAnimation } from "./host-animation";
+
+class FakeAnimation extends Animation {
+  poses: Pose[];
+  received: Pose[][] = [];
+  playCount = 0;
+  reverseCount = 0;
+  pauseCount = 0;
+  completeCount = 0;
+
+  constructor(poses: Pose[] = []) {
+    super();
+    this.poses = poses;
+  }
+  play(): void {
+    this.playCount++;
+  }
+  reverse(): void {
+    this.reverseCount++;
+  }
+  pause(): void {
+    this.pauseCount++;
+  }
+  complete(): void {
+    this.completeCount++;
+    this.onComplete?.();
+  }
+  getPose(): Pose[] {
+    return this.poses;
+  }
+  getTimeline(): Timeline[] {
+    return [];
+  }
+  matchInto(poses: Pose[]): void {
+    this.received.push(poses);
+  }
+  get isAnimating(): boolean {
+    return false;
+  }
+  get isPaused(): boolean {
+    return false;
+  }
+  get isComplete(): boolean {
+    return this.completeCount > 0;
+  }
+  get isReversing(): boolean {
+    return false;
+  }
+  get progress(): number {
+    return 0;
+  }
+  findTimeForProgress(): number | null {
+    return null;
+  }
+}
+
+describe("HostAnimation.attach", () => {
+  it("plays the first attached animation without a handoff", () => {
+    const host = new HostAnimation();
+    const first = new FakeAnimation();
+    host.attach(first);
+    expect(first.playCount).toBe(1);
+    expect(first.received).toEqual([]);
+  });
+
+  it("hands the prior child's live pose to the next and completes it", () => {
+    const host = new HostAnimation();
+    const pose: Pose = {
+      element: {} as HTMLElement,
+      value: 0.7,
+      velocity: -2,
+      key: "out",
+    };
+    const first = new FakeAnimation([pose]);
+    const second = new FakeAnimation();
+
+    host.attach(first);
+    host.attach(second);
+
+    expect(first.completeCount).toBe(1);
+    expect(second.received).toEqual([[pose]]);
+    expect(second.playCount).toBe(1);
+    expect(host.activeChild).toBe(second);
+  });
+
+  it("carries the host playbackRate onto attached children", () => {
+    const host = new HostAnimation();
+    host.playbackRate = 2;
+    const child = new FakeAnimation();
+    host.attach(child);
+    expect(child.playbackRate).toBe(2);
+  });
+
+  it("keeps a paused host paused across a handoff", () => {
+    const host = new HostAnimation();
+    const first = new FakeAnimation();
+    host.attach(first);
+    host.pause();
+    const second = new FakeAnimation();
+    host.attach(second);
+    expect(second.pauseCount).toBe(1);
+    expect(second.playCount).toBe(0);
+  });
+
+  it("supports a two-step flush → attach handoff", () => {
+    // The dispatcher flushes the interrupted run BEFORE building the next
+    // animation (so the settled run's style cleanups land first), then
+    // hands the captured poses to attach.
+    const host = new HostAnimation();
+    const pose: Pose = {
+      element: {} as HTMLElement,
+      value: 0.4,
+      velocity: 1,
+      key: "in",
+    };
+    const first = new FakeAnimation([pose]);
+    host.attach(first);
+
+    const poses = host.flush();
+    expect(poses).toEqual([pose]);
+    expect(first.completeCount).toBe(1);
+    expect(host.activeChild).toBeNull();
+
+    const second = new FakeAnimation();
+    host.attach(second, poses);
+    expect(second.received).toEqual([[pose]]);
+    // Host state survived the flush — it was not reset to idle.
+    expect(second.playCount).toBe(1);
+  });
+
+  it("returns to idle once the active child settles", () => {
+    const host = new HostAnimation();
+    const child = new FakeAnimation();
+    host.attach(child);
+    child.complete();
+    expect(host.activeChild).toBeNull();
+    expect(host.isComplete).toBe(true);
+  });
+});

--- a/packages/core/src/lib/animation/host-animation.ts
+++ b/packages/core/src/lib/animation/host-animation.ts
@@ -24,19 +24,34 @@ export class HostAnimation extends Animation {
   private _settled = false;
   private listeners = new Set<() => void>();
 
-  attach(next: Animation): void {
+  /**
+   * Sample the active child's live pose and force-settle it, returning the
+   * poses for a successor's `matchInto`. The dispatcher calls this BEFORE
+   * the next transition's animation factory runs, so the settled run's
+   * preset cleanups (which wipe inline styles off shared real nodes in
+   * hidden mode) land before — never after — the new run's setup styles.
+   * `attach()` flushes lazily when no poses are handed in.
+   */
+  flush(): Pose[] {
     const prev = this.child;
-    // Swap the slot up front so prev's onComplete (which guards on
-    // `this.child === prev`) won't reset host state to idle when we
-    // complete it below.
+    if (!prev) return [];
+    // Clear the slot first so prev's onComplete (which guards on
+    // `this.child === prev`) won't reset host state to idle — a successor
+    // is about to attach.
+    this.child = null;
+    const poses = prev.getPose();
+    prev.complete();
+    return poses;
+  }
+
+  attach(next: Animation, poses?: Pose[]): void {
+    // Settle any straggler child (no-op when the caller already flush()ed).
+    const flushed = this.flush();
+    const handoff = poses ?? flushed;
     this.child = next;
     this._settled = false;
 
-    if (prev) {
-      const pose = prev.getPose();
-      prev.complete();
-      next.matchInto(pose);
-    }
+    if (handoff.length > 0) next.matchInto(handoff);
 
     next.playbackRate = this.playbackRate;
 

--- a/packages/core/src/lib/animation/index.ts
+++ b/packages/core/src/lib/animation/index.ts
@@ -1,5 +1,15 @@
 export { Animation } from "./animation";
 export { WebAnimation, type WebAnimationOptions } from "./web-animation";
+export { capturePoseFrom, type CapturePoseOptions } from "./capture-pose";
+export {
+  findPoseMatch,
+  rebasePose,
+  OUT_ROLE,
+  IN_ROLE,
+  type PoseMatch,
+  type PoseBounds,
+} from "./pose-matching";
+export { compressSettledFrames } from "./keyframe-compression";
 export {
   MultiAnimation,
   type MultiAnimationOptions,

--- a/packages/core/src/lib/animation/integrator/integrator.test.ts
+++ b/packages/core/src/lib/animation/integrator/integrator.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import type { IntegratorState } from "./types";
+import { SpringIntegrator } from "./spring-integrator";
+import { DoubleSpringIntegrator } from "./double-spring-integrator";
+import { InertiaIntegrator } from "./inertia-integrator";
+import { LinearIntegrator } from "./linear-integrator";
+import { IntegratorProvider } from "./provider";
+
+const DT = 1 / 60;
+
+const runUntilSettled = (
+  integrator: {
+    step: (s: IntegratorState, t: number, dt: number) => IntegratorState;
+    isSettled: (s: IntegratorState, t: number) => boolean;
+  },
+  from: number,
+  target: number,
+  maxSteps = 2000,
+) => {
+  let state: IntegratorState = { position: from, velocity: 0 };
+  let steps = 0;
+  while (steps < maxSteps) {
+    state = integrator.step(state, target, DT);
+    steps++;
+    if (integrator.isSettled(state, target)) break;
+  }
+  return { state, steps };
+};
+
+describe("SpringIntegrator", () => {
+  it("is deterministic — identical inputs produce identical trajectories", () => {
+    const trajectory = () => {
+      const spring = new SpringIntegrator({ stiffness: 300, damping: 30 });
+      let state: IntegratorState = { position: 0, velocity: 0 };
+      const out: IntegratorState[] = [];
+      for (let i = 0; i < 120; i++) {
+        state = spring.step(state, 1, DT);
+        out.push(state);
+      }
+      return out;
+    };
+    expect(trajectory()).toEqual(trajectory());
+  });
+
+  it("converges to the target and settles", () => {
+    const spring = new SpringIntegrator({ stiffness: 300, damping: 30 });
+    const { state, steps } = runUntilSettled(spring, 0, 1);
+    expect(steps).toBeLessThan(2000);
+    expect(state.position).toBeCloseTo(1, 1);
+    expect(spring.isSettled(state, 1)).toBe(true);
+  });
+
+  it("settles sooner with loosened rest thresholds", () => {
+    const tight = new SpringIntegrator({ stiffness: 1000, damping: 40 });
+    const loose = new SpringIntegrator({
+      stiffness: 1000,
+      damping: 40,
+      restDelta: 0.1,
+      restSpeed: 0.1,
+    });
+    const tightSteps = runUntilSettled(tight, 0, 1).steps;
+    const looseSteps = runUntilSettled(loose, 0, 1).steps;
+    expect(looseSteps).toBeLessThan(tightSteps);
+  });
+
+  it("honors a seeded initial velocity", () => {
+    const spring = new SpringIntegrator({ stiffness: 300, damping: 30 });
+    const fromRest = spring.step({ position: 0.5, velocity: 0 }, 1, DT);
+    const fromMoving = spring.step({ position: 0.5, velocity: 5 }, 1, DT);
+    expect(fromMoving.position).toBeGreaterThan(fromRest.position);
+  });
+});
+
+describe("DoubleSpringIntegrator", () => {
+  it("converges to the target and settles", () => {
+    const spring = new DoubleSpringIntegrator({
+      stiffness: 300,
+      damping: 30,
+      follower: 1.2,
+    });
+    const { state, steps } = runUntilSettled(spring, 0, 1);
+    expect(steps).toBeLessThan(2000);
+    expect(state.position).toBeCloseTo(1, 1);
+  });
+
+  it("lags a plain spring early on (ease-in character)", () => {
+    const single = new SpringIntegrator({ stiffness: 300, damping: 30 });
+    const chained = new DoubleSpringIntegrator({ stiffness: 300, damping: 30 });
+    let singleState: IntegratorState = { position: 0, velocity: 0 };
+    let chainedState: IntegratorState = { position: 0, velocity: 0 };
+    for (let i = 0; i < 5; i++) {
+      singleState = single.step(singleState, 1, DT);
+      chainedState = chained.step(chainedState, 1, DT);
+    }
+    expect(chainedState.position).toBeLessThan(singleState.position);
+  });
+});
+
+describe("InertiaIntegrator", () => {
+  it("accelerates toward the target and settles on it", () => {
+    const inertia = new InertiaIntegrator({
+      acceleration: 150,
+      resistance: 1.5,
+    });
+    const { state, steps } = runUntilSettled(inertia, 0, 1);
+    expect(steps).toBeLessThan(2000);
+    expect(Math.abs(state.position - 1)).toBeLessThan(0.01);
+  });
+
+  it("clamps to the target instead of overshooting", () => {
+    const inertia = new InertiaIntegrator({
+      acceleration: 5000,
+      resistance: 0.01,
+    });
+    let state: IntegratorState = { position: 0, velocity: 0 };
+    for (let i = 0; i < 200; i++) {
+      state = inertia.step(state, 1, DT);
+      expect(state.position).toBeLessThanOrEqual(1);
+    }
+    expect(state.position).toBe(1);
+    expect(state.velocity).toBe(0);
+  });
+});
+
+describe("LinearIntegrator", () => {
+  it("reaches the target and settles", () => {
+    const linear = new LinearIntegrator({ durationSec: 0.3 });
+    const { state, steps } = runUntilSettled(linear, 0, 1);
+    expect(steps).toBeLessThan(2000);
+    expect(Math.abs(state.position - 1)).toBeLessThan(0.01);
+  });
+});
+
+describe("IntegratorProvider", () => {
+  it("throws when both spring and inertia are configured", () => {
+    expect(() =>
+      IntegratorProvider.from({
+        spring: { stiffness: 300, damping: 30 },
+        inertia: { acceleration: 100, resistance: 1 },
+      }),
+    ).toThrow();
+  });
+
+  it("selects the integrator matching the physics config", () => {
+    expect(
+      IntegratorProvider.from({
+        inertia: { acceleration: 100, resistance: 1 },
+      }),
+    ).toBeInstanceOf(InertiaIntegrator);
+    expect(
+      IntegratorProvider.from({
+        spring: { stiffness: 300, damping: 30, doubleSpring: true },
+      }),
+    ).toBeInstanceOf(DoubleSpringIntegrator);
+    expect(
+      IntegratorProvider.from({ spring: { stiffness: 300, damping: 30 } }),
+    ).toBeInstanceOf(SpringIntegrator);
+    expect(IntegratorProvider.from({})).toBeInstanceOf(SpringIntegrator);
+  });
+});

--- a/packages/core/src/lib/animation/keyframe-compression.test.ts
+++ b/packages/core/src/lib/animation/keyframe-compression.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { compressSettledFrames } from "./keyframe-compression";
+
+describe("compressSettledFrames", () => {
+  it("keeps everything for two or fewer frames", () => {
+    expect(compressSettledFrames([], 0.01)).toEqual([]);
+    expect(compressSettledFrames([0.5], 0.01)).toEqual([0]);
+    expect(compressSettledFrames([0, 1], 0.01)).toEqual([0, 1]);
+  });
+
+  it("keeps fast-moving sections at full resolution", () => {
+    const positions = [0, 0.2, 0.4, 0.6, 0.8, 1];
+    expect(compressSettledFrames(positions, 0.01)).toEqual([0, 1, 2, 3, 4, 5]);
+  });
+
+  it("collapses a flat settle tail to its endpoints", () => {
+    const positions = [0, 0.5, 1, 1.001, 1.002, 1.001, 1.0, 1.0];
+    const kept = compressSettledFrames(positions, 0.01);
+    expect(kept).toEqual([0, 1, 2, 7]);
+  });
+
+  it("collapses a mid-flight plateau but keeps the surrounding motion", () => {
+    const positions = [0, 0.5, 0.5, 0.5, 0.5, 1];
+    const kept = compressSettledFrames(positions, 0.01);
+    expect(kept).toEqual([0, 1, 4, 5]);
+  });
+
+  it("always keeps first and last frames", () => {
+    const positions = Array.from({ length: 100 }, () => 1);
+    const kept = compressSettledFrames(positions, 0.01);
+    expect(kept[0]).toBe(0);
+    expect(kept[kept.length - 1]).toBe(99);
+    expect(kept).toEqual([0, 99]);
+  });
+
+  it("bounds the position deviation of dropped frames by the band", () => {
+    // Damped oscillation around 1 — the classic spring tail.
+    const positions: number[] = [];
+    for (let i = 0; i < 200; i++) {
+      positions.push(1 + 0.2 * Math.exp(-i / 12) * Math.cos(i / 3));
+    }
+    const band = 0.005;
+    const kept = compressSettledFrames(positions, band);
+
+    expect(kept.length).toBeLessThan(positions.length);
+    // Every dropped frame must sit inside the band window spanned by its
+    // surrounding kept frames' run.
+    for (let k = 0; k < kept.length - 1; k++) {
+      const start = kept[k]!;
+      const end = kept[k + 1]!;
+      if (end - start <= 1) continue; // adjacent kept frames, nothing dropped
+      const window = positions.slice(start, end);
+      const low = Math.min(...window);
+      const high = Math.max(...window);
+      expect(high - low).toBeLessThanOrEqual(band);
+    }
+  });
+
+  it("returns strictly increasing indices", () => {
+    const positions = [0, 0.1, 0.1, 0.1, 0.5, 0.5, 0.9, 1, 1, 1];
+    const kept = compressSettledFrames(positions, 0.02);
+    for (let i = 1; i < kept.length; i++) {
+      expect(kept[i]!).toBeGreaterThan(kept[i - 1]!);
+    }
+  });
+});

--- a/packages/core/src/lib/animation/keyframe-compression.ts
+++ b/packages/core/src/lib/animation/keyframe-compression.ts
@@ -1,0 +1,53 @@
+/**
+ * Decimation for baked WAAPI keyframes.
+ *
+ * A simulated spring spends most of its frames in a near-still settle tail
+ * (and, for underdamped springs, in sub-visual oscillation around the
+ * target). Baking every simulation frame inflates each animation with
+ * hundreds of visually identical keyframes.
+ *
+ * `compressSettledFrames` collapses every maximal run of consecutive frames
+ * whose positions stay inside a `band`-wide window down to the run's two
+ * endpoint frames. Style values are a continuous function of position, so
+ * the visual error of dropping interior frames is bounded by the style
+ * variation across `band` — no linearity assumption about the style
+ * function is needed (unlike error-based line simplification, which is only
+ * safe when styles are linear in position).
+ *
+ * Fast-moving sections break the band every frame and are kept at full
+ * resolution. The first and last frames are always kept, so the animation's
+ * start state and forwards-fill end state are exact.
+ */
+export function compressSettledFrames(
+  positions: readonly number[],
+  band: number,
+): number[] {
+  const count = positions.length;
+  if (count <= 2) return positions.map((_, i) => i);
+
+  const keep: number[] = [0];
+  let runLow = positions[0]!;
+  let runHigh = positions[0]!;
+  let runEnd = 0; // last index inside the current flat run
+
+  for (let i = 1; i < count; i++) {
+    const p = positions[i]!;
+    const low = Math.min(runLow, p);
+    const high = Math.max(runHigh, p);
+    if (high - low <= band) {
+      runLow = low;
+      runHigh = high;
+      runEnd = i;
+      continue;
+    }
+    // `i` would stretch the window past the band: close the current run at
+    // its end (its start is already kept), then start a fresh run at `i`.
+    if (runEnd !== keep[keep.length - 1]) keep.push(runEnd);
+    keep.push(i);
+    runLow = p;
+    runHigh = p;
+    runEnd = i;
+  }
+  if (keep[keep.length - 1] !== count - 1) keep.push(count - 1);
+  return keep;
+}

--- a/packages/core/src/lib/animation/multi-animation.test.ts
+++ b/packages/core/src/lib/animation/multi-animation.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Pose, Timeline } from "@types";
+import { Animation } from "./animation";
+import { MultiAnimation } from "./multi-animation";
+import { SpringIntegrator } from "./integrator";
+import { WebAnimation } from "./web-animation";
+
+class RecordingAnimation extends Animation {
+  received: Pose[][] = [];
+  play(): void {}
+  reverse(): void {}
+  pause(): void {}
+  complete(): void {
+    this.onComplete?.();
+  }
+  getPose(): Pose[] {
+    return [];
+  }
+  getTimeline(): Timeline[] {
+    return [];
+  }
+  matchInto(poses: Pose[]): void {
+    this.received.push(poses);
+  }
+  get isAnimating(): boolean {
+    return false;
+  }
+  get isPaused(): boolean {
+    return false;
+  }
+  get isComplete(): boolean {
+    return false;
+  }
+  get isReversing(): boolean {
+    return false;
+  }
+  get progress(): number {
+    return 0;
+  }
+  findTimeForProgress(): number | null {
+    return null;
+  }
+}
+
+const createFakeElement = () => {
+  const animate = vi.fn(() => ({
+    playbackRate: 1,
+    onfinish: null,
+    cancel: vi.fn(),
+    pause: vi.fn(),
+    play: vi.fn(),
+  }));
+  const element = { style: {}, animate } as unknown as HTMLElement;
+  return { element, animate };
+};
+
+describe("MultiAnimation.matchInto", () => {
+  it("fans poses out to every child", () => {
+    const a = new RecordingAnimation();
+    const b = new RecordingAnimation();
+    const multi = new MultiAnimation([a, b]);
+    const poses: Pose[] = [
+      { element: {} as HTMLElement, value: 0.5, velocity: 1, key: "out" },
+    ];
+    multi.matchInto(poses);
+    expect(a.received).toEqual([poses]);
+    expect(b.received).toEqual([poses]);
+  });
+
+  it("resumes an interrupted sequence from the right stage", () => {
+    // Hidden-mode reverse: A→B fade interrupted at out t=0.6 by B→A. The
+    // same real nodes flip roles — A (was "out" at 0.6) is now the in side,
+    // B (was "in", never started) is now the out side. Element identity +
+    // role flip mirrors both: B's out child seeds at 1 − 0 = 1 (already
+    // done), A's in child seeds at 1 − 0.6 = 0.4 (re-enter from where the
+    // page visually is).
+    const outSide = createFakeElement(); // element B
+    const inSide = createFakeElement(); // element A
+    const spring = () => new SpringIntegrator({ stiffness: 300, damping: 30 });
+
+    const outAnim = new WebAnimation({
+      element: outSide.element,
+      key: "out",
+      integrator: spring(),
+      style: (_t, u) => ({ opacity: u }),
+    });
+    const inAnim = new WebAnimation({
+      element: inSide.element,
+      key: "in",
+      integrator: spring(),
+      style: (t) => ({ opacity: t }),
+    });
+    const multi = new MultiAnimation([outAnim, inAnim], { mode: "sequence" });
+
+    const priorPoses: Pose[] = [
+      { element: inSide.element, value: 0.6, velocity: 2, key: "out" },
+      { element: outSide.element, value: 0, velocity: 0, key: "in" },
+    ];
+    multi.matchInto(priorPoses);
+    multi.play();
+
+    // Out child was seeded at its target → settled instantly; only the
+    // zero-duration forwards-fill hold ran, no real WAAPI animation.
+    expect(outSide.animate).toHaveBeenCalledTimes(1);
+    expect(outAnim.isComplete).toBe(true);
+
+    // In child started immediately (no sequence wait) from mirrored 0.4.
+    expect(inSide.animate).toHaveBeenCalledTimes(1);
+    expect(inAnim.progress).toBeCloseTo(0.4, 1);
+    expect(multi.isComplete).toBe(false);
+  });
+});

--- a/packages/core/src/lib/animation/multi-animation.ts
+++ b/packages/core/src/lib/animation/multi-animation.ts
@@ -86,11 +86,16 @@ export class MultiAnimation extends Animation {
     return this.children.flatMap((c) => c.getTimeline());
   }
 
-  matchInto(_poses: Pose[]): void {
-    // TODO: handing a flat pose list to a composite isn't well-defined yet —
-    // sequence/stagger progress, mode mismatches, and active-child awareness
-    // all need a richer protocol than per-child broadcast. Left as a no-op
-    // for now so we don't pretend to support cross-multi handoff.
+  matchInto(poses: Pose[]): void {
+    // Fan the flat pose list out to every child: each child applies the
+    // shared matching rules (element identity first, then role keys — see
+    // pose-matching.ts), so cross-multi handoff works without this composite
+    // knowing which prior child maps to which of its own. Children that find
+    // no match keep their resting state. This composes with sequence
+    // scheduling naturally: a child whose match seeds it at (or past) its
+    // target settles instantly on play() and hands off to the next child, so
+    // an interrupted sequence resumes from the right stage.
+    for (const child of this.children) child.matchInto(poses);
   }
 
   get isAnimating(): boolean {

--- a/packages/core/src/lib/animation/pose-matching.test.ts
+++ b/packages/core/src/lib/animation/pose-matching.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "vitest";
+import type { Pose } from "@types";
+import { findPoseMatch, rebasePose } from "./pose-matching";
+
+const el = () => ({}) as HTMLElement;
+
+const pose = (overrides: Partial<Pose> & { element: HTMLElement }): Pose => ({
+  value: 0,
+  velocity: 0,
+  ...overrides,
+});
+
+describe("findPoseMatch", () => {
+  it("matches same element + same key directly", () => {
+    const a = el();
+    const p = pose({ element: a, key: "out", value: 0.4 });
+    const match = findPoseMatch([p], { element: a, key: "out" });
+    expect(match).toEqual({ pose: p, mirror: false });
+  });
+
+  it("does not match unkeyed identity poses — no role info to seed safely", () => {
+    // In hidden mode the same real node flips roles between consecutive
+    // runs; without keys a raw value copy would land on the wrong visual
+    // state (e.g. film/zoom interrupts), so unkeyed animations opt out.
+    const a = el();
+    const p = pose({ element: a, value: 0.4 });
+    expect(findPoseMatch([p], { element: a })).toBeNull();
+  });
+
+  it("mirrors same element across a role flip (out ↔ in)", () => {
+    const a = el();
+    const p = pose({ element: a, key: "out", value: 0.7 });
+    const match = findPoseMatch([p], { element: a, key: "in" });
+    expect(match).toEqual({ pose: p, mirror: true });
+  });
+
+  it("prefers same-role over flipped-role for the same element", () => {
+    const a = el();
+    const sameRole = pose({ element: a, key: "in", value: 0.2 });
+    const flipped = pose({ element: a, key: "out", value: 0.9 });
+    const match = findPoseMatch([flipped, sameRole], {
+      element: a,
+      key: "in",
+    });
+    expect(match).toEqual({ pose: sameRole, mirror: false });
+  });
+
+  it("does not match identity poses when key info is one-sided", () => {
+    // A keyed↔unkeyed pair (e.g. film interrupted by fade) has no shared
+    // role convention, so a direct seed would be unmirrored guesswork.
+    const a = el();
+    const keyed = pose({ element: a, key: "hero:thumb", value: 0.5 });
+    expect(findPoseMatch([keyed], { element: a })).toBeNull();
+    const unkeyed = pose({ element: a, value: 0.5 });
+    expect(findPoseMatch([unkeyed], { element: a, key: "out" })).toBeNull();
+  });
+
+  it("lets the out side borrow the unique prior in pose across elements", () => {
+    // The page being left is always the page that was arriving, so this
+    // pairing is safe even when the node changed (unmount-mode clones).
+    const prior = pose({ element: el(), key: "in", value: 0.4 });
+    const other = pose({ element: el(), key: "out", value: 0.9 });
+    const match = findPoseMatch([prior, other], { element: el(), key: "out" });
+    expect(match).toEqual({ pose: prior, mirror: true });
+  });
+
+  it("never lets the in side borrow cross-element continuity (chained-nav guard)", () => {
+    // A→B interrupted by B→C: the arriving page C is brand new and must
+    // start fresh, not inherit page A's out pose.
+    const priorOut = pose({ element: el(), key: "out", value: 0.3 });
+    const priorIn = pose({ element: el(), key: "in", value: 0 });
+    expect(
+      findPoseMatch([priorOut, priorIn], { element: el(), key: "in" }),
+    ).toBeNull();
+  });
+
+  it("matches a unique custom key across different elements directly", () => {
+    const prior = pose({ element: el(), key: "hero:thumb", value: 0.6 });
+    const match = findPoseMatch([prior], { element: el(), key: "hero:thumb" });
+    expect(match).toEqual({ pose: prior, mirror: false });
+  });
+
+  it("matches nothing when the role fallback is ambiguous", () => {
+    const inA = pose({ element: el(), key: "in", value: 0.2 });
+    const inB = pose({ element: el(), key: "in", value: 0.8 });
+    expect(findPoseMatch([inA, inB], { element: el(), key: "out" })).toBeNull();
+  });
+
+  it("matches nothing without element identity or key", () => {
+    const p = pose({ element: el(), key: "out", value: 0.5 });
+    expect(findPoseMatch([p], { element: el() })).toBeNull();
+  });
+});
+
+describe("rebasePose", () => {
+  const bounds = { lowerBound: 0, upperBound: 1 };
+
+  it("copies value and velocity for identical bounds without mirror", () => {
+    const p = pose({ element: el(), value: 0.7, velocity: -2 });
+    expect(rebasePose(p, bounds, false)).toEqual({ value: 0.7, velocity: -2 });
+  });
+
+  it("mirrors progress and negates velocity", () => {
+    const p = pose({ element: el(), value: 0.7, velocity: -2 });
+    const seeded = rebasePose(p, bounds, true);
+    expect(seeded.value).toBeCloseTo(0.3);
+    expect(seeded.velocity).toBeCloseTo(2);
+  });
+
+  it("rebases value and rescales velocity across different spans", () => {
+    const p = pose({
+      element: el(),
+      value: 0.5,
+      velocity: 1,
+      lowerBound: 0,
+      upperBound: 1,
+    });
+    const seeded = rebasePose(p, { lowerBound: 0, upperBound: 100 }, false);
+    expect(seeded.value).toBeCloseTo(50);
+    expect(seeded.velocity).toBeCloseTo(100);
+  });
+
+  it("rebases from non-zero source bounds", () => {
+    const p = pose({
+      element: el(),
+      value: 15,
+      velocity: 5,
+      lowerBound: 10,
+      upperBound: 20,
+    });
+    const seeded = rebasePose(p, bounds, true);
+    expect(seeded.value).toBeCloseTo(0.5);
+    expect(seeded.velocity).toBeCloseTo(-0.5);
+  });
+
+  it("preserves overshoot outside the source bounds", () => {
+    const p = pose({ element: el(), value: 1.05, velocity: -0.5 });
+    const seeded = rebasePose(p, bounds, true);
+    expect(seeded.value).toBeCloseTo(-0.05);
+    expect(seeded.velocity).toBeCloseTo(0.5);
+  });
+
+  it("falls back to a raw copy for degenerate spans", () => {
+    const p = pose({
+      element: el(),
+      value: 0.4,
+      velocity: 3,
+      lowerBound: 1,
+      upperBound: 1,
+    });
+    expect(rebasePose(p, bounds, true)).toEqual({ value: 0.4, velocity: 3 });
+    const q = pose({ element: el(), value: 0.4, velocity: 3 });
+    expect(rebasePose(q, { lowerBound: 2, upperBound: 2 }, false)).toEqual({
+      value: 0.4,
+      velocity: 3,
+    });
+  });
+});

--- a/packages/core/src/lib/animation/pose-matching.ts
+++ b/packages/core/src/lib/animation/pose-matching.ts
@@ -1,0 +1,124 @@
+import type { Pose } from "@types";
+
+/**
+ * Pose matching rules shared by Animation implementations.
+ *
+ * Matching priority (first hit wins):
+ *   1. Same element, same defined key       → direct seed
+ *   2. Same element, opposite role keys     → mirrored seed
+ *   3. No element match, custom key         → direct seed when exactly one
+ *      pose carries the same key
+ *   4. No element match, self is "out"      → mirrored seed when exactly one
+ *      pose carries the "in" role
+ *
+ * Mirroring encodes the page-handoff invariant: presets draw visual
+ * "presence" as `t` on the in side and `1 - t` on the out side, so when an
+ * interrupting navigation flips an element's role (or replaces the node
+ * entirely, as unmount-mode clones do), seeding `1 - progress` with negated
+ * velocity lands the new animation on the visual state the old one left
+ * behind. Presets whose in/out styles are NOT mirror images (continuation
+ * choreography like rotate/strip) must simply not set reserved keys.
+ *
+ * Deliberate non-matches — a wrong seed is worse than a fresh start:
+ *   - Unkeyed identity matches. In hidden mode the same real node flips
+ *     roles between consecutive runs, so a raw value copy lands on the
+ *     wrong visual state. Without keys there is no role information, so we
+ *     don't seed at all (the pre-motion-matching behavior).
+ *   - Cross-element fallback for the IN side. The page being left is always
+ *     the page that was arriving (navigation continuity), so an "out"
+ *     animation may safely borrow the unique prior "in" pose. The reverse
+ *     is not true: the page arriving next may be a brand-new page (A→B
+ *     interrupted by B→C), and poses carry no page identity to tell a true
+ *     reverse from a chained navigation.
+ *   - Ambiguous fallbacks (several poses sharing the candidate key).
+ */
+
+/** Reserved role for animations that drive the outgoing page. */
+export const OUT_ROLE = "out";
+/** Reserved role for animations that drive the incoming page. */
+export const IN_ROLE = "in";
+
+export type PoseMatch = {
+  pose: Pose;
+  /** Seed as `1 - progress` with negated velocity (role flip). */
+  mirror: boolean;
+};
+
+export type PoseBounds = {
+  lowerBound: number;
+  upperBound: number;
+};
+
+function oppositeRole(key: string): string | null {
+  if (key === OUT_ROLE) return IN_ROLE;
+  if (key === IN_ROLE) return OUT_ROLE;
+  return null;
+}
+
+export function findPoseMatch(
+  poses: readonly Pose[],
+  self: { element: HTMLElement; key?: string },
+): PoseMatch | null {
+  if (self.key === undefined) return null;
+
+  const byElement = poses.filter((p) => p.element === self.element);
+  if (byElement.length > 0) {
+    const sameKey = byElement.find((p) => p.key === self.key);
+    if (sameKey) return { pose: sameKey, mirror: false };
+
+    const opposite = oppositeRole(self.key);
+    const flipped =
+      opposite !== null ? byElement.find((p) => p.key === opposite) : undefined;
+    if (flipped) return { pose: flipped, mirror: true };
+    return null;
+  }
+
+  const opposite = oppositeRole(self.key);
+  if (opposite === null) {
+    const sameKey = poses.filter((p) => p.key === self.key);
+    return sameKey.length === 1 ? { pose: sameKey[0]!, mirror: false } : null;
+  }
+  // Reserved roles: only the OUT side may borrow continuity cross-element —
+  // see the module doc for why the IN side must start fresh.
+  if (self.key !== OUT_ROLE) return null;
+  const candidates = poses.filter((p) => p.key === IN_ROLE);
+  return candidates.length === 1
+    ? { pose: candidates[0]!, mirror: true }
+    : null;
+}
+
+/**
+ * Translate a pose from its source t-space into `target` bounds.
+ *
+ * Value maps via normalized progress; velocity rescales by the span ratio so
+ * perceived speed carries over even when the two animations cover different
+ * ranges. A mirrored rebase flips progress (`1 - p`) and negates velocity.
+ *
+ * Degenerate (zero-width) spans carry no scale information — fall back to
+ * the legacy raw copy rather than dividing by zero.
+ */
+export function rebasePose(
+  pose: Pose,
+  target: PoseBounds,
+  mirror: boolean,
+): { value: number; velocity: number } {
+  const sourceLower = pose.lowerBound ?? 0;
+  const sourceUpper = pose.upperBound ?? 1;
+  const sourceSpan = sourceUpper - sourceLower;
+  const targetSpan = target.upperBound - target.lowerBound;
+
+  if (sourceSpan === 0 || targetSpan === 0) {
+    return { value: pose.value, velocity: pose.velocity };
+  }
+
+  let progress = (pose.value - sourceLower) / sourceSpan;
+  let velocity = pose.velocity / sourceSpan;
+  if (mirror) {
+    progress = 1 - progress;
+    velocity = -velocity;
+  }
+  return {
+    value: target.lowerBound + progress * targetSpan,
+    velocity: velocity * targetSpan,
+  };
+}

--- a/packages/core/src/lib/animation/web-animation.test.ts
+++ b/packages/core/src/lib/animation/web-animation.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it, vi } from "vitest";
+import { SpringIntegrator } from "./integrator";
+import { WebAnimation } from "./web-animation";
+
+type AnimateCall = {
+  keyframes: Keyframe[];
+  options: KeyframeAnimationOptions;
+};
+
+type FakeWaapi = {
+  playbackRate: number;
+  onfinish: (() => void) | null;
+  cancel: ReturnType<typeof vi.fn>;
+  pause: ReturnType<typeof vi.fn>;
+  play: ReturnType<typeof vi.fn>;
+};
+
+const createFakeElement = () => {
+  const calls: AnimateCall[] = [];
+  const waapis: FakeWaapi[] = [];
+  const element = {
+    style: {} as Record<string, string>,
+    animate: vi.fn(
+      (keyframes: Keyframe[], options: KeyframeAnimationOptions) => {
+        const waapi: FakeWaapi = {
+          playbackRate: 1,
+          onfinish: null,
+          cancel: vi.fn(),
+          pause: vi.fn(),
+          play: vi.fn(),
+        };
+        calls.push({ keyframes, options });
+        waapis.push(waapi);
+        return waapi as unknown as globalThis.Animation;
+      },
+    ),
+  } as unknown as HTMLElement & { animate: ReturnType<typeof vi.fn> };
+  return { element, calls, waapis };
+};
+
+const springAnimation = (
+  element: HTMLElement,
+  overrides: Partial<ConstructorParameters<typeof WebAnimation>[0]> = {},
+) =>
+  new WebAnimation({
+    element,
+    integrator: new SpringIntegrator({ stiffness: 300, damping: 30 }),
+    style: (t) => ({ opacity: t }),
+    ...overrides,
+  });
+
+describe("WebAnimation pose handoff", () => {
+  it("exposes key and bounds on getPose", () => {
+    const { element } = createFakeElement();
+    const animation = springAnimation(element, {
+      key: "out",
+      lowerBound: 0,
+      upperBound: 100,
+    });
+    expect(animation.getPose()).toEqual([
+      {
+        element,
+        value: 0,
+        velocity: 0,
+        key: "out",
+        lowerBound: 0,
+        upperBound: 100,
+      },
+    ]);
+  });
+
+  it("seeds directly from a same-element same-key pose", () => {
+    const { element } = createFakeElement();
+    const animation = springAnimation(element, { key: "out" });
+    animation.matchInto([{ element, value: 0.7, velocity: -2, key: "out" }]);
+    const [pose] = animation.getPose();
+    expect(pose!.value).toBeCloseTo(0.7);
+    expect(pose!.velocity).toBeCloseTo(-2);
+  });
+
+  it("seeds mirrored when the element's role flips", () => {
+    const { element } = createFakeElement();
+    const animation = springAnimation(element, { key: "in" });
+    animation.matchInto([{ element, value: 0.7, velocity: -2, key: "out" }]);
+    const [pose] = animation.getPose();
+    expect(pose!.value).toBeCloseTo(0.3);
+    expect(pose!.velocity).toBeCloseTo(2);
+  });
+
+  it("seeds mirrored from a unique opposite-role pose on another element", () => {
+    const { element } = createFakeElement();
+    const previous = {} as HTMLElement;
+    const animation = springAnimation(element, { key: "out" });
+    animation.matchInto([
+      { element: previous, value: 0.4, velocity: 1.5, key: "in" },
+    ]);
+    const [pose] = animation.getPose();
+    expect(pose!.value).toBeCloseTo(0.6);
+    expect(pose!.velocity).toBeCloseTo(-1.5);
+  });
+
+  it("rebases a pose into different bounds", () => {
+    const { element } = createFakeElement();
+    const animation = springAnimation(element, {
+      key: "in",
+      lowerBound: 0,
+      upperBound: 200,
+    });
+    animation.matchInto([
+      {
+        element,
+        value: 0.5,
+        velocity: 1,
+        key: "in",
+        lowerBound: 0,
+        upperBound: 1,
+      },
+    ]);
+    const [pose] = animation.getPose();
+    expect(pose!.value).toBeCloseTo(100);
+    expect(pose!.velocity).toBeCloseTo(200);
+  });
+
+  it("keeps its resting state when nothing matches", () => {
+    const { element } = createFakeElement();
+    const animation = springAnimation(element, { key: "out" });
+    animation.matchInto([
+      { element: {} as HTMLElement, value: 0.9, velocity: 4, key: "out" },
+      { element: {} as HTMLElement, value: 0.1, velocity: 1, key: "out" },
+    ]);
+    const [pose] = animation.getPose();
+    expect(pose!.value).toBe(0);
+    expect(pose!.velocity).toBe(0);
+  });
+
+  it("plays the seeded simulation from the handoff point", () => {
+    const { element, calls } = createFakeElement();
+    const animation = springAnimation(element, { key: "in" });
+    animation.matchInto([{ element, value: 0.75, velocity: 0, key: "out" }]);
+    animation.play();
+    const first = calls[0]!.keyframes[0]!;
+    // Seeded at mirrored 0.25 → the first baked keyframe styles t = 0.25.
+    expect(Number(first.opacity)).toBeCloseTo(0.25);
+  });
+
+  it("completes instantly when seeded at the target, holding the final frame", () => {
+    const { element, calls } = createFakeElement();
+    const onComplete = vi.fn();
+    const animation = springAnimation(element, { key: "out", onComplete });
+    animation.matchInto([{ element, value: 0, velocity: 0, key: "in" }]);
+    animation.play();
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(animation.isComplete).toBe(true);
+    // The final frame must be held by a forwards-filling WAAPI entry —
+    // preset onComplete cleanups wipe inline styles, and without the fill
+    // the element would pop back to its resting styles mid-run.
+    expect(calls.length).toBe(1);
+    expect(calls[0]!.options.duration).toBe(0);
+    expect(calls[0]!.options.fill).toBe("forwards");
+    expect(Number(calls[0]!.keyframes[0]!.opacity)).toBeCloseTo(1);
+  });
+});
+
+describe("WebAnimation keyframe baking", () => {
+  it("bakes monotonic offsets from 0 to 1", () => {
+    const { element, calls } = createFakeElement();
+    const animation = springAnimation(element);
+    animation.play();
+
+    const keyframes = calls[0]!.keyframes;
+    expect(keyframes.length).toBeGreaterThanOrEqual(2);
+    expect(keyframes[0]!.offset).toBe(0);
+    expect(keyframes[keyframes.length - 1]!.offset).toBe(1);
+    for (let i = 1; i < keyframes.length; i++) {
+      expect(Number(keyframes[i]!.offset)).toBeGreaterThan(
+        Number(keyframes[i - 1]!.offset),
+      );
+    }
+  });
+
+  it("bakes fewer keyframes than simulated frames once the spring settles", () => {
+    const { element, calls } = createFakeElement();
+    // Tiny rest thresholds force a long, visually-still settle tail.
+    const animation = springAnimation(element, {
+      integrator: new SpringIntegrator({
+        stiffness: 300,
+        damping: 30,
+        restDelta: 0.0001,
+        restSpeed: 0.0001,
+      }),
+    });
+    animation.play();
+
+    const { keyframes, options } = calls[0]!;
+    const simulatedFrames =
+      Math.round((options.duration as number) / (1000 / 60)) + 1;
+    expect(keyframes.length).toBeLessThan(simulatedFrames * 0.8);
+  });
+
+  it("does not leak the offset key into inline style clearing", () => {
+    const { element } = createFakeElement();
+    const style = (element as unknown as { style: Record<string, string> })
+      .style;
+    style.opacity = "0.5";
+    style.offset = "preexisting";
+    const animation = springAnimation(element);
+    animation.play();
+    expect(style.opacity).toBe("");
+    expect(style.offset).toBe("preexisting");
+  });
+});

--- a/packages/core/src/lib/animation/web-animation.ts
+++ b/packages/core/src/lib/animation/web-animation.ts
@@ -5,8 +5,15 @@ import {
   SETTLE_THRESHOLD,
 } from "./integrator";
 import { Animation } from "./animation";
+import { compressSettledFrames } from "./keyframe-compression";
+import { findPoseMatch, rebasePose } from "./pose-matching";
 
 const FRAME_TIME = 1000 / 60;
+
+// Band width for keyframe decimation, as a fraction of the simulation's
+// total position travel. 0.2% of travel is sub-pixel for any sub-500px
+// motion and invisible for opacity — see keyframe-compression.ts.
+const KEYFRAME_FLATTEN_RATIO = 0.002;
 
 export interface WebAnimationOptions {
   element: HTMLElement;
@@ -16,6 +23,13 @@ export interface WebAnimationOptions {
   lowerBound?: number;
   /** Default 1 — the value `t` takes at the end of `play()`. */
   upperBound?: number;
+  /**
+   * Logical role for motion matching across handoffs. The reserved roles
+   * "out"/"in" mirror into each other when an interrupting transition takes
+   * over (see pose-matching.ts); any other string matches itself directly,
+   * letting a pose survive node replacement (e.g. unmount-mode clones).
+   */
+  key?: string;
   onUpdate?: (poses: Pose[]) => void;
   onComplete?: () => void;
 }
@@ -35,10 +49,13 @@ interface SimFrame {
  *      velocity) toward the target bound, producing a frame list.
  *   2. Frames are converted to WAAPI keyframes; `element.animate(...)` runs them.
  *   3. While playing, `getPose()` interpolates the live position from frames
- *      using `performance.now() - startTime`.
+ *      using the WAAPI clock (`waapi.currentTime`), which tracks
+ *      playbackRate and pause/resume; wall-clock elapsed is the fallback.
  *
- * Identity for motion matching is the DOM element itself — when a previous
- * animation's pose is handed in via `matchInto`, we look up by element.
+ * Identity for motion matching is the DOM element first, then the logical
+ * `key` role — when a previous animation's pose is handed in via
+ * `matchInto`, the shared rules in pose-matching.ts decide whether to seed
+ * it directly or mirrored (role flip), rebased into this animation's bounds.
  */
 export class WebAnimation extends Animation {
   private element: HTMLElement;
@@ -46,6 +63,7 @@ export class WebAnimation extends Animation {
   private styleFn: (t: number, u: number) => StyleObject;
   private lowerBound: number;
   private upperBound: number;
+  private key: string | undefined;
 
   private currentValue: number;
   private currentVelocity = 0;
@@ -64,6 +82,7 @@ export class WebAnimation extends Animation {
     this.styleFn = opts.style;
     this.lowerBound = opts.lowerBound ?? 0;
     this.upperBound = opts.upperBound ?? 1;
+    this.key = opts.key;
     this.currentValue = this.lowerBound;
     this.onUpdate = opts.onUpdate;
     this.onComplete = opts.onComplete;
@@ -164,6 +183,9 @@ export class WebAnimation extends Animation {
         element: this.element,
         value: this.currentValue,
         velocity: this.currentVelocity,
+        key: this.key,
+        lowerBound: this.lowerBound,
+        upperBound: this.upperBound,
       },
     ];
   }
@@ -183,10 +205,18 @@ export class WebAnimation extends Animation {
   }
 
   matchInto(poses: Pose[]): void {
-    const match = poses.find((p) => p.element === this.element);
+    const match = findPoseMatch(poses, {
+      element: this.element,
+      key: this.key,
+    });
     if (!match) return;
-    this.currentValue = match.value;
-    this.currentVelocity = match.velocity;
+    const seeded = rebasePose(
+      match.pose,
+      { lowerBound: this.lowerBound, upperBound: this.upperBound },
+      match.mirror,
+    );
+    this.currentValue = seeded.value;
+    this.currentVelocity = seeded.velocity;
   }
 
   /* ───────────────────────────────────────────────────────── private */
@@ -209,27 +239,60 @@ export class WebAnimation extends Animation {
       this.currentValue = target;
       this.currentVelocity = 0;
       this.applyStyleAt(target);
+      // Natural completion keeps its final frame alive through the
+      // forwards-filling WAAPI entry, and preset onComplete cleanups count
+      // on that when they wipe inline styles. Mirror it here — otherwise a
+      // child seeded exactly at its target (a fast-forwarded sequence
+      // stage) pops back to its resting styles for the rest of the run.
+      const u = this.lowerBound + this.upperBound - target;
+      this.waapi = this.element.animate([this.styleFn(target, u) as Keyframe], {
+        duration: 0,
+        fill: "forwards",
+        composite: "replace",
+      });
       this.settled = true;
       this.onComplete?.();
       return;
     }
 
-    const keyframes: Keyframe[] = this.frames.map((f) => {
+    const lastFrame = this.frames[this.frames.length - 1]!;
+    const duration = lastFrame.time;
+
+    // Decimate near-still stretches (the settle tail, sub-visual overshoot
+    // wiggle) before baking keyframes — see compressSettledFrames. Dropped
+    // frames force explicit offsets so the kept frames stay on the original
+    // clock. Live-state reads are unaffected: getPose() and
+    // findTimeForProgress() interpolate this.frames, never the baked
+    // keyframes.
+    let positionLow = Infinity;
+    let positionHigh = -Infinity;
+    for (const f of this.frames) {
+      if (f.position < positionLow) positionLow = f.position;
+      if (f.position > positionHigh) positionHigh = f.position;
+    }
+    const keptIndices = compressSettledFrames(
+      this.frames.map((f) => f.position),
+      (positionHigh - positionLow) * KEYFRAME_FLATTEN_RATIO,
+    );
+
+    // Collect the animated props off the first style BEFORE tacking offsets
+    // onto the keyframes — `offset` is also a CSS property and must not be
+    // swept up by the inline-style clearing below.
+    let styledProps: string[] = [];
+    const keyframes: Keyframe[] = keptIndices.map((idx, kept) => {
+      const f = this.frames[idx]!;
       const t = f.position;
       const u = this.lowerBound + this.upperBound - t;
-      return this.styleFn(t, u) as Keyframe;
+      const frame = this.styleFn(t, u) as Keyframe;
+      if (kept === 0) styledProps = Object.keys(frame);
+      frame.offset = duration > 0 ? f.time / duration : 0;
+      return frame;
     });
 
     // Clear inline styles for animated props so they don't clash with WAAPI.
-    const firstFrame = keyframes[0];
-    if (firstFrame) {
-      for (const prop of Object.keys(firstFrame)) {
-        (this.element.style as unknown as Record<string, string>)[prop] = "";
-      }
+    for (const prop of styledProps) {
+      (this.element.style as unknown as Record<string, string>)[prop] = "";
     }
-
-    const lastFrame = this.frames[this.frames.length - 1]!;
-    const duration = lastFrame.time;
 
     this.waapi = this.element.animate(keyframes, {
       duration,
@@ -259,7 +322,13 @@ export class WebAnimation extends Animation {
 
   private captureLiveState() {
     if (this.frames.length === 0) return;
-    const elapsed = performance.now() - this.startTime;
+    // Frame timestamps are 1×-speed simulation times. The WAAPI clock
+    // (currentTime) advances at playbackRate and freezes across
+    // pause/resume, so prefer it over wall-clock elapsed, which diverges
+    // from the visual under either.
+    const local = this.waapi?.currentTime;
+    const elapsed =
+      typeof local === "number" ? local : performance.now() - this.startTime;
     const { position, velocity } = interpolateFrame(this.frames, elapsed);
     this.currentValue = position;
     this.currentVelocity = velocity;

--- a/packages/core/src/lib/index.ts
+++ b/packages/core/src/lib/index.ts
@@ -1,9 +1,21 @@
 export * from "./transitions";
-export { Animation, WebAnimation, MultiAnimation } from "./animation";
+export {
+  Animation,
+  WebAnimation,
+  MultiAnimation,
+  capturePoseFrom,
+  findPoseMatch,
+  rebasePose,
+  OUT_ROLE,
+  IN_ROLE,
+} from "./animation";
 export type {
   WebAnimationOptions,
   MultiAnimationOptions,
   MultiAnimationMode,
+  CapturePoseOptions,
+  PoseMatch,
+  PoseBounds,
 } from "./animation";
 export type {
   SsgoiConfig,

--- a/packages/core/src/lib/ssgoi-transition/create-context-manager.test.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-context-manager.test.ts
@@ -373,4 +373,80 @@ describe("createContextManager", () => {
 
     expect(documentElement.scrollTop).toBe(0);
   });
+
+  it("evicts the least-recently-scrolled path beyond the LRU cap", () => {
+    const manager = createContextManager({ preserveScroll: true });
+
+    // 51 distinct paths each capture one scroll — one over the cap of 50.
+    for (let i = 0; i <= 50; i++) {
+      const page = createFakeElement({ parentElement: body });
+      manager.initializeContext(page, `/page-${i}`);
+      flushAnimationFrames(11);
+      documentElement.scrollTop = 100 + i;
+      emitWindowScroll();
+    }
+
+    expect(manager.getScrollPosition("/page-0")).toEqual({ x: 0, y: 0 });
+    expect(manager.getScrollPosition("/page-1")).toEqual({ x: 0, y: 101 });
+    expect(manager.getScrollPosition("/page-50")).toEqual({ x: 0, y: 150 });
+  });
+
+  it("refreshes recency on re-scroll so active paths survive eviction", () => {
+    const manager = createContextManager({ preserveScroll: true });
+
+    // Fill exactly to the cap.
+    for (let i = 0; i < 50; i++) {
+      const page = createFakeElement({ parentElement: body });
+      manager.initializeContext(page, `/page-${i}`);
+      flushAnimationFrames(11);
+      documentElement.scrollTop = 100 + i;
+      emitWindowScroll();
+    }
+
+    // Revisit the oldest path — its entry moves to the recent end.
+    const revisited = createFakeElement({ parentElement: body });
+    manager.initializeContext(revisited, "/page-0");
+    flushAnimationFrames(11);
+    documentElement.scrollTop = 300;
+    emitWindowScroll();
+
+    // One more path pushes the map over the cap: /page-1 is now the oldest.
+    const fresh = createFakeElement({ parentElement: body });
+    manager.initializeContext(fresh, "/page-new");
+    flushAnimationFrames(11);
+    documentElement.scrollTop = 555;
+    emitWindowScroll();
+
+    expect(manager.getScrollPosition("/page-0")).toEqual({ x: 0, y: 300 });
+    expect(manager.getScrollPosition("/page-1")).toEqual({ x: 0, y: 0 });
+    expect(manager.getScrollPosition("/page-2")).toEqual({ x: 0, y: 102 });
+    expect(manager.getScrollPosition("/page-new")).toEqual({ x: 0, y: 555 });
+  });
+
+  it("never evicts a shared scroll entry for per-path churn", () => {
+    // Excluded paths still capture under path:<path> keys but are only
+    // cleaned up when a transition runs — heavy churn on them must not push
+    // the long-lived shared:<key> singleton out of the cap.
+    const manager = createContextManager({
+      preserveScroll: { key: "tabs", exclude: ["/detail/*"] },
+    });
+
+    const home = createFakeElement({ parentElement: body });
+    manager.initializeContext(home, "/home");
+    flushAnimationFrames(11);
+    documentElement.scrollTop = 400;
+    emitWindowScroll();
+
+    for (let i = 0; i <= 55; i++) {
+      const page = createFakeElement({ parentElement: body });
+      manager.initializeContext(page, `/detail/${i}`);
+      flushAnimationFrames(11);
+      documentElement.scrollTop = 100 + i;
+      emitWindowScroll();
+    }
+
+    // The shared entry survived; old per-path entries were evicted instead.
+    expect(manager.getScrollPosition("/home")).toEqual({ x: 0, y: 400 });
+    expect(manager.getScrollPosition("/detail/0")).toEqual({ x: 0, y: 0 });
+  });
 });

--- a/packages/core/src/lib/ssgoi-transition/create-context-manager.test.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-context-manager.test.ts
@@ -449,4 +449,28 @@ describe("createContextManager", () => {
     expect(manager.getScrollPosition("/home")).toEqual({ x: 0, y: 400 });
     expect(manager.getScrollPosition("/detail/0")).toEqual({ x: 0, y: 0 });
   });
+
+  it("destroy() detaches scroll tracking and a later init re-attaches", () => {
+    const manager = createContextManager({ preserveScroll: true });
+    const page = createFakeElement({ parentElement: body });
+
+    manager.initializeContext(page, "/feed");
+    flushAnimationFrames(11);
+    documentElement.scrollTop = 100;
+    emitWindowScroll();
+    expect(manager.getScrollPosition("/feed")).toEqual({ x: 0, y: 100 });
+
+    manager.destroy();
+    documentElement.scrollTop = 200;
+    emitWindowScroll();
+    // Listener detached — the scroll after destroy is not captured.
+    expect(manager.getScrollPosition("/feed")).toEqual({ x: 0, y: 100 });
+
+    const remounted = createFakeElement({ parentElement: body });
+    manager.initializeContext(remounted, "/feed");
+    flushAnimationFrames(11);
+    documentElement.scrollTop = 300;
+    emitWindowScroll();
+    expect(manager.getScrollPosition("/feed")).toEqual({ x: 0, y: 300 });
+  });
 });

--- a/packages/core/src/lib/ssgoi-transition/create-context-manager.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-context-manager.ts
@@ -6,6 +6,11 @@ import { matchPath } from "./find-matching-transition";
 const MOBILE_BREAKPOINT_PX = 768;
 const RESTORE_MAX_RETRIES = 10;
 const TRANSITION_SETTLE_FRAMES = 10;
+// Cap on saved scroll positions: preserved paths accumulate for the lifetime
+// of the context, so a long session across many routes would otherwise grow
+// the map without bound. 50 distinct scroll targets is far beyond what a
+// back/forward journey meaningfully revisits.
+const MAX_SCROLL_ENTRIES = 50;
 
 type ScrollPosition = { x: number; y: number };
 type ScrollPolicy = {
@@ -99,9 +104,27 @@ export function createContextManager(options: ContextManagerOptions = {}) {
   // isTransitioning back to false mid-way through a newer transition.
   let initGeneration = 0;
 
+  // LRU write: Map iterates in insertion order, so delete-then-set keeps
+  // recency and the size cap evicts the least-recently-scrolled path.
+  const rememberScrollPosition = (key: string, position: ScrollPosition) => {
+    if (scrollPositions.has(key)) scrollPositions.delete(key);
+    scrollPositions.set(key, position);
+    if (scrollPositions.size > MAX_SCROLL_ENTRIES) {
+      // Evict the least-recently-written PER-PATH entry. `shared:` entries
+      // are long-lived singletons (one per share key); churning one out via
+      // unrelated path traffic would strand every path that resolves to it.
+      for (const candidate of scrollPositions.keys()) {
+        if (candidate.startsWith("path:")) {
+          scrollPositions.delete(candidate);
+          break;
+        }
+      }
+    }
+  };
+
   const scrollListener = () => {
     if (scrollContainer && currentPath && !isTransitioning) {
-      scrollPositions.set(getScrollPolicy(currentPath).storageKey, {
+      rememberScrollPosition(getScrollPolicy(currentPath).storageKey, {
         x: scrollContainer.scrollLeft,
         y: scrollContainer.scrollTop,
       });

--- a/packages/core/src/lib/ssgoi-transition/create-context-manager.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-context-manager.ts
@@ -94,6 +94,10 @@ export function createContextManager(options: ContextManagerOptions = {}) {
   };
 
   let contextElement: HTMLElement | null = null;
+  // Window-level resources, kept so destroy() can release them. Re-acquired
+  // lazily by the next initializeContext after a destroy.
+  let scrollTarget: Window | HTMLElement | null = null;
+  let resizeObserver: ResizeObserver | null = null;
   const scrollPositions: Map<string, ScrollPosition> = new Map();
   let currentPath: string | null = null;
   // Suppress scroll capture during the transition window so OUT scrolls of
@@ -192,18 +196,18 @@ export function createContextManager(options: ContextManagerOptions = {}) {
       cachedIsMobile = measureIsMobile();
       isMobileMeasured = true;
       if (typeof ResizeObserver !== "undefined") {
-        const observer = new ResizeObserver(() => {
+        resizeObserver = new ResizeObserver(() => {
           cachedIsMobile = measureIsMobile();
         });
-        observer.observe(scrollContainer);
+        resizeObserver.observe(scrollContainer);
       }
 
       // IMPORTANT: When the scrolling element is document.documentElement,
       // scroll events must be attached to window, not the element itself.
       // For all other scrollable containers, attach to the element directly.
-      const target =
+      scrollTarget =
         scrollContainer === document.documentElement ? window : scrollContainer;
-      target.addEventListener("scroll", scrollListener, {
+      scrollTarget.addEventListener("scroll", scrollListener, {
         passive: true,
       });
     }
@@ -277,6 +281,18 @@ export function createContextManager(options: ContextManagerOptions = {}) {
       : { x: 0, y: 0 };
   };
 
+  // Release the scroll listener + ResizeObserver. Dropping the cached
+  // container makes the next initializeContext re-discover it and re-attach
+  // fresh listeners, so a destroyed manager is fully restartable.
+  const destroy = () => {
+    scrollTarget?.removeEventListener("scroll", scrollListener);
+    scrollTarget = null;
+    resizeObserver?.disconnect();
+    resizeObserver = null;
+    scrollContainer = null;
+    isMobileMeasured = false;
+  };
+
   return {
     initializeContext,
     calculateScrollOffset,
@@ -285,5 +301,6 @@ export function createContextManager(options: ContextManagerOptions = {}) {
     getScrollContainer,
     getPositionedParentElement,
     getScrollPosition,
+    destroy,
   };
 }

--- a/packages/core/src/lib/ssgoi-transition/create-ssgoi-transition-context.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-ssgoi-transition-context.ts
@@ -109,6 +109,7 @@ export function createSggoiTransitionContext(
     getScrollContainer,
     getPositionedParentElement,
     getScrollPosition,
+    destroy: releaseScrollTracking,
   } = createContextManager({ preserveScroll });
 
   let pendingOut: PendingSide | null = null;
@@ -581,5 +582,18 @@ export function createSggoiTransitionContext(
     return cb;
   };
 
-  return { register, refFor };
+  // Window-level resource lifecycle, driven by observeSsgoiTransitions so
+  // every adapter's existing observe-cleanup wiring covers it: observe →
+  // start(), cleanup → destroy(). Both are idempotent, keeping provider
+  // remount cycles (HMR, React strict mode) symmetric.
+  const start = () => {
+    swipeDetector.initialize();
+  };
+
+  const destroy = () => {
+    swipeDetector.destroy();
+    releaseScrollTracking();
+  };
+
+  return { register, refFor, start, destroy };
 }

--- a/packages/core/src/lib/ssgoi-transition/create-ssgoi-transition-context.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-ssgoi-transition-context.ts
@@ -309,6 +309,14 @@ export function createSggoiTransitionContext(
       to: toPromise,
       extras: extrasPromise,
     }).then(({ from: resolvedFrom, to: resolvedTo, extras }) => {
+      // Settle the interrupted run NOW — before the new transition's
+      // animation() writes setup styles (clipPath, transformOrigin, …) onto
+      // nodes both runs share in hidden mode. Completing it later (inside
+      // host.attach) would fire its preset onComplete cleanups last and
+      // wipe those styles for the whole new run. The returned poses still
+      // carry the live mid-flight state for the matchInto handoff below.
+      const handoffPoses = host.flush();
+
       // Now that prepare's microtasks have all run (initial styles, extras
       // built), drop the outgoing clone into place. Order is:
       //   prepare → out insert → animation create/play
@@ -351,7 +359,7 @@ export function createSggoiTransitionContext(
 
       // Host owns pose handoff, playbackRate carry-over, and starts the run
       // according to its own play/pause/reverse state.
-      host.attach(animation);
+      host.attach(animation, handoffPoses);
     });
   };
 

--- a/packages/core/src/lib/ssgoi-transition/create-swipe-back-detector.test.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-swipe-back-detector.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createSwipeBackDetector } from "./create-swipe-back-detector";
+
+type Handler = (event: TouchEvent) => void;
+
+const makeTouch = (identifier: number, clientX: number, clientY: number) => ({
+  identifier,
+  clientX,
+  clientY,
+});
+
+const touchList = (touches: ReturnType<typeof makeTouch>[]) => ({
+  length: touches.length,
+  item: (i: number) => touches[i] ?? null,
+});
+
+describe("createSwipeBackDetector", () => {
+  let handlers: Map<string, Set<Handler>>;
+
+  const fire = (type: string, event: object) => {
+    for (const handler of handlers.get(type) ?? []) {
+      handler(event as TouchEvent);
+    }
+  };
+
+  const swipeFromLeftEdge = () => {
+    fire("touchstart", { touches: touchList([makeTouch(1, 10, 300)]) });
+    fire("touchmove", { touches: touchList([makeTouch(1, 40, 302)]) });
+    fire("touchend", { changedTouches: touchList([makeTouch(1, 70, 300)]) });
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    handlers = new Map();
+    vi.stubGlobal("window", {
+      innerWidth: 400,
+      addEventListener: (type: string, handler: Handler) => {
+        if (!handlers.has(type)) handlers.set(type, new Set());
+        handlers.get(type)!.add(handler);
+      },
+      removeEventListener: (type: string, handler: Handler) => {
+        handlers.get(type)?.delete(handler);
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("initialize is idempotent and destroy removes every listener", () => {
+    const detector = createSwipeBackDetector();
+    detector.initialize();
+    detector.initialize();
+
+    const types = ["touchstart", "touchmove", "touchend", "touchcancel"];
+    for (const type of types) {
+      expect(handlers.get(type)?.size).toBe(1);
+    }
+
+    detector.destroy();
+    for (const type of types) {
+      expect(handlers.get(type)?.size).toBe(0);
+    }
+  });
+
+  it("re-arms after destroy (provider remount cycle)", () => {
+    const detector = createSwipeBackDetector();
+    detector.initialize();
+    detector.destroy();
+    detector.initialize();
+
+    expect(handlers.get("touchstart")?.size).toBe(1);
+    swipeFromLeftEdge();
+    expect(detector.isSwipeBack()).toBe(true);
+  });
+
+  it("detects an edge swipe and clears after onPageEnter", () => {
+    const detector = createSwipeBackDetector();
+    detector.initialize();
+
+    expect(detector.isSwipeBack()).toBe(false);
+    swipeFromLeftEdge();
+    expect(detector.isSwipeBack()).toBe(true);
+
+    detector.onPageEnter();
+    // stickyActive lives one extra macrotask so an OUT/IN pair queued
+    // together reads the same value.
+    expect(detector.isSwipeBack()).toBe(true);
+    vi.advanceTimersByTime(0);
+    expect(detector.isSwipeBack()).toBe(false);
+  });
+
+  it("ignores center-screen and vertical gestures", () => {
+    const detector = createSwipeBackDetector();
+    detector.initialize();
+
+    // Start away from both edges.
+    fire("touchstart", { touches: touchList([makeTouch(1, 200, 300)]) });
+    fire("touchend", { changedTouches: touchList([makeTouch(1, 260, 300)]) });
+    expect(detector.isSwipeBack()).toBe(false);
+
+    // Edge start, but vertically dominant movement (scrolling).
+    fire("touchstart", { touches: touchList([makeTouch(2, 10, 300)]) });
+    fire("touchmove", { touches: touchList([makeTouch(2, 14, 400)]) });
+    fire("touchend", { changedTouches: touchList([makeTouch(2, 50, 500)]) });
+    expect(detector.isSwipeBack()).toBe(false);
+  });
+
+  it("destroy clears a pending swipe flag", () => {
+    const detector = createSwipeBackDetector();
+    detector.initialize();
+    swipeFromLeftEdge();
+    detector.destroy();
+    expect(detector.isSwipeBack()).toBe(false);
+  });
+});

--- a/packages/core/src/lib/ssgoi-transition/create-swipe-back-detector.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-swipe-back-detector.ts
@@ -210,11 +210,11 @@ export function createSwipeBackDetector() {
     window.addEventListener("touchcancel", onTouchCancel, opts);
   };
 
-  // TODO: not currently called from anywhere. Wire from each adapter's Ssgoi
-  // provider unmount (React useEffect cleanup, Vue onUnmounted, Svelte
-  // onDestroy, Solid onCleanup, Angular ngOnDestroy) so HMR / repeated mounts /
-  // multi-provider pages don't accumulate window touch listeners. Non-issue in
-  // production root-level usage today.
+  // Wired through observeSsgoiTransitions: its returned cleanup calls
+  // context.destroy() → here, and a re-observe calls initialize() again.
+  // Every adapter already runs that cleanup on provider unmount, so HMR /
+  // repeated mounts / multi-provider pages don't accumulate window touch
+  // listeners.
   const destroy = () => {
     if (typeof window === "undefined" || !installed) return;
     installed = false;

--- a/packages/core/src/lib/ssgoi-transition/observe-ssgoi-transitions.test.ts
+++ b/packages/core/src/lib/ssgoi-transition/observe-ssgoi-transitions.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SsgoiContext } from "@types";
+import { observeSsgoiTransitions } from "./observe-ssgoi-transitions";
+
+const createFakeRoot = (): Element => {
+  const root = {
+    nodeType: 1,
+    setAttribute: vi.fn(),
+    matches: () => false,
+    querySelectorAll: () => [],
+    closest: () => root,
+  };
+  return root as unknown as Element;
+};
+
+const createFakeContext = () => {
+  const context: SsgoiContext = {
+    register: vi.fn(),
+    refFor: vi.fn(),
+    start: vi.fn(),
+    destroy: vi.fn(),
+  };
+  return context;
+};
+
+describe("observeSsgoiTransitions context lifecycle", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "MutationObserver",
+      class {
+        observe = vi.fn();
+        disconnect = vi.fn();
+      },
+    );
+    vi.stubGlobal("HTMLElement", class {});
+    vi.stubGlobal("Node", { ELEMENT_NODE: 1 });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("arms the context on observe and releases it in the cleanup", () => {
+    const context = createFakeContext();
+    const cleanup = observeSsgoiTransitions(createFakeRoot(), context);
+
+    expect(context.start).toHaveBeenCalledTimes(1);
+    expect(context.destroy).not.toHaveBeenCalled();
+
+    cleanup();
+    expect(context.destroy).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays symmetric across remount cycles (HMR / strict mode)", () => {
+    const context = createFakeContext();
+
+    const first = observeSsgoiTransitions(createFakeRoot(), context);
+    first();
+    const second = observeSsgoiTransitions(createFakeRoot(), context);
+    second();
+
+    expect(context.start).toHaveBeenCalledTimes(2);
+    expect(context.destroy).toHaveBeenCalledTimes(2);
+  });
+
+  it("touches nothing when the DOM cannot be observed (SSR)", () => {
+    vi.stubGlobal("MutationObserver", undefined);
+    const context = createFakeContext();
+
+    const cleanup = observeSsgoiTransitions(createFakeRoot(), context);
+    cleanup();
+
+    expect(context.start).not.toHaveBeenCalled();
+    expect(context.destroy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/lib/ssgoi-transition/observe-ssgoi-transitions.ts
+++ b/packages/core/src/lib/ssgoi-transition/observe-ssgoi-transitions.ts
@@ -28,6 +28,12 @@ export function observeSsgoiTransitions(
 ): () => void {
   if (!canObserveDom()) return () => {};
 
+  // Arm the context's window-level resources (swipe-back detector) together
+  // with the DOM observer, and release them in the returned cleanup. Every
+  // adapter already runs that cleanup on provider unmount, so listeners
+  // can't accumulate across HMR / strict-mode remounts.
+  ssgoi.start?.();
+
   root.setAttribute(ROOT_ATTRIBUTE, "");
 
   const ownsElement = (element: Element) =>
@@ -81,5 +87,8 @@ export function observeSsgoiTransitions(
   });
   scanNode(root);
 
-  return () => observer.disconnect();
+  return () => {
+    observer.disconnect();
+    ssgoi.destroy?.();
+  };
 }

--- a/packages/core/src/lib/transitions/axis/transition.ts
+++ b/packages/core/src/lib/transitions/axis/transition.ts
@@ -62,6 +62,12 @@ export const axis = (options: AxisOptions = {}): TransitionConfig => {
       return {};
     },
     animation: ({ from, to, context }) => {
+      // X/Y pairs mirror cleanly (in(t) ≈ out(1-t) under direction-paired
+      // routes), so they opt into pose matching. Z's fade-through opacity
+      // split (out fades over t∈[0,1/3], in over t∈[1/3,1]) is NOT a
+      // mirror — a role-flip seed would pop opacity by up to 0.5 — so z
+      // stays unkeyed and starts fresh on interrupts.
+      const poseKey = (role: "out" | "in") => (type === "z" ? undefined : role);
       // Z scales the page element in place. Without clipping to the viewport
       // slice, scale-up paints over chrome / scroll overflow and scale-down
       // exposes neighbouring layout. Mirror sheet's inset trick.
@@ -74,6 +80,7 @@ export const axis = (options: AxisOptions = {}): TransitionConfig => {
 
       const outAnim = new WebAnimation({
         element: from,
+        key: poseKey("out"),
         integrator: IntegratorProvider.from(provider.outPhysics),
         style: (t) => config.out.animate(t),
         // Restore the reused from node's inline styles on complete. This
@@ -85,6 +92,7 @@ export const axis = (options: AxisOptions = {}): TransitionConfig => {
 
       const inAnim = new WebAnimation({
         element: to,
+        key: poseKey("in"),
         integrator: IntegratorProvider.from(provider.inPhysics),
         style: (t) => config.in.animate(t),
         onComplete: () => clearStyle(to),

--- a/packages/core/src/lib/transitions/drill/transition.ts
+++ b/packages/core/src/lib/transitions/drill/transition.ts
@@ -42,6 +42,7 @@ export const drill = (options: DrillOptions = {}): TransitionConfig => {
     animation: ({ from, to }) => {
       const outAnim = new WebAnimation({
         element: from,
+        key: "out",
         integrator: IntegratorProvider.from(physicsOptions),
         style: (t) => config.out.animate(t),
         // The outgoing node is the real, reused element (re-hidden on navigate),
@@ -61,6 +62,7 @@ export const drill = (options: DrillOptions = {}): TransitionConfig => {
 
       const inAnim = new WebAnimation({
         element: to,
+        key: "in",
         integrator: IntegratorProvider.from(physicsOptions),
         style: (t) => config.in.animate(t),
         onComplete: () => {

--- a/packages/core/src/lib/transitions/fade/transition.ts
+++ b/packages/core/src/lib/transitions/fade/transition.ts
@@ -33,6 +33,7 @@ export const fade = (options: FadeOptions = {}): TransitionConfig => {
     animation: ({ from, to }) => {
       const outAnim = new WebAnimation({
         element: from,
+        key: "out",
         integrator: IntegratorProvider.from(outPhysics),
         // Default bounds (0, 1). `u` runs 1→0 as the animation moves
         // forward, mapping opacity from fully visible to invisible.
@@ -49,6 +50,7 @@ export const fade = (options: FadeOptions = {}): TransitionConfig => {
 
       const inAnim = new WebAnimation({
         element: to,
+        key: "in",
         integrator: IntegratorProvider.from(inPhysics),
         style: (t) => ({ opacity: t }),
         onComplete: () => {

--- a/packages/core/src/lib/transitions/hero/provider/chrome/fade.ts
+++ b/packages/core/src/lib/transitions/hero/provider/chrome/fade.ts
@@ -33,11 +33,13 @@ class PageCrossfadeChromeStrategy implements HeroStrategy {
     return [
       new WebAnimation({
         element: from,
+        key: "out",
         integrator: IntegratorProvider.from(physics),
         style: (_t, u) => ({ opacity: u }),
       }),
       new WebAnimation({
         element: to,
+        key: "in",
         integrator: IntegratorProvider.from(physics),
         style: (t) => ({ opacity: t }),
       }),

--- a/packages/core/src/lib/transitions/jaemin/transition.ts
+++ b/packages/core/src/lib/transitions/jaemin/transition.ts
@@ -65,6 +65,11 @@ export const jaemin = (options: JaeminOptions = {}): TransitionConfig => {
       return {};
     },
     animation: ({ from, to }) => {
+      // No motion-matching keys: the two sides animate different channels
+      // entirely (out is a pure opacity fade; in is a pow-9-eased scale +
+      // late rotation unwind at opacity 1), so in(t) is nothing like
+      // out(1-t) and a role-flip seed would pop hard. Unkeyed animations
+      // opt out of pose handoff entirely.
       const outAnim = new WebAnimation({
         element: from,
         integrator: IntegratorProvider.from(OUT_PHYSICS),

--- a/packages/core/src/lib/transitions/rotate/transition.ts
+++ b/packages/core/src/lib/transitions/rotate/transition.ts
@@ -30,6 +30,10 @@ export const rotate = (options: RotateOptions = {}): TransitionConfig => {
       return {};
     },
     animation: ({ from, to }) => {
+      // No motion-matching keys: rotate's in/out styles are a CONTINUATION
+      // (out spins 0→+180°, in unwinds −180°→0 so the pair reads as one
+      // 360° turn), not mirrors — a role-flip seed would jump the visible
+      // angle. Unkeyed animations opt out of pose handoff entirely.
       const outAnim = new WebAnimation({
         element: from,
         integrator: IntegratorProvider.from(physicsOptions),

--- a/packages/core/src/lib/transitions/scroll/transition.ts
+++ b/packages/core/src/lib/transitions/scroll/transition.ts
@@ -51,6 +51,7 @@ export const scroll = (options: ScrollOptions = {}): TransitionConfig => {
 
       const outAnim = new WebAnimation({
         element: from,
+        key: "out",
         integrator: IntegratorProvider.from(physicsOptions),
         style: (t) => {
           const translateY = isUp ? -height * t : height * t;
@@ -74,6 +75,7 @@ export const scroll = (options: ScrollOptions = {}): TransitionConfig => {
 
       const inAnim = new WebAnimation({
         element: to,
+        key: "in",
         integrator: IntegratorProvider.from(physicsOptions),
         style: (_t, u) => {
           const translateY = isUp ? u * height : u * -height;

--- a/packages/core/src/lib/transitions/sheet/transition.ts
+++ b/packages/core/src/lib/transitions/sheet/transition.ts
@@ -88,6 +88,10 @@ export const sheet = (options: SheetOptions = {}): TransitionConfig => {
 
       const sheetAnim = new WebAnimation({
         element: sheetEl,
+        // The sheet is the incoming page on `enter` and the outgoing page on
+        // `exit`; its enter/exit styles are exact mirrors (u vs t × height),
+        // so role-flip pose matching resumes an interrupted slide in place.
+        key: direction === "enter" ? "in" : "out",
         integrator: IntegratorProvider.from(physics),
         style: sheetStyle,
         onComplete: () => {
@@ -126,6 +130,7 @@ export const sheet = (options: SheetOptions = {}): TransitionConfig => {
 
       const bgAnim = new WebAnimation({
         element: backgroundEl,
+        key: direction === "enter" ? "out" : "in",
         integrator: IntegratorProvider.from(physics),
         style: bgStyle,
         // On `exit` the background is the incoming (`to`) node; on `enter` it is

--- a/packages/core/src/lib/transitions/slide/transition.ts
+++ b/packages/core/src/lib/transitions/slide/transition.ts
@@ -43,6 +43,7 @@ export const slide = (options: SlideOptions = {}): TransitionConfig => {
     animation: ({ from, to }) => {
       const outAnim = new WebAnimation({
         element: from,
+        key: "out",
         integrator: IntegratorProvider.from(physicsOptions),
         style: (t) => {
           const translateX = isLeft ? -100 * t : 100 * t;
@@ -63,6 +64,7 @@ export const slide = (options: SlideOptions = {}): TransitionConfig => {
 
       const inAnim = new WebAnimation({
         element: to,
+        key: "in",
         integrator: IntegratorProvider.from(physicsOptions),
         style: (_t, u) => {
           const translateX = isLeft ? u * 100 : u * -100;

--- a/packages/core/src/lib/transitions/strip/transition.ts
+++ b/packages/core/src/lib/transitions/strip/transition.ts
@@ -37,6 +37,10 @@ export const strip = (options: StripOptions = {}): TransitionConfig => {
       return {};
     },
     animation: ({ from, to }) => {
+      // No motion-matching keys: the strip carousel always exits to the
+      // right and enters from the left, so in(t) is NOT out(1-t) — a
+      // role-flip seed would teleport the page across the viewport. Unkeyed
+      // animations opt out of pose handoff entirely.
       const outAnim = new WebAnimation({
         element: from,
         integrator: IntegratorProvider.from(physicsOptions),

--- a/packages/core/src/lib/types/index.ts
+++ b/packages/core/src/lib/types/index.ts
@@ -58,6 +58,22 @@ export type Pose = {
   element: HTMLElement;
   value: number;
   velocity: number;
+  /**
+   * Logical role for matching when element identity can't survive a handoff
+   * (unmount-mode clones are new nodes every navigation). The reserved roles
+   * "out" and "in" match each other MIRRORED — a page 70% gone re-enters 30%
+   * visible, moving the opposite way. Any other string is a custom identity
+   * that matches itself directly. See animation/pose-matching.ts.
+   */
+  key?: string;
+  /**
+   * Bounds of the t-space `value` and `velocity` live in. A receiver with
+   * different bounds rebases the pose into its own range (value via
+   * normalized progress, velocity rescaled to the new span) instead of
+   * misreading raw numbers. Default 0 / 1.
+   */
+  lowerBound?: number;
+  upperBound?: number;
 };
 
 export type TimelineFrame = {

--- a/packages/core/src/lib/types/index.ts
+++ b/packages/core/src/lib/types/index.ts
@@ -246,4 +246,19 @@ export type SsgoiContext = {
    * `useCallback`/`useMemo`.
    */
   refFor: (path: string) => (element: HTMLElement | null) => void;
+
+  /**
+   * (Re-)arm window-level resources (swipe-back touch listeners). Idempotent.
+   * `observeSsgoiTransitions` calls this on every (re)observe, so provider
+   * teardown/remount cycles (HMR, React strict mode) stay symmetric without
+   * any adapter-side wiring.
+   */
+  start?: () => void;
+
+  /**
+   * Release window-level resources (swipe-back touch listeners, scroll
+   * tracking). Called by the cleanup function `observeSsgoiTransitions`
+   * returns; a later `start()` + `register()` re-arms everything.
+   */
+  destroy?: () => void;
 };


### PR DESCRIPTION
## Why

Every page preset returns a `MultiAnimation`, and `MultiAnimation.matchInto()` was a documented no-op — so the `getPose()` → `matchInto()` handoff that `HostAnimation.attach()` performs was effectively dead. Interrupting a transition always restarted the next one from rest, with a visible pop. This PR turns motion matching on, makes it correct under interruption, and ships a set of engine optimizations alongside it.

## What

### Motion matching (pose protocol)

- **`Pose` gains `key` and `lowerBound`/`upperBound`** (all optional, backward compatible). `key` carries the animation's logical role — reserved `"out"`/`"in"` or a custom string. Bounds let a receiver rebase a pose captured in a different t-space.
- **New `pose-matching.ts`** centralizes the matching rules:
  1. same element + same key → direct seed
  2. same element + opposite roles → **mirrored** seed (`1 − progress`, negated velocity) — a page 70% gone re-enters 30% visible, moving the opposite way
  3. cross-element custom key → direct seed when unique
  4. cross-element reserved roles → **out-side only**: the page being left is always the page that was arriving, so `"out"` may borrow the unique prior `"in"` pose (this is what survives unmount-mode clone replacement). The in side never borrows cross-element — poses carry no page identity, so a true reverse (B→A) is indistinguishable from a chained navigation to a brand-new page (B→C).
- **`rebasePose`** maps value via normalized progress and rescales velocity by the span ratio, so handoffs across different bounds keep perceived speed.
- **`MultiAnimation.matchInto` fans poses out to children.** Interrupted sequences resume from the right stage: a child seeded at its target settles instantly and hands off to the next. The zero-frame fast path now holds its final frame with a 0-duration forwards-filling WAAPI entry, matching natural-finish semantics (preset cleanups wipe inline styles and rely on the fill).
- **`HostAnimation.flush()`**: the dispatcher now settles the interrupted run *before* the new transition's `animation()` writes setup styles, so the old run's preset cleanups can no longer wipe the new run's `clipPath`/`transformOrigin` on shared real nodes (hidden mode). `attach(next, poses?)` accepts the pre-captured poses.
- **Preset wiring**: `key: "out"/"in"` added where the mirror invariant `in(t) ≈ out(1−t)` actually holds — axis x/y, fade, drill, slide, scroll, sheet, hero chrome. **Deliberately unkeyed** (they opt out of seeding entirely, with comments explaining why): rotate and strip (continuation choreography), jaemin (different channels per side), axis z (asymmetric fade-through split).

### External ("host") animation takeover

- **New `capturePoseFrom(element, { read, … })`** (public export): samples in-flight WAAPI/CSS animations into a `Pose` — value from computed styles, velocity by seeking playback back `sampleMs` of wall-clock and re-reading, all synchronously. Rate-aware (handles `reverse()`/negative rates, scales by `playbackRate`), skips frozen (`rate === 0`) and future-scheduled (negative `currentTime`) animations, restores playback position in a `finally`. Feed the result into `animation.matchInto([pose])` to take over host-driven motion continuously.

### Engine fixes & optimizations

- **`captureLiveState` now reads the WAAPI clock** (`waapi.currentTime`) instead of wall-clock elapsed, so live poses stay correct under `playbackRate ≠ 1` and across pause/resume (wall-clock remains the fallback).
- **Keyframe decimation** (`keyframe-compression.ts`): baked WAAPI keyframes collapse every run of frames whose positions stay within a 0.2%-of-travel band down to its endpoints — the spring settle tail and sub-visual overshoot wiggle shrink from hundreds of keyframes to a handful. The error bound needs no linearity assumption about the style function (style is continuous in position, and the band bounds position variation). Explicit offsets keep the original clock; `getPose()`/`findTimeForProgress()` still interpolate the full simulation frames, so live reads lose no accuracy.
- **Scroll position LRU**: `scrollPositions` is capped at 50 entries with delete-then-set recency. `shared:<key>` singletons are exempt from eviction so per-path churn (e.g. excluded routes with no matching transition) can't strand shared-scroll paths.

## How this was reviewed

The branch went through a 30-agent adversarial review (4 domain reviewers — physics/math, interruption semantics, WAAPI mechanics, API compat — with 2 independent verifiers per finding), which confirmed 12 findings including one critical (the zero-frame fill hold) and the chained-navigation over-match. All were fixed, and a second 8-agent pass verified every fix against the final code with no remaining issues.

## Tests

57 new tests (95 total, all passing): integrator determinism and settling, pose matching priorities and the chained-nav guard, rebase math (mirror, span rescale, overshoot, degenerate spans), keyframe compression error bounds, seeded handoff through `WebAnimation`/`MultiAnimation`/`HostAnimation` (including instant-settle + fill hold and the two-step flush→attach), rate-aware external pose capture, and scroll LRU behavior. `tsc`, eslint, and the library build are clean.

## Follow-ups (out of scope here)

- ~~Wire the already-implemented swipe-back detector into the framework adapters~~ — done in this PR: the context now exposes `start()`/`destroy()` and `observeSsgoiTransitions` arms/releases them, so every adapter gets symmetric window-listener teardown (HMR / strict-mode safe) with zero adapter changes. The detector's job is detect-and-suppress (the native gesture owns the visuals), so no gesture-driven interactive mode is planned.
- Path-scoped role keys (e.g. `in:<path>`) would let the in side safely borrow continuity on true reverses in unmount mode.
- Epoch-guarded preset cleanups: `prepare`-written hint styles (`willChange`/`contain`/`pointerEvents`) on shared hidden-mode nodes can still be wiped by an interrupted run's cleanup — pre-existing, lower-impact than the `clipPath` case fixed here.
- Extend hidden-mode (real node reuse) support beyond React `<Activity>`/Next `cacheComponents` to Vue `<KeepAlive>` and Svelte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

