### PR TITLE
Release v6.5.0 — React <Activity> / Next.js cacheComponents page transitions

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -7,6 +7,13 @@
       "runtimeArgs": ["run", "docs"],
       "port": 3000,
       "autoPort": false
+    },
+    {
+      "name": "dev",
+      "runtimeExecutable": "pnpm",
+      "runtimeArgs": ["--filter", "dev", "dev"],
+      "port": 3000,
+      "autoPort": false
     }
   ]
 }

--- a/apps/dev/src/app/activity/page.tsx
+++ b/apps/dev/src/app/activity/page.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { Activity, useState } from "react";
+import type { CSSProperties } from "react";
+import { Ssgoi, type SsgoiConfig } from "@ssgoi/react";
+import { drill } from "@ssgoi/react/view-transitions";
+
+/**
+ * React `<Activity>` smoke test for ssgoi core — using the `drill` transition,
+ * which (like most transitions) leaks inline styles onto the OUTGOING node
+ * (pointer-events:none, z-index, …) and never resets them, because it assumes
+ * that node is a throwaway clone. In hidden mode the outgoing node is the REAL
+ * reused element, so those must be cleaned up or the page comes back
+ * non-interactive / behind everything. The per-page click counters verify the
+ * pages stay interactive after navigating back and forth.
+ */
+
+const A = "/activity/a";
+const B = "/activity/b";
+
+const config: SsgoiConfig = {
+  transitions: drill({ enter: B, exit: A }),
+};
+
+const page = (bg: string): CSSProperties => ({
+  position: "absolute",
+  inset: 0,
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "center",
+  justifyContent: "center",
+  gap: 16,
+  background: bg,
+  color: "white",
+  fontSize: 24,
+  fontWeight: 600,
+});
+
+const btn: CSSProperties = {
+  padding: "8px 16px",
+  borderRadius: 9999,
+  border: "1px solid rgba(255,255,255,0.25)",
+  background: "rgba(255,255,255,0.12)",
+  color: "white",
+  fontSize: 16,
+  cursor: "pointer",
+};
+
+const navBtn: CSSProperties = { ...btn, fontSize: 14 };
+
+export default function ActivityTestPage() {
+  const [active, setActive] = useState<"a" | "b">("a");
+  const [draft, setDraft] = useState("");
+  const [countA, setCountA] = useState(0);
+  const [countB, setCountB] = useState(0);
+
+  return (
+    <main
+      style={{
+        minHeight: "100dvh",
+        display: "flex",
+        flexDirection: "column",
+        background: "#0a0a0a",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          gap: 8,
+          alignItems: "center",
+          padding: 16,
+          color: "#a3a3a3",
+          fontSize: 14,
+        }}
+      >
+        <button style={navBtn} onClick={() => setActive("a")}>
+          Show A
+        </button>
+        <button style={navBtn} onClick={() => setActive("b")}>
+          Show B
+        </button>
+        <button
+          style={navBtn}
+          onClick={() => setActive((p) => (p === "a" ? "b" : "a"))}
+        >
+          Toggle
+        </button>
+        <span style={{ marginLeft: "auto", fontFamily: "monospace" }}>
+          active: {active}
+        </span>
+      </div>
+
+      <Ssgoi config={config}>
+        <div style={{ position: "relative", flex: 1, overflow: "hidden" }}>
+          <Activity mode={active === "a" ? "visible" : "hidden"}>
+            <div data-ssgoi-transition={A} style={page("#1e3a8a")}>
+              <span>Page A</span>
+              <button style={btn} onClick={() => setCountA((c) => c + 1)}>
+                A clicks: {countA}
+              </button>
+              <input
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
+                placeholder="type, then toggle"
+                style={{
+                  padding: "8px 12px",
+                  borderRadius: 8,
+                  border: "1px solid rgba(255,255,255,0.25)",
+                  background: "rgba(0,0,0,0.25)",
+                  color: "white",
+                  fontSize: 16,
+                  fontWeight: 400,
+                  width: 220,
+                  textAlign: "center",
+                }}
+              />
+            </div>
+          </Activity>
+
+          <Activity mode={active === "b" ? "visible" : "hidden"}>
+            <div data-ssgoi-transition={B} style={page("#7c2d12")}>
+              <span>Page B</span>
+              <button style={btn} onClick={() => setCountB((c) => c + 1)}>
+                B clicks: {countB}
+              </button>
+            </div>
+          </Activity>
+        </div>
+      </Ssgoi>
+    </main>
+  );
+}

--- a/apps/dev/src/app/page.tsx
+++ b/apps/dev/src/app/page.tsx
@@ -11,6 +11,12 @@ const ROUTES: { href: string; title: string; description: string }[] = [
     title: "/animator",
     description: "Animator 테스트용 빈 라우트",
   },
+  {
+    href: "/activity",
+    title: "/activity",
+    description:
+      "React <Activity> 전환 테스트 — display:none hide/show로 unmount 없이 페이지 전환",
+  },
 ];
 
 export default function Home() {

--- a/apps/docs/next.config.ts
+++ b/apps/docs/next.config.ts
@@ -20,6 +20,11 @@ const devHosts =
 
 const nextConfig: NextConfig = {
   allowedDevOrigins: devHosts,
+  // Keep previously-visited routes mounted (hidden via React <Activity>) on
+  // client navigation instead of unmounting them. ssgoi detects the
+  // display:none hide/show and runs page transitions on the real nodes,
+  // so navigation animations work with cached/kept-alive pages.
+  cacheComponents: true,
   async redirects() {
     return [{ source: "/showcase", destination: "/", permanent: true }];
   },

--- a/apps/docs/src/app/blog/rss.xml/route.ts
+++ b/apps/docs/src/app/blog/rss.xml/route.ts
@@ -1,7 +1,8 @@
 import { SITE_DESCRIPTION, SITE_NAME, SITE_URL } from "@/lib/seo";
 import { getAllPosts } from "@/lib/blog";
 
-export const dynamic = "force-static";
+// `dynamic = "force-static"` is incompatible with cacheComponents; the feed is
+// cheap to generate per request from local MDX, so render it dynamically.
 
 function escapeXml(value: string) {
   return value

--- a/apps/docs/src/app/demo/layout.tsx
+++ b/apps/docs/src/app/demo/layout.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { Suspense, type ReactNode } from "react";
 import { useShowcaseHost } from "@/lib/components/host-context";
 import { FloatingAnimationDock } from "@/lib/components/animation-dock";
 
@@ -16,7 +16,11 @@ export default function DemoLayout({ children }: { children: ReactNode }) {
   const host = useShowcaseHost();
   return (
     <>
-      {children}
+      {/* Demo route pages read runtime-dynamic data (route `params`,
+          `searchParams`) for their interactive content. Under cacheComponents
+          that must sit inside a <Suspense> boundary so the static shell can
+          prerender without it — one boundary here covers every /demo/* page. */}
+      <Suspense>{children}</Suspense>
       <FloatingAnimationDock host={host} />
     </>
   );

--- a/apps/docs/src/app/docs/page.tsx
+++ b/apps/docs/src/app/docs/page.tsx
@@ -9,13 +9,13 @@ import { DOCS_NAV } from "@/page/docs/nav";
 export const metadata: Metadata = {
   title: "Docs — Setup, transitions, and how SSGOI works",
   description:
-    "Install SSGOI, mark your pages, and pick from twelve page transitions. Setup lives in plain-text llms.txt files your AI agent can read directly.",
+    "Install SSGOI, mark your pages, and pick from thirteen page transitions. Setup lives in plain-text llms.txt files your AI agent can read directly.",
   alternates: { canonical: "/docs" },
   openGraph: buildOpenGraph({
     path: "/docs",
     title: "SSGOI Docs — Setup, transitions, and how it works",
     description:
-      "Install SSGOI, mark your pages, and pick from twelve page transitions. Setup lives in plain-text llms.txt files your AI agent can read directly.",
+      "Install SSGOI, mark your pages, and pick from thirteen page transitions. Setup lives in plain-text llms.txt files your AI agent can read directly.",
   }),
 };
 

--- a/apps/docs/src/app/docs/transitions/[transition]/page.tsx
+++ b/apps/docs/src/app/docs/transitions/[transition]/page.tsx
@@ -9,8 +9,9 @@ import {
   getTransitionDoc,
 } from "@/page/docs/transitions-data";
 
-export const dynamicParams = false;
-
+// `dynamicParams = false` is incompatible with cacheComponents. The known
+// transitions are still prerendered via generateStaticParams; an unknown slug
+// falls through to `notFound()` below, so it 404s either way.
 export function generateStaticParams() {
   return TRANSITION_DOCS.map((t) => ({ transition: t.name }));
 }

--- a/apps/docs/src/app/docs/transitions/[transition]/page.tsx
+++ b/apps/docs/src/app/docs/transitions/[transition]/page.tsx
@@ -1,0 +1,62 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { JsonLd } from "@/components/json-ld";
+import { breadcrumbSchema, buildOpenGraph } from "@/lib/seo";
+import { DocsPageHeading } from "@/page/docs/sections";
+import { TransitionDetailBody } from "@/page/docs/transition-detail";
+import {
+  TRANSITION_DOCS,
+  getTransitionDoc,
+} from "@/page/docs/transitions-data";
+
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return TRANSITION_DOCS.map((t) => ({ transition: t.name }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ transition: string }>;
+}): Promise<Metadata> {
+  const { transition } = await params;
+  const doc = getTransitionDoc(transition);
+  if (!doc)
+    return { title: "Not found", robots: { index: false, follow: true } };
+
+  const path = `/docs/transitions/${doc.name}`;
+  const variantList = doc.variants.map((v) => v.label).join(", ");
+  return {
+    title: `${doc.name} — page transition variants & usage | SSGOI`,
+    description: `${doc.intro} Variants: ${variantList}.`,
+    alternates: { canonical: path },
+    openGraph: buildOpenGraph({ path }),
+  };
+}
+
+export default async function DocsTransitionDetailPage({
+  params,
+}: {
+  params: Promise<{ transition: string }>;
+}) {
+  const { transition } = await params;
+  const doc = getTransitionDoc(transition);
+  if (!doc) notFound();
+
+  const path = `/docs/transitions/${doc.name}`;
+  return (
+    <>
+      <JsonLd
+        data={breadcrumbSchema([
+          { name: "Home", path: "/" },
+          { name: "Docs", path: "/docs" },
+          { name: "Transitions", path: "/docs/transitions" },
+          { name: doc.name, path },
+        ])}
+      />
+      <DocsPageHeading eyebrow="Transition" title={doc.name} lead={doc.intro} />
+      <TransitionDetailBody doc={doc} />
+    </>
+  );
+}

--- a/apps/docs/src/app/docs/transitions/page.tsx
+++ b/apps/docs/src/app/docs/transitions/page.tsx
@@ -4,9 +4,9 @@ import { breadcrumbSchema, buildOpenGraph } from "@/lib/seo";
 import { DocsPageHeading, TransitionsBody } from "@/page/docs/sections";
 
 export const metadata: Metadata = {
-  title: "Transitions — the twelve built-in SSGOI transitions",
+  title: "Transitions — the thirteen built-in SSGOI transitions",
   description:
-    "drill, fade, slide, scroll, sheet, hero, zoom, strip, blind, film, rotate, jaemin. Each transition links to a self-contained .txt with the full API.",
+    "drill, fade, slide, axis, scroll, sheet, hero, zoom, strip, blind, film, rotate, jaemin. Each links to its variants, usage, live demos, and a self-contained .txt with the full API.",
   alternates: { canonical: "/docs/transitions" },
   openGraph: buildOpenGraph({ path: "/docs/transitions" }),
 };
@@ -23,7 +23,7 @@ export default function DocsTransitionsPage() {
       />
       <DocsPageHeading
         title="Transitions"
-        lead="Twelve built-in transitions. Pick one, drop it into your config, and let the AI agent wire up the per-element keys."
+        lead="Thirteen built-in transitions. Pick one, drop it into your config, and let the AI agent wire up the per-element keys."
       />
       <TransitionsBody />
     </>

--- a/apps/docs/src/app/sitemap.ts
+++ b/apps/docs/src/app/sitemap.ts
@@ -2,6 +2,7 @@ import type { MetadataRoute } from "next";
 import { showcases } from "@/page/showcase/data";
 import { getAllPosts } from "@/lib/blog";
 import { DOCS_NAV_FLAT } from "@/page/docs/nav";
+import { TRANSITION_DOCS } from "@/page/docs/transitions-data";
 
 const BASE_URL = "https://ssgoi.dev";
 
@@ -38,6 +39,13 @@ export default function sitemap(): MetadataRoute.Sitemap {
     changeFrequency: "weekly",
   }));
 
+  const transitionRoutes: MetadataRoute.Sitemap = TRANSITION_DOCS.map((t) => ({
+    url: `${BASE_URL}/docs/transitions/${t.name}`,
+    lastModified: now,
+    priority: 0.7,
+    changeFrequency: "monthly",
+  }));
+
   const showcaseRoutes: MetadataRoute.Sitemap = showcases.map((s) => ({
     url: `${BASE_URL}/showcase/${s.slug}`,
     lastModified: now,
@@ -52,5 +60,11 @@ export default function sitemap(): MetadataRoute.Sitemap {
     changeFrequency: "monthly",
   }));
 
-  return [...staticRoutes, ...docsRoutes, ...showcaseRoutes, ...blogRoutes];
+  return [
+    ...staticRoutes,
+    ...docsRoutes,
+    ...transitionRoutes,
+    ...showcaseRoutes,
+    ...blogRoutes,
+  ];
 }

--- a/apps/docs/src/components/desktop-frame.tsx
+++ b/apps/docs/src/components/desktop-frame.tsx
@@ -2,7 +2,6 @@
 
 import {
   forwardRef,
-  useEffect,
   useLayoutEffect,
   useRef,
   useState,
@@ -59,9 +58,15 @@ export const DesktopFrame = forwardRef<HTMLIFrameElement, Props>(
     const [screenW, setScreenW] = useState(0);
     const [loaded, setLoaded] = useState(false);
 
-    useEffect(() => {
+    // Reset the loading overlay only when `src` ACTUALLY changes — not on a bare
+    // effect re-run. React <Activity> re-runs passive effects on hidden→visible,
+    // so a `useEffect(..., [src])` would fire on every reveal and re-show the
+    // overlay over an already-loaded iframe that never re-fires `onLoad`.
+    const [trackedSrc, setTrackedSrc] = useState(src);
+    if (src !== trackedSrc) {
+      setTrackedSrc(src);
       setLoaded(false);
-    }, [src]);
+    }
 
     useLayoutEffect(() => {
       if (!scaleViewport) return;

--- a/apps/docs/src/components/phone-frame.tsx
+++ b/apps/docs/src/components/phone-frame.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { IframeLoadingOverlay } from "./iframe-loading-overlay";
 
 type Props = {
@@ -16,9 +16,17 @@ export function PhoneFrame({
 }: Props) {
   const [loaded, setLoaded] = useState(false);
 
-  useEffect(() => {
+  // Reset the loading overlay only when `src` ACTUALLY changes — not on a bare
+  // effect re-run. React <Activity> re-runs passive effects on hidden→visible,
+  // so a `useEffect(..., [src])` would fire on every reveal and re-show the
+  // overlay over an already-loaded iframe that never re-fires `onLoad` (the
+  // iframe state is preserved, so it just sits behind a stuck loader). Deriving
+  // from a tracked src keeps the reset tied to a genuine src change.
+  const [trackedSrc, setTrackedSrc] = useState(src);
+  if (src !== trackedSrc) {
+    setTrackedSrc(src);
     setLoaded(false);
-  }, [src]);
+  }
 
   return (
     <div className={`relative mx-auto shrink-0 ${widthClassName}`}>

--- a/apps/docs/src/components/showcase-phone.tsx
+++ b/apps/docs/src/components/showcase-phone.tsx
@@ -2,7 +2,6 @@
 
 import {
   forwardRef,
-  useEffect,
   useLayoutEffect,
   useRef,
   useState,
@@ -57,9 +56,15 @@ export const ShowcasePhone = forwardRef<HTMLIFrameElement, Props>(
     const [screenW, setScreenW] = useState(0);
     const [loaded, setLoaded] = useState(false);
 
-    useEffect(() => {
+    // Reset the loading overlay only when `src` ACTUALLY changes — not on a bare
+    // effect re-run. React <Activity> re-runs passive effects on hidden→visible,
+    // so a `useEffect(..., [src])` would fire on every reveal and re-show the
+    // overlay over an already-loaded iframe that never re-fires `onLoad`.
+    const [trackedSrc, setTrackedSrc] = useState(src);
+    if (src !== trackedSrc) {
+      setTrackedSrc(src);
       setLoaded(false);
-    }, [src]);
+    }
 
     useLayoutEffect(() => {
       if (!scaleViewport) return;

--- a/apps/docs/src/components/transition-demo.tsx
+++ b/apps/docs/src/components/transition-demo.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { showcaseFrameProtocol } from "@/lib/hooks";
+import { ShowcasePhone } from "@/components/showcase-phone";
+import { DesktopFrame } from "@/components/desktop-frame";
+import { IframeLoadingOverlay } from "@/components/iframe-loading-overlay";
+import type { ShowcasePlatform } from "@/page/showcase/data";
+
+type Props = {
+  platform: ShowcasePlatform;
+  /** Path the iframe routes _to_ on the "enter" leg. */
+  enterPath: string;
+  /** Path it routes back to on the "exit" leg — also the starting frame. */
+  exitPath: string;
+  title: string;
+  intervalMs?: number;
+};
+
+/**
+ * One transition's representative live demo. Mirrors the showcase card preview:
+ * lazy-mounts when near the viewport, then ping-pongs the iframe between the
+ * enter/exit routes so the transition plays on a loop. Stays inert when the docs
+ * site is itself embedded in an iframe (showcase-within-showcase).
+ */
+export function TransitionDemo({
+  platform,
+  enterPath,
+  exitPath,
+  title,
+  intervalMs = 3000,
+}: Props) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const [hasBeenVisible, setHasBeenVisible] = useState(false);
+  const [inView, setInView] = useState(false);
+  const [topLevel, setTopLevel] = useState(false);
+
+  useEffect(() => {
+    try {
+      setTopLevel(window.self === window.top);
+    } catch {
+      setTopLevel(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    const io = new IntersectionObserver(
+      ([entry]) => {
+        setInView(entry.isIntersecting);
+        if (entry.isIntersecting) setHasBeenVisible(true);
+      },
+      { rootMargin: "300px" },
+    );
+    io.observe(el);
+    return () => io.disconnect();
+  }, []);
+
+  const show = topLevel && hasBeenVisible;
+
+  useEffect(() => {
+    if (!show || !inView) return;
+    let onEnter = false;
+    const id = window.setInterval(() => {
+      const next = onEnter ? exitPath : enterPath;
+      onEnter = !onEnter;
+      iframeRef.current?.contentWindow?.postMessage(
+        { type: showcaseFrameProtocol.messages.navigate, path: next },
+        "*",
+      );
+    }, intervalMs);
+    return () => window.clearInterval(id);
+  }, [show, inView, enterPath, exitPath, intervalMs]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={platform === "web" ? "w-full" : "flex w-full justify-center"}
+    >
+      {show ? (
+        platform === "web" ? (
+          <DesktopFrame
+            ref={iframeRef}
+            src={exitPath}
+            title={title}
+            widthClassName="w-full"
+            interactive={false}
+          />
+        ) : (
+          <ShowcasePhone
+            ref={iframeRef}
+            src={exitPath}
+            title={title}
+            widthClassName="w-[190px]"
+            interactive={false}
+          />
+        )
+      ) : (
+        <DemoPlaceholder platform={platform} />
+      )}
+    </div>
+  );
+}
+
+function DemoPlaceholder({ platform }: { platform: ShowcasePlatform }) {
+  if (platform === "web") {
+    return (
+      <div className="w-full overflow-hidden rounded-[12px] bg-[#1c1611] p-[1px]">
+        <div className="flex h-7 w-full items-center gap-[5px] rounded-t-[11px] bg-gradient-to-b from-[#2a221c] to-[#1c1611] px-2.5">
+          <span className="inline-block h-2.5 w-2.5 rounded-full bg-[#ff5f57]" />
+          <span className="inline-block h-2.5 w-2.5 rounded-full bg-[#febc2e]" />
+          <span className="inline-block h-2.5 w-2.5 rounded-full bg-[#28c840]" />
+        </div>
+        <div className="relative aspect-[1280/800] overflow-hidden rounded-b-[11px] bg-neutral-950">
+          <IframeLoadingOverlay visible variant="dark" />
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="w-[190px]">
+      <div className="relative aspect-[9/19] rounded-[32px] bg-gradient-to-b from-[#1c1611] to-[#0f0b08] p-[6px]">
+        <div className="relative h-full overflow-hidden rounded-[26px] bg-white">
+          <IframeLoadingOverlay visible variant="light" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/docs/src/demo/air-bnb/page/home/listing-row.tsx
+++ b/apps/docs/src/demo/air-bnb/page/home/listing-row.tsx
@@ -1,5 +1,6 @@
 import { Link } from "@/lib/link";
 import { ChevronRight, Heart } from "lucide-react";
+import { DragScroller } from "@/lib/components/drag-scroller";
 import type { ListingSimple } from "@/demo/air-bnb/state/listing";
 
 export function ListingRow({
@@ -17,7 +18,7 @@ export function ListingRow({
         <h2 className="text-[20px] font-bold text-neutral-900">{title}</h2>
         <ChevronRight className="h-5 w-5 text-neutral-500" />
       </div>
-      <div className="scrollbar-hide flex gap-3 overflow-x-auto px-4 pt-3">
+      <DragScroller className="pt-3" trackClassName="gap-3 px-4">
         {loading
           ? Array.from({ length: 3 }).map((_, idx) => (
               <div
@@ -26,7 +27,7 @@ export function ListingRow({
               />
             ))
           : listings.map((l) => <RowCard key={l.id} listing={l} />)}
-      </div>
+      </DragScroller>
     </section>
   );
 }

--- a/apps/docs/src/lib/components/drag-scroller.tsx
+++ b/apps/docs/src/lib/components/drag-scroller.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import {
+  useEffect,
+  useRef,
+  type ComponentPropsWithoutRef,
+  type ReactNode,
+} from "react";
+import { cn } from "@/lib/utils";
+
+const FRICTION = 0.95; // decel per 16ms frame (pointer-flick momentum)
+const MIN_VELOCITY = 0.02; // px/ms — momentum stops below this
+const DRAG_THRESHOLD = 8; // px — move past this to be a "drag" (swallow click + capture); below = tap
+const LINE_HEIGHT = 16; // px, normalizes wheel deltaMode=line
+const KEY_STEP_RATIO = 0.8; // arrow key steps this fraction of the viewport width
+const CLICK_SWALLOW_MS = 350; // window after a drag in which the next click is swallowed
+
+type Props = ComponentPropsWithoutRef<"div"> & {
+  /** class for the track (the item row) — gap/padding etc. */
+  trackClassName?: string;
+  children: ReactNode;
+};
+
+/**
+ * translateX-based MANUAL horizontal scroller — mouse / trackpad / touch / keyboard.
+ *
+ * Why transform instead of native overflow:
+ *  - The position lives in the track's inline transform — not a layout-derived
+ *    value — so it isn't lost when the node is hidden. This docs app runs Next
+ *    `cacheComponents`, which wraps route segments in <Activity>: navigating away
+ *    (home → listing detail) hides the page with display:none rather than
+ *    unmounting it, so the node stays alive and the transform position is
+ *    preserved for free → no restore logic needed. (A native overflow scrollLeft
+ *    is React-invisible state that Activity can't keep, which is exactly why it
+ *    would need restoring.) The offset is applied imperatively, so re-renders
+ *    never clobber it.
+ *  - getBoundingClientRect reflects the transform, so ssgoi's zoom measures a
+ *    tile's true on-screen rect even when the row is scrolled — a card scrolled
+ *    out of its starting spot zooms from where it actually is.
+ *
+ * Re-implements what native gave for free: pointer drag + flick momentum (capture
+ * only past the threshold so taps still navigate; pointerId isolates multitouch;
+ * touch-action: pan-y yields vertical swipes to the page), wheel/trackpad
+ * (non-passive listener, deltaMode-normalized, consumes horizontal intent only),
+ * keyboard (←/→) + focus-into-view for a11y, and a ResizeObserver that re-clamps
+ * on size changes (skips display:none so the offset is preserved while hidden).
+ */
+export function DragScroller({
+  trackClassName,
+  children,
+  className,
+  ...rest
+}: Props) {
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const trackRef = useRef<HTMLDivElement>(null);
+
+  const offset = useRef(0); // current scroll amount (px); transform = translateX(-offset)
+  const vel = useRef(0); // px/ms (pointer momentum)
+  const max = useRef(0); // max scroll amount
+  const raf = useRef(0); // momentum rAF id
+  const dragging = useRef(false); // past threshold, actively dragging (= captured)
+  const start = useRef({ x: 0, off: 0, t: 0, pointerId: -1, pending: false });
+
+  const apply = () => {
+    const t = trackRef.current;
+    if (t) t.style.transform = `translate3d(${-offset.current}px,0,0)`;
+  };
+  const clamp = (v: number) => (v < 0 ? 0 : v > max.current ? max.current : v);
+  const computeMax = () => {
+    const vp = viewportRef.current;
+    const t = trackRef.current;
+    if (!vp || !t || !vp.clientWidth) return; // not rendered (display:none) → keep max so offset is preserved
+    max.current = Math.max(0, t.scrollWidth - vp.clientWidth);
+  };
+  const setOffset = (v: number) => {
+    offset.current = clamp(v);
+    apply();
+  };
+  const stopMomentum = () => {
+    if (raf.current) cancelAnimationFrame(raf.current);
+    raf.current = 0;
+  };
+  const momentum = () => {
+    let last = performance.now();
+    const step = (now: number) => {
+      const dt = now - last;
+      last = now;
+      if (Math.abs(vel.current) < MIN_VELOCITY) return void (raf.current = 0);
+      const next = clamp(offset.current + vel.current * dt);
+      if (next === offset.current)
+        return void ((vel.current = 0), (raf.current = 0)); // hit the edge
+      offset.current = next;
+      apply();
+      vel.current *= Math.pow(FRICTION, dt / 16); // framerate-independent decel
+      raf.current = requestAnimationFrame(step);
+    };
+    raf.current = requestAnimationFrame(step);
+  };
+
+  // Swallow the one click (a child <Link> nav) that fires right after a drag /
+  // momentum-stop. Auto-releases after 350ms. One-shot listener so the guard
+  // can't get stuck on pointercancel etc.
+  const swallowNextClick = () => {
+    const vp = viewportRef.current;
+    if (!vp) return;
+    let timer = 0;
+    const done = () => {
+      window.clearTimeout(timer);
+      vp.removeEventListener("click", swallow, true);
+    };
+    const swallow = (ev: MouseEvent) => {
+      ev.preventDefault();
+      ev.stopPropagation();
+      done();
+    };
+    vp.addEventListener("click", swallow, true);
+    timer = window.setTimeout(done, CLICK_SWALLOW_MS);
+  };
+
+  // ── pointer drag ──────────────────────────────────────────────
+  const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (e.button !== 0) return; // primary button / touch / pen only
+    if (dragging.current || start.current.pending) return; // another pointer owns it → multitouch isolation
+    const wasMoving = raf.current !== 0;
+    stopMomentum();
+    computeMax();
+    vel.current = 0;
+    dragging.current = false;
+    start.current = {
+      x: e.clientX,
+      off: offset.current,
+      t: performance.now(),
+      pointerId: e.pointerId,
+      pending: true,
+    };
+    if (wasMoving) swallowNextClick(); // tap during momentum = intent to stop, not navigate
+  };
+  const onPointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    const s = start.current;
+    if (e.pointerId !== s.pointerId) return;
+    if (!s.pending && !dragging.current) return;
+    if (!dragging.current) {
+      if (Math.abs(e.clientX - s.x) < DRAG_THRESHOLD) return;
+      // capture only once past the threshold — so a tap still fires as a click
+      dragging.current = true;
+      s.pending = false;
+      s.x = e.clientX; // rebase to the current point to avoid a jump
+      s.off = offset.current;
+      s.t = performance.now();
+      viewportRef.current?.setPointerCapture(e.pointerId);
+      if (viewportRef.current) viewportRef.current.style.cursor = "grabbing";
+      return;
+    }
+    const now = performance.now();
+    const next = clamp(s.off - (e.clientX - s.x));
+    const dt = now - s.t;
+    if (dt > 0) vel.current = (next - offset.current) / dt;
+    offset.current = next;
+    apply();
+    s.t = now;
+  };
+  const onPointerUp = (e: React.PointerEvent<HTMLDivElement>) => {
+    const s = start.current;
+    if (e.pointerId !== s.pointerId) return;
+    if (dragging.current) {
+      dragging.current = false;
+      viewportRef.current?.releasePointerCapture?.(e.pointerId);
+      if (viewportRef.current) viewportRef.current.style.cursor = "";
+      swallowNextClick(); // swallow the click that would navigate
+      if (Math.abs(vel.current) >= MIN_VELOCITY) momentum();
+    }
+    s.pending = false;
+    s.pointerId = -1;
+  };
+  const onPointerCancel = (e: React.PointerEvent<HTMLDivElement>) => {
+    const s = start.current;
+    if (e.pointerId !== s.pointerId) return;
+    // cancel doesn't produce a click, so no swallow — just release the guard.
+    dragging.current = false;
+    viewportRef.current?.releasePointerCapture?.(e.pointerId);
+    if (viewportRef.current) viewportRef.current.style.cursor = "";
+    s.pending = false;
+    s.pointerId = -1;
+  };
+
+  // ── keyboard (←/→) ────────────────────────────────────────────
+  const onKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+    const t = e.target as HTMLElement;
+    if (
+      t.tagName === "INPUT" ||
+      t.tagName === "TEXTAREA" ||
+      t.tagName === "SELECT" ||
+      t.isContentEditable
+    )
+      return;
+    const vp = viewportRef.current;
+    if (!vp) return;
+    e.preventDefault();
+    stopMomentum();
+    computeMax();
+    setOffset(
+      offset.current +
+        (e.key === "ArrowRight" ? 1 : -1) * vp.clientWidth * KEY_STEP_RATIO,
+    );
+  };
+
+  // ── focus-into-view (Tab onto an off-screen link) ─────────────
+  const onFocus = (e: React.FocusEvent<HTMLDivElement>) => {
+    const vp = viewportRef.current;
+    const t = trackRef.current;
+    const child = e.target as HTMLElement;
+    if (!vp || !t || !t.contains(child)) return;
+    computeMax();
+    const c = child.getBoundingClientRect();
+    const v = vp.getBoundingClientRect();
+    let delta = 0;
+    if (c.left < v.left)
+      delta = c.left - v.left; // off the left → move content right
+    else if (c.right > v.right) delta = c.right - v.right; // off the right → move content left
+    if (delta !== 0) setOffset(offset.current + delta);
+  };
+
+  // ── wheel/trackpad + resize: native (non-passive) listeners ───
+  useEffect(() => {
+    const vp = viewportRef.current;
+    if (!vp) return;
+
+    const onWheel = (e: WheelEvent) => {
+      const unit =
+        e.deltaMode === 1
+          ? LINE_HEIGHT
+          : e.deltaMode === 2
+            ? vp.clientWidth
+            : 1;
+      let dx = e.deltaX * unit;
+      let dy = e.deltaY * unit;
+      if (e.shiftKey && dx === 0) {
+        dx = dy; // shift+wheel → horizontal (when the browser doesn't translate it)
+        dy = 0;
+      }
+      if (Math.abs(dx) <= Math.abs(dy)) return; // vertical intent → let the page scroll
+      e.preventDefault(); // consume horizontal intent only
+      stopMomentum();
+      computeMax();
+      setOffset(offset.current + dx);
+    };
+    vp.addEventListener("wheel", onWheel, { passive: false });
+
+    const ro = new ResizeObserver(() => {
+      if (!vp.clientWidth) return; // display:none → keep the offset
+      computeMax();
+      setOffset(offset.current); // re-clamp to the new max
+    });
+    ro.observe(vp);
+    if (trackRef.current) ro.observe(trackRef.current);
+
+    return () => {
+      vp.removeEventListener("wheel", onWheel);
+      ro.disconnect();
+      stopMomentum();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <div
+      ref={viewportRef}
+      className={cn(
+        "cursor-grab touch-pan-y select-none overflow-hidden overscroll-x-contain",
+        className,
+      )}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerCancel}
+      onKeyDown={onKeyDown}
+      onFocus={onFocus}
+      onDragStart={(e) => e.preventDefault()}
+      {...rest}
+    >
+      <div ref={trackRef} className={cn("flex w-max", trackClassName)}>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/docs/src/page/docs/nav.ts
+++ b/apps/docs/src/page/docs/nav.ts
@@ -28,7 +28,7 @@ export const DOCS_NAV: DocsNavGroup[] = [
       {
         title: "Transitions",
         href: "/docs/transitions",
-        blurb: "The twelve built-in transitions.",
+        blurb: "The thirteen built-in transitions.",
       },
       {
         title: "Layout",

--- a/apps/docs/src/page/docs/sections.tsx
+++ b/apps/docs/src/page/docs/sections.tsx
@@ -2,6 +2,11 @@ import { Link } from "@/lib/link";
 import { NpmPill } from "@/components/npm-pill";
 import { CodeBlock } from "@/components/code-block";
 import {
+  TRANSITION_DOCS,
+  USE_META,
+  type TransitionDoc,
+} from "@/page/docs/transitions-data";
+import {
   NextMark,
   NuxtMark,
   ReactRouterMark,
@@ -248,62 +253,57 @@ function SetupStep({
 /* Transitions                                                                */
 /* -------------------------------------------------------------------------- */
 
-type TransitionEntry = { name: string; blurb: string };
-
-const TRANSITIONS: TransitionEntry[] = [
-  { name: "drill", blurb: "iOS-style hierarchical navigation." },
-  { name: "fade", blurb: "Calm cross-fade. Safe default." },
-  { name: "slide", blurb: "Horizontal push." },
-  { name: "scroll", blurb: "Vertical page scroll." },
-  { name: "sheet", blurb: "Bottom sheet, slides up." },
-  {
-    name: "hero",
-    blurb: "Shared element. data-hero-enter-key / data-hero-exit-key.",
-  },
-  { name: "zoom", blurb: "Card expands to detail. data-zoom-*-key." },
-  { name: "strip", blurb: "3D Y-axis flip." },
-  { name: "blind", blurb: "Window-blinds wipe." },
-  { name: "film", blurb: "Cinematic shrink + tile." },
-  { name: "rotate", blurb: "Card flip." },
-  { name: "jaemin", blurb: "Playful rotated zoom." },
-];
-
 export function TransitionsBody() {
   return (
     <div className="mt-8">
-      <p className="text-sm text-neutral-500">
-        Each links to a self-contained{" "}
-        <span className="font-mono text-neutral-300">.txt</span> with the full
+      <p className="max-w-xl text-sm leading-relaxed text-neutral-400">
+        Every built-in transition, tagged with when it fits. Open one for its
+        variants, usage, and live demos — or grab the{" "}
+        <span className="font-mono text-neutral-300">.txt</span> for the full
         API.
       </p>
-      <ul className="mt-6 divide-y divide-white/[0.05] border-y border-white/[0.05]">
-        {TRANSITIONS.map((t) => (
-          <li key={t.name}>
-            <a
-              href={`https://ssgoi.dev/llms/${t.name}.txt`}
-              target="_blank"
-              rel="noreferrer"
-              className="group flex items-center justify-between gap-6 py-4 transition-colors hover:bg-white/[0.02]"
-            >
-              <div className="flex min-w-0 items-baseline gap-4">
-                <span className="font-mono text-base font-semibold text-neutral-100">
-                  {t.name}
-                </span>
-                <span className="truncate text-sm text-neutral-400">
-                  {t.blurb}
-                </span>
-              </div>
-              <span
-                className="hidden shrink-0 font-mono text-xs text-neutral-500 transition-colors group-hover:text-orange-400 sm:inline"
-                aria-hidden
-              >
-                /llms/{t.name}.txt ↗
-              </span>
-            </a>
-          </li>
+
+      <ul className="mt-8 grid gap-3 sm:grid-cols-2">
+        {TRANSITION_DOCS.map((t) => (
+          <TransitionCard key={t.name} entry={t} />
         ))}
       </ul>
     </div>
+  );
+}
+
+function TransitionCard({ entry }: { entry: TransitionDoc }) {
+  const meta = USE_META[entry.use];
+
+  return (
+    <li>
+      <Link
+        href={`/docs/transitions/${entry.name}`}
+        className="group flex h-full flex-col gap-2 rounded-2xl border border-white/[0.06] bg-white/[0.015] p-5 transition-colors hover:border-white/15 hover:bg-white/[0.04]"
+      >
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-base font-semibold text-neutral-100 transition-colors group-hover:text-orange-400">
+            {entry.name}
+          </span>
+          <span
+            className={
+              "rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider " +
+              meta.cls
+            }
+          >
+            {meta.label}
+          </span>
+          <span
+            className="ml-auto text-neutral-600 transition-colors group-hover:text-orange-400"
+            aria-hidden
+          >
+            →
+          </span>
+        </div>
+        <p className="text-sm leading-snug text-neutral-300">{entry.blurb}</p>
+        <p className="text-xs leading-snug text-neutral-500">{meta.when}</p>
+      </Link>
+    </li>
   );
 }
 

--- a/apps/docs/src/page/docs/transition-detail.tsx
+++ b/apps/docs/src/page/docs/transition-detail.tsx
@@ -1,0 +1,130 @@
+import { Link } from "@/lib/link";
+import { CodeBlock } from "@/components/code-block";
+import { TransitionDemo } from "@/components/transition-demo";
+import {
+  USE_META,
+  variantCall,
+  type TransitionDoc,
+  type TransitionVariant,
+} from "@/page/docs/transitions-data";
+
+export function TransitionDetailBody({ doc }: { doc: TransitionDoc }) {
+  const meta = USE_META[doc.use];
+  const paths =
+    doc.pathStyle === "enter-exit"
+      ? `enter: "/list", exit: "/detail"`
+      : `paths: ["/list", "/detail"]`;
+
+  const setup = `import { ${doc.name} } from "@ssgoi/react/view-transitions";
+
+const config = {
+  transitions: [
+    ${doc.name}({ ${paths} }),
+  ],
+};`;
+
+  return (
+    <div className="mt-8">
+      <div className="flex items-center gap-3">
+        <span
+          className={
+            "rounded-full border px-2.5 py-0.5 text-[11px] font-medium uppercase tracking-wider " +
+            meta.cls
+          }
+        >
+          {meta.label}
+        </span>
+        <span className="text-sm text-neutral-500">{meta.when}</span>
+      </div>
+
+      <section className="mt-8">
+        <h2 className="text-lg font-semibold text-neutral-100">Usage</h2>
+        <p className="mt-2 max-w-xl text-sm leading-relaxed text-neutral-400">
+          Add the factory to your <code className="font-mono">config</code>.
+          Shown for React — the same factory works in Svelte, Vue, Solid, and
+          Angular.
+        </p>
+        <CodeBlock className="mt-4" code={setup} />
+      </section>
+
+      <section className="mt-12">
+        <h2 className="text-lg font-semibold text-neutral-100">
+          {doc.variants.length > 1 ? "Variants" : "Behavior"}
+        </h2>
+        <ul className="mt-5 flex flex-col gap-8">
+          {doc.variants.map((v) => (
+            <VariantRow key={v.label} doc={doc} variant={v} />
+          ))}
+        </ul>
+      </section>
+
+      <div className="mt-12 flex items-center justify-between border-t border-white/[0.06] pt-6 text-sm">
+        <Link
+          href="/docs/transitions"
+          className="text-neutral-400 transition-colors hover:text-neutral-100"
+        >
+          ← All transitions
+        </Link>
+        <a
+          href={`https://ssgoi.dev/llms/${doc.name}.txt`}
+          target="_blank"
+          rel="noreferrer"
+          className="font-mono text-neutral-400 transition-colors hover:text-orange-400"
+        >
+          /llms/{doc.name}.txt ↗
+        </a>
+      </div>
+    </div>
+  );
+}
+
+function VariantRow({
+  doc,
+  variant,
+}: {
+  doc: TransitionDoc;
+  variant: TransitionVariant;
+}) {
+  const demos = variant.demos ?? [];
+
+  return (
+    <li className="rounded-2xl border border-white/[0.06] bg-white/[0.015] p-5">
+      {demos.length > 0 ? (
+        <ul className="grid gap-4 sm:grid-cols-2">
+          {demos.map((demo) => (
+            <li
+              key={`${demo.enterPath}→${demo.exitPath}`}
+              className="flex justify-center rounded-xl bg-neutral-900/40 p-3"
+            >
+              <TransitionDemo
+                platform={demo.platform ?? "mobile"}
+                enterPath={demo.enterPath}
+                exitPath={demo.exitPath}
+                title={`${doc.name} · ${variant.label}`}
+              />
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <div className="flex items-center justify-center rounded-xl bg-neutral-900/40 py-10">
+          <span className="text-xs text-neutral-500">Demo coming soon</span>
+        </div>
+      )}
+
+      <div className="mt-5 flex items-center gap-2">
+        <h3 className="font-mono text-base font-semibold text-neutral-100">
+          {variant.label}
+        </h3>
+        {variant.isDefault && (
+          <span className="rounded-full border border-white/10 bg-white/[0.04] px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider text-neutral-400">
+            default
+          </span>
+        )}
+      </div>
+      <p className="mt-2 text-sm leading-relaxed text-neutral-300">
+        {variant.ux}
+      </p>
+      <CodeBlock className="mt-4" code={variantCall(doc, variant)} />
+    </li>
+  );
+}

--- a/apps/docs/src/page/docs/transitions-data.ts
+++ b/apps/docs/src/page/docs/transitions-data.ts
@@ -1,0 +1,483 @@
+import type { ShowcasePlatform } from "@/page/showcase/data";
+
+export type UseKind = "drill-in" | "sibling" | "top-level" | "decorative";
+
+export const USE_META: Record<
+  UseKind,
+  { label: string; when: string; cls: string }
+> = {
+  "drill-in": {
+    label: "Drill-in",
+    when: "List → detail, going one level deeper.",
+    cls: "border-orange-400/40 bg-orange-400/10 text-orange-200",
+  },
+  sibling: {
+    label: "Sibling",
+    when: "Between peer screens at the same level.",
+    cls: "border-sky-400/40 bg-sky-400/10 text-sky-200",
+  },
+  "top-level": {
+    label: "Top-level",
+    when: "Switching tabs or root sections.",
+    cls: "border-emerald-400/40 bg-emerald-400/10 text-emerald-200",
+  },
+  decorative: {
+    label: "Decorative",
+    when: "A flourish — use anywhere for effect.",
+    cls: "border-violet-400/40 bg-violet-400/10 text-violet-200",
+  },
+};
+
+export type TransitionDemoExample = {
+  /** Route the iframe plays the "enter" leg to. */
+  enterPath: string;
+  /** Route it returns to — also the starting frame. */
+  exitPath: string;
+  /** Frame style for this demo. Defaults to "mobile". */
+  platform?: ShowcasePlatform;
+};
+
+export type TransitionVariant = {
+  /** Section label, e.g. "parallax" or "x · snappy". */
+  label: string;
+  /** One-line UX note: what it looks/feels like, when to reach for it. */
+  ux: string;
+  /**
+   * Extra args shown inside the factory call, e.g. `type: "slide"`. Empty for
+   * the bare default call. Paths are added by the renderer per `pathStyle`.
+   */
+  args: string;
+  /** Marks the default behavior of the transition. */
+  isDefault?: boolean;
+  /**
+   * Zero or more live demos for this variant — a variant can show several
+   * flows. Empty until real examples are wired; the renderer shows a
+   * "demo coming soon" placeholder until then.
+   */
+  demos?: TransitionDemoExample[];
+};
+
+export type TransitionDoc = {
+  name: string;
+  /** One-liner used on the catalog card. */
+  blurb: string;
+  use: UseKind;
+  /** Intro paragraph for the detail page header. */
+  intro: string;
+  /** How the factory receives routes. */
+  pathStyle: "enter-exit" | "paths";
+  variants: TransitionVariant[];
+};
+
+export const TRANSITION_DOCS: TransitionDoc[] = [
+  {
+    name: "drill",
+    blurb: "iOS-style hierarchical navigation.",
+    use: "drill-in",
+    intro:
+      "Hierarchical push/pop, like an iOS navigation stack. Use it when the user goes one level deeper — a list into its detail — and back out again.",
+    pathStyle: "enter-exit",
+    variants: [
+      {
+        label: "parallax",
+        isDefault: true,
+        args: 'type: "parallax"',
+        ux: "Layered depth: the outgoing page recedes a touch while the new page slides over it. The default — reads as real hierarchy.",
+        demos: [
+          {
+            enterPath: "/demo/gamja-market/products/p-001",
+            exitPath: "/demo/gamja-market",
+          },
+          {
+            enterPath: "/demo/kakao-talk/chats/c-001",
+            exitPath: "/demo/kakao-talk/chats",
+          },
+        ],
+      },
+      {
+        label: "slide",
+        args: 'type: "slide"',
+        ux: "Flat cross-faded horizontal slide, no parallax. Lighter and faster when depth feels like too much.",
+        demos: [
+          {
+            enterPath:
+              "/demo/pinterest/search/%EC%97%AC%EC%9E%90%20%EC%B9%98%EB%A7%88",
+            exitPath: "/demo/pinterest/search",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: "fade",
+    blurb: "Calm cross-fade. Safe default.",
+    use: "top-level",
+    intro:
+      "A calm symmetric cross-fade. The safe default for any navigation where you don't want to imply direction or hierarchy.",
+    pathStyle: "paths",
+    variants: [
+      {
+        label: "fade",
+        isDefault: true,
+        args: "",
+        ux: "Both pages cross-fade. Neutral and direction-less — great for top-level/tab switches.",
+        demos: [
+          {
+            enterPath: "/demo/silent-room/tension",
+            exitPath: "/demo/silent-room",
+            platform: "web",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: "slide",
+    blurb: "Horizontal push.",
+    use: "sibling",
+    intro:
+      "A horizontal push between peer screens. Direction follows path order — forward slides left, back slides right.",
+    pathStyle: "paths",
+    variants: [
+      {
+        label: "slide",
+        isDefault: true,
+        args: "",
+        ux: "Pages push horizontally in the direction of travel. Good for moving between siblings at the same level.",
+        demos: [
+          {
+            enterPath: "/demo/instagram/profile/deaseungseung94/reels",
+            exitPath: "/demo/instagram/profile/deaseungseung94",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: "axis",
+    blurb: "Material shared-axis. Coordinated slide + fade.",
+    use: "sibling",
+    intro:
+      "Material Design shared-axis: a coordinated slide + fade along one axis. Pick the axis that matches the spatial relationship between screens.",
+    pathStyle: "paths",
+    variants: [
+      {
+        label: "x",
+        isDefault: true,
+        args: 'type: "x"',
+        ux: "Horizontal shared-axis; direction follows path order. The default tone is fluid.",
+      },
+      {
+        label: "x · snappy",
+        args: 'type: "x", variant: "snappy"',
+        ux: "Same horizontal axis with a tighter, snappier spring — feels more immediate.",
+        demos: [
+          {
+            enterPath: "/demo/kakao-talk/chats",
+            exitPath: "/demo/kakao-talk",
+          },
+        ],
+      },
+      {
+        label: "y",
+        args: 'type: "y"',
+        ux: "Vertical shared-axis; direction follows path order.",
+      },
+      {
+        label: "y · non-directional",
+        args: 'type: "y", variant: "non-directional"',
+        ux: "Vertical axis where every move slides the same way, ignoring path order.",
+      },
+      {
+        label: "z",
+        args: 'type: "z"',
+        ux: "Z-axis depth — pages scale through each other, the container-transform feel.",
+      },
+    ],
+  },
+  {
+    name: "scroll",
+    blurb: "Vertical page scroll.",
+    use: "sibling",
+    intro:
+      "Pages scroll vertically as if stacked. Reads as continuous movement through a sequence.",
+    pathStyle: "paths",
+    variants: [
+      {
+        label: "directional",
+        isDefault: true,
+        args: 'type: "directional"',
+        ux: "Path order decides direction — earlier→later scrolls up, the reverse scrolls down.",
+      },
+      {
+        label: "non-directional",
+        args: 'type: "non-directional"',
+        ux: "Every navigation scrolls upward regardless of order — good for paginated or onboarding flows.",
+        demos: [
+          {
+            enterPath: "/showcase",
+            exitPath: "/",
+            platform: "web",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: "sheet",
+    blurb: "Bottom sheet, slides up.",
+    use: "drill-in",
+    intro:
+      "A bottom sheet that slides up over the current page — for modal-like detail that keeps the origin in context.",
+    pathStyle: "enter-exit",
+    variants: [
+      {
+        label: "static",
+        isDefault: true,
+        args: 'type: "static"',
+        ux: "The sheet rises over a static background page. The default.",
+        demos: [
+          {
+            enterPath: "/demo/gamja-market/review/o-001",
+            exitPath: "/demo/gamja-market",
+          },
+          {
+            enterPath: "/demo/youtube-music-web/watch?v=wggigwtz4dQ",
+            exitPath: "/demo/youtube-music-web",
+            platform: "web",
+          },
+        ],
+      },
+      {
+        label: "scale",
+        args: 'type: "scale"',
+        ux: "The background page scales down as the sheet rises — iOS-style stacked-card depth.",
+        demos: [
+          {
+            enterPath: "/demo/material-mail/compose",
+            exitPath: "/demo/material-mail",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: "hero",
+    blurb: "Shared element. data-hero-enter-key / data-hero-exit-key.",
+    use: "drill-in",
+    intro:
+      "A shared-element transition: a tagged element flies from its spot on one page to its spot on the next. Mark the element with data-hero-enter-key / data-hero-exit-key.",
+    pathStyle: "paths",
+    variants: [
+      {
+        label: "static",
+        isDefault: true,
+        args: 'type: "static"',
+        ux: "Incoming chrome snaps in while the shared element morphs to its new position. The default.",
+        demos: [
+          {
+            enterPath: "/demo/airbnb-photo-tour/photos/kitchen-1",
+            exitPath: "/demo/airbnb-photo-tour",
+            platform: "web",
+          },
+        ],
+      },
+      {
+        label: "fade",
+        args: 'type: "fade"',
+        ux: "Both pages cross-fade as whole surfaces while the shared element morphs — softer hand-off.",
+        demos: [
+          {
+            enterPath: "/demo/google-photos/p/ph-001",
+            exitPath: "/demo/google-photos",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: "zoom",
+    blurb: "Card expands to detail. data-zoom-*-key.",
+    use: "drill-in",
+    intro:
+      "A card expands into its detail view. Tag the source and target with data-zoom-enter-key / data-zoom-exit-key.",
+    pathStyle: "paths",
+    variants: [
+      {
+        label: "static",
+        isDefault: true,
+        args: 'type: "static"',
+        ux: "The card holds in place while the detail expands over it. The default.",
+        demos: [
+          {
+            enterPath: "/demo/instagram/feed/p-001",
+            exitPath: "/demo/instagram/profile/deaseungseung94",
+          },
+        ],
+      },
+      {
+        label: "expand",
+        args: 'type: "expand"',
+        ux: "The card itself expands to become the full detail surface.",
+        demos: [
+          {
+            enterPath: "/demo/pinterest/feed/pin-1",
+            exitPath: "/demo/pinterest",
+          },
+        ],
+      },
+      {
+        label: "blur",
+        args: 'type: "blur"',
+        ux: "The background blurs as the detail zooms in — a focus pull.",
+        demos: [
+          {
+            enterPath: "/demo/air-bnb/listings/l-003",
+            exitPath: "/demo/air-bnb",
+          },
+        ],
+      },
+      {
+        label: "fade",
+        args: 'variant: "fade"',
+        ux: "Modifier on any zoom type: adds a cross-fade for a softer expand.",
+      },
+    ],
+  },
+  {
+    name: "strip",
+    blurb: "3D Y-axis flip.",
+    use: "decorative",
+    intro:
+      "A 3D flip around the Y-axis, like turning a card. A decorative flourish for moments that want a little drama.",
+    pathStyle: "paths",
+    variants: [
+      {
+        label: "strip",
+        isDefault: true,
+        args: "",
+        ux: "Pages flip in 3D around the vertical axis.",
+        demos: [
+          {
+            enterPath: "/demo/nora-hale/about",
+            exitPath: "/demo/nora-hale",
+            platform: "web",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: "blind",
+    blurb: "Window-blinds wipe.",
+    use: "decorative",
+    intro:
+      "A window-blinds wipe — the page reveals in slats. Decorative; pick the axis the slats open along.",
+    pathStyle: "paths",
+    variants: [
+      {
+        label: "horizontal",
+        isDefault: true,
+        args: 'type: "horizontal"',
+        ux: "Blinds wipe along the horizontal axis. The default.",
+      },
+      {
+        label: "vertical",
+        args: 'type: "vertical"',
+        ux: "Blinds open along the vertical axis.",
+      },
+    ],
+  },
+  {
+    name: "film",
+    blurb: "Cinematic shrink + tile.",
+    use: "decorative",
+    intro:
+      "A cinematic shrink-and-tile with film-strip corner borders. Decorative — for a movie-reel feel.",
+    pathStyle: "paths",
+    variants: [
+      {
+        label: "film",
+        isDefault: true,
+        args: "",
+        ux: "Pages shrink and tile with cinematic corner borders.",
+        demos: [
+          {
+            enterPath: "/demo/lumen/cinematic-eye",
+            exitPath: "/demo/lumen",
+            platform: "web",
+          },
+        ],
+      },
+      {
+        label: "custom border",
+        args: 'options: { borderColor: "#f97316" }',
+        ux: "Override the cinematic corner-border color via options.borderColor.",
+      },
+    ],
+  },
+  {
+    name: "rotate",
+    blurb: "Card flip.",
+    use: "decorative",
+    intro: "A full card flip between pages. A playful decorative transition.",
+    pathStyle: "paths",
+    variants: [
+      {
+        label: "rotate",
+        isDefault: true,
+        args: "",
+        ux: "One page flips over to reveal the next.",
+        demos: [
+          {
+            enterPath: "/demo/honeydrop/drop",
+            exitPath: "/demo/honeydrop",
+            platform: "web",
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: "jaemin",
+    blurb: "Playful rotated zoom.",
+    use: "decorative",
+    intro:
+      "A playful rotated zoom — the signature flourish. Decorative, for personality.",
+    pathStyle: "paths",
+    variants: [
+      {
+        label: "jaemin",
+        isDefault: true,
+        args: "",
+        ux: "Pages zoom in with a slight rotation for a lively feel.",
+        demos: [
+          {
+            enterPath: "/demo/yuzu-club/flavors",
+            exitPath: "/demo/yuzu-club",
+            platform: "web",
+          },
+        ],
+      },
+    ],
+  },
+];
+
+export const TRANSITION_NAMES = TRANSITION_DOCS.map((t) => t.name);
+
+export function getTransitionDoc(name: string): TransitionDoc | undefined {
+  return TRANSITION_DOCS.find((t) => t.name === name);
+}
+
+/** Factory call string for a variant, e.g. `drill({ enter: "/list", exit: "/detail", type: "slide" })`. */
+export function variantCall(
+  doc: TransitionDoc,
+  variant: TransitionVariant,
+): string {
+  const paths =
+    doc.pathStyle === "enter-exit"
+      ? 'enter: "/list", exit: "/detail"'
+      : 'paths: ["/list", "/detail"]';
+  const rest = variant.args ? `, ${variant.args}` : "";
+  return `${doc.name}({ ${paths}${rest} })`;
+}

--- a/apps/docs/src/page/showcase/data.ts
+++ b/apps/docs/src/page/showcase/data.ts
@@ -13,7 +13,7 @@ import { silentRoomShowcase } from "@/demo/silent-room/showcase";
 import { ssgoiDocsShowcase } from "@/demo/ssgoi-docs/showcase";
 import { youtubeMusicWebShowcase } from "@/demo/youtube-music-web/showcase";
 import { yuzuClubShowcase } from "@/demo/yuzu-club/showcase";
-import type { ShowcaseApp } from "./types";
+import type { ShowcaseApp, ShowcaseClip } from "./types";
 
 export type { ShowcaseApp, ShowcaseClip, ShowcasePlatform } from "./types";
 
@@ -46,6 +46,17 @@ export const showcases: ShowcaseApp[] = [
 
 export function findShowcase(slug: string): ShowcaseApp | undefined {
   return showcases.find((s) => s.slug === slug);
+}
+
+/** First showcase + clip demonstrating a given transition, in catalog order. */
+export function representativeClip(
+  transition: string,
+): { showcase: ShowcaseApp; clip: ShowcaseClip } | undefined {
+  for (const s of showcases) {
+    const clip = s.clips.find((c) => c.transition === transition);
+    if (clip) return { showcase: s, clip };
+  }
+  return undefined;
 }
 
 /** All transition names across the catalog, deduped, sorted. */

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/angular",
-  "version": "6.4.0",
+  "version": "6.5.0",
   "description": "Angular bindings for SSGOI - Native app-like page transitions for Angular applications",
   "private": false,
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/core",
-  "version": "6.5.0-beta.2",
+  "version": "6.5.0",
   "description": "Core animation engine for SSGOI - Native app-like page transitions with spring physics",
   "private": false,
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/core",
-  "version": "6.4.0",
+  "version": "6.5.0-beta.0",
   "description": "Core animation engine for SSGOI - Native app-like page transitions with spring physics",
   "private": false,
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/core",
-  "version": "6.5.0-beta.0",
+  "version": "6.5.0-beta.2",
   "description": "Core animation engine for SSGOI - Native app-like page transitions with spring physics",
   "private": false,
   "type": "module",

--- a/packages/core/src/lib/animation/web-animation.ts
+++ b/packages/core/src/lib/animation/web-animation.ts
@@ -111,6 +111,17 @@ export class WebAnimation extends Animation {
     this.onComplete?.();
   }
 
+  /**
+   * Drop the WAAPI forwards-fill after the run has settled, letting inline
+   * styles govern the resting visual. Call only from `onComplete` (the run is
+   * already finished) — otherwise it cancels mid-flight. Unlike `complete()`,
+   * it writes no final frame, so a caller can reset the element to its natural
+   * state without the lingering fill clobbering it.
+   */
+  releaseFill(): void {
+    this.clearWaapi();
+  }
+
   get isAnimating(): boolean {
     return this.running;
   }

--- a/packages/core/src/lib/ssgoi-transition/create-ssgoi-transition-context.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-ssgoi-transition-context.ts
@@ -15,6 +15,7 @@ import { createSwipeBackDetector } from "./create-swipe-back-detector";
 import { findMatchingTransition } from "./find-matching-transition";
 import { createNavigationDetector } from "./navigation-detector-strategy";
 import { watchUnmount } from "./unmount-observer";
+import { watchVisibility, type VisibilityHandle } from "./visibility-observer";
 import { HostAnimation } from "../animation/host-animation";
 
 function isTransitionGroup(
@@ -37,10 +38,23 @@ function flattenTransitions(
   return flattened;
 }
 
+type TransitionMode = "unmount" | "hidden";
+
 type PendingSide = {
   element: HTMLElement;
   parent: Element | null;
   nextSibling: Element | null;
+  /**
+   * How the outgoing page left (meaningful on the OUT side only):
+   *  - "unmount": real DOM removal (SPA frameworks, Next without
+   *    cacheComponents). The outgoing page is cloned and the clone is removed on
+   *    settle — the battle-tested baseline path.
+   *  - "hidden":  React `<Activity>` / Next `cacheComponents` toggled it to
+   *    `display:none`. The REAL node is reused (page state preserved) and
+   *    re-hidden on settle.
+   * Absent on the IN side; defaults to "unmount".
+   */
+  mode?: TransitionMode;
 };
 
 type ElementAnchor = {
@@ -118,6 +132,79 @@ export function createSggoiTransitionContext(
     };
   };
 
+  // ── Hidden-mode bookkeeping (React <Activity> / Next cacheComponents) ───────
+  //
+  // In hidden mode a page element is registered ONCE (first mount) and then
+  // toggled between visible and display:none forever; OUT/IN are driven by the
+  // visibility-observer rather than mount/unmount. Repeated, interruptible
+  // navigation stays correct via three pieces of state:
+  //
+  //  - `owner` / `transitionEpoch`: every hidden run stamps the real nodes it
+  //    drives with a monotonically increasing epoch. On settle a run only
+  //    restores a node it STILL owns, so when a follow-up navigation re-claims
+  //    the same nodes mid-flight (A: OUT→IN, B: IN→OUT) the interrupted run's
+  //    cleanup is skipped and the live run owns the final resting state — no
+  //    vanished or stuck-hidden pages.
+  //  - `hiddenState`: per-element resting bookkeeping. `savedCss` is the clean
+  //    inline cssText snapshot taken on idle→active entry (so every style a
+  //    transition leaks onto a reused node is wiped on settle); `intent` is
+  //    React's latest visible/hidden intent; `visibleDisplay` is the inline
+  //    display to restore to when resting visible (possibly "" for class-driven
+  //    display); `computedDisplay` is a concrete value used to reveal a hidden
+  //    node for its out-animation.
+  type HiddenState = {
+    vis: VisibilityHandle;
+    savedCss: string | null;
+    intent: "visible" | "hidden";
+    visibleDisplay: string;
+    computedDisplay: string;
+  };
+  const hiddenState = new WeakMap<HTMLElement, HiddenState>();
+  const owner = new WeakMap<HTMLElement, number>();
+  let transitionEpoch = 0;
+
+  const readComputedDisplay = (el: HTMLElement): string => {
+    const d =
+      typeof getComputedStyle !== "undefined"
+        ? getComputedStyle(el).display
+        : "";
+    return d && d !== "none" ? d : "block";
+  };
+
+  // Capture the element's resting visible display while it IS visible: the
+  // inline value (what React restores on reveal, possibly "") plus a concrete
+  // computed value (needed to reveal it later, where "" is not a legal write).
+  const captureVisibleDisplay = (el: HTMLElement, state: HiddenState): void => {
+    state.visibleDisplay = el.style.getPropertyValue("display");
+    state.computedDisplay = readComputedDisplay(el);
+  };
+
+  // Reconcile a reused (hidden-mode) real node to its final resting state — but
+  // only if this run still owns it (a newer run re-claiming it wins). Wipes all
+  // transition-leaked inline styles via the clean cssText snapshot, then sets
+  // display to match React's latest intent.
+  const reconcileResting = (el: HTMLElement, epoch: number): void => {
+    if (owner.get(el) !== epoch) return; // superseded by a newer run
+    owner.delete(el);
+    const state = hiddenState.get(el);
+    if (!state) return;
+    if (state.savedCss !== null) {
+      el.style.cssText = state.savedCss;
+      state.savedCss = null;
+    }
+    if (state.intent === "hidden") {
+      // Match React's own hidden form so a later React reveal is observable.
+      state.vis.setDisplay("none", true);
+    } else if (state.visibleDisplay) {
+      state.vis.setDisplay(state.visibleDisplay, false);
+      captureVisibleDisplay(el, state);
+    } else {
+      // React drives visibility via a class / UA default (no inline display).
+      state.vis.setDisplay(null);
+      captureVisibleDisplay(el, state);
+    }
+  };
+
   const runTransition = (
     config: AnyTransitionConfig,
     fromPath: string,
@@ -127,15 +214,13 @@ export function createSggoiTransitionContext(
   ): void => {
     const fromOriginal = outSide.element;
     const toElement = inSide.element;
+    const outMode: TransitionMode = outSide.mode ?? "unmount";
+    const isHidden = outMode === "hidden";
 
     const { parent, nextSibling } = outSide.parent
       ? { parent: outSide.parent, nextSibling: outSide.nextSibling }
       : readAnchor(fromOriginal);
 
-    // Clone while the original is still mounted; the host framework will
-    // detach the original right after `out()` returns.
-    const fromClone = fromOriginal.cloneNode(true) as HTMLElement;
-    fromClone.setAttribute("data-ssgoi-clone", "");
     const scrollOffset = calculateScrollOffset(fromPath, toPath);
 
     const ssgoiContext: SsgoiTransitionContext = {
@@ -150,14 +235,49 @@ export function createSggoiTransitionContext(
       },
     };
 
-    // Auto-applied for every transition — outgoing page goes absolute so the
-    // incoming page can take its slot. Style only; insertion is deferred
-    // until after `prepare` so any pre-paint styling settles first.
-    prepareOutgoing(fromClone, ssgoiContext);
+    // The element handed to the animation as `from`:
+    //  - unmount mode: a throwaway deep clone (the real node is being destroyed
+    //    by the host framework), inserted after `prepare` and removed on settle.
+    //  - hidden mode: the REAL outgoing node, already revealed + taken out of
+    //    flow by `handleHide`. Reusing it keeps page state alive AND lets a
+    //    follow-up navigation hand its motion back continuously (matchInto keys
+    //    on element identity) — a fresh clone every nav never could.
+    let fromElement: HTMLElement;
+    if (isHidden) {
+      fromElement = fromOriginal;
+      // scrollOffset is only known now — finish the out-of-flow placement begun
+      // in handleHide so the incoming page lines up with the prior scroll.
+      fromElement.style.top = `${-1 * (scrollOffset?.y ?? 0)}px`;
+      // Snapshot the incoming node's clean inline styles BEFORE `prepare` paints
+      // starting styles onto it, so settle can wipe transition leakage off this
+      // reused real node. (The outgoing node was snapshotted in handleHide.)
+      const toState = hiddenState.get(toElement);
+      if (toState && toState.savedCss === null) {
+        toState.savedCss = toElement.style.cssText;
+      }
+    } else {
+      // Clone while the original is still mounted; the host framework will
+      // detach the original right after `out()` returns.
+      fromElement = fromOriginal.cloneNode(true) as HTMLElement;
+      fromElement.setAttribute("data-ssgoi-clone", "");
+      // Outgoing page goes absolute so the incoming page can take its slot.
+      // Style only; insertion is deferred until after `prepare`.
+      prepareOutgoing(fromElement, ssgoiContext);
+    }
 
     if (!shouldPreserve(fromPath)) evictScrollPosition(fromPath);
 
-    const fromPromise: Promise<HTMLElement> = Promise.resolve(fromClone);
+    // Stamp ownership BEFORE host.attach force-completes any prior run (below):
+    // the prior run's settle checks ownership and must already see THIS run
+    // owning the shared real nodes, so it skips them instead of fighting us.
+    // Only hidden mode reuses/owns real nodes; unmount mode stays clone-based.
+    const epoch = isHidden ? ++transitionEpoch : 0;
+    if (isHidden) {
+      owner.set(toElement, epoch);
+      owner.set(fromOriginal, epoch);
+    }
+
+    const fromPromise: Promise<HTMLElement> = Promise.resolve(fromElement);
     const toPromise: Promise<HTMLElement> = Promise.resolve(toElement);
 
     const createdElements: HTMLElement[] = [];
@@ -192,11 +312,12 @@ export function createSggoiTransitionContext(
       // Now that prepare's microtasks have all run (initial styles, extras
       // built), drop the outgoing clone into place. Order is:
       //   prepare → out insert → animation create/play
-      if (parent) {
+      // Hidden mode skips insertion: the real node is already in place.
+      if (!isHidden && parent) {
         if (nextSibling && parent.contains(nextSibling)) {
-          parent.insertBefore(fromClone, nextSibling);
+          parent.insertBefore(fromElement, nextSibling);
         } else {
-          parent.appendChild(fromClone);
+          parent.appendChild(fromElement);
         }
       }
 
@@ -207,14 +328,21 @@ export function createSggoiTransitionContext(
         ...(extras as Record<string, unknown>),
       });
 
-      // Per-transition cleanup (clone removal, prepare-created nodes). Wire
-      // this BEFORE attach — host.attach hooks onComplete itself and chains
-      // through prior hooks, so cleanup still fires once the run settles.
+      // Per-transition settle. Wire this BEFORE attach — host.attach hooks
+      // onComplete itself and chains through prior hooks, so cleanup still
+      // fires once the run settles (natural finish OR host force-completing it).
       const prevOnComplete = animation.onComplete;
       animation.onComplete = () => {
         prevOnComplete?.();
-        if (fromClone.parentElement) {
-          fromClone.parentElement.removeChild(fromClone);
+        if (isHidden) {
+          // Reuse: re-hide the real outgoing node (or leave it visible if a
+          // follow-up navigation re-claimed it as an incoming page) and wipe
+          // every inline style the transition leaked onto it. Both reconciles
+          // no-op if a newer run now owns the node.
+          reconcileResting(fromOriginal, epoch);
+          reconcileResting(toElement, epoch);
+        } else if (fromElement.parentElement) {
+          fromElement.parentElement.removeChild(fromElement);
         }
         for (const extra of createdElements) {
           if (extra.parentElement) extra.parentElement.removeChild(extra);
@@ -270,12 +398,114 @@ export function createSggoiTransitionContext(
     });
   };
 
-  const handleRemoval = (element: HTMLElement, path: string) => {
+  // React drove `element` to display:none (an <Activity> went mode="hidden").
+  // Reveal the REAL node immediately — synchronously, inside the observer's
+  // microtask, before the browser paints — so it animates out from where it sat
+  // instead of flashing away, and take it out of flow so the incoming page
+  // claims its slot. The run itself starts once the IN side pairs.
+  const handleHide = (element: HTMLElement, path: string) => {
+    const state = hiddenState.get(element);
+    if (!state) return;
+    // React's <Activity> can commit the SAME hide more than once (dev re-commit
+    // / follow-up render). Only the first edge of a given intent starts a
+    // transition; a repeat must NOT enqueue a second OUT, or it corrupts the
+    // navigation detector's pairing for the next real navigation. Real nav
+    // always FLIPS intent, so it is never deduped here.
+    const alreadyHidden = state.intent === "hidden";
+    state.intent = "hidden";
+
+    // Snapshot inline styles once, on idle→active entry, so settle can wipe
+    // transition leakage off this reused node. These are the node's resting
+    // styles except for React's just-applied `display:none` — which is fine,
+    // because reconcileResting always overrides display explicitly afterward.
+    // If already mid-flight (savedCss set), keep the original snapshot.
+    if (state.savedCss === null) state.savedCss = element.style.cssText;
+
+    // (Re-)reveal over React's `display:none !important`, every time — so the
+    // node stays visible for its out-animation even when React re-asserts the
+    // hide. A concrete computed value WITH !important keeps our reveal
+    // observably distinct from React's plain `display:` reveal, so an
+    // interrupting React reveal is still caught.
+    state.vis.setDisplay(state.computedDisplay || "block", true);
+    element.style.position = "absolute";
+    element.style.width = "100%";
+    element.style.left = "0";
+
+    if (alreadyHidden) return; // duplicate hide — kept revealed, don't re-pair
+
     const anchor = readAnchor(element);
     pendingOut = {
       element,
       parent: anchor.parent,
       nextSibling: anchor.nextSibling,
+      mode: "hidden",
+    };
+    const currentPath = element.getAttribute("data-ssgoi-transition") ?? path;
+    handleArrival(currentPath, "out");
+  };
+
+  // React revealed `element` (an <Activity> went mode="visible"): it is entering
+  // again, with its state preserved. Drive an IN exactly like a fresh mount,
+  // minus the mount.
+  const handleShow = (element: HTMLElement, path: string) => {
+    const state = hiddenState.get(element);
+    if (!state) return;
+    // Dedupe redundant reveals (see handleHide): only an intent flip enters.
+    if (state.intent === "visible") return;
+    state.intent = "visible";
+    // Capture React's visible display BEFORE the restore below mutates it.
+    captureVisibleDisplay(element, state);
+
+    // OUT→IN role swap: an in-flight outgoing node (savedCss already taken) is
+    // being re-claimed as the incoming page. It still carries the out-of-flow
+    // positioning handleHide imposed (position:absolute/width/left/top) plus the
+    // out-transition's style leakage — normalize it back to its clean inline
+    // styles so the incoming page re-enters in NORMAL flow, then re-assert the
+    // visible display (the snapshot carries React's display:none from the hide).
+    // savedCss is kept for the eventual settle; the spring handoff (matchInto)
+    // carries motion continuity, so wiping the stale inline transform is fine.
+    if (state.savedCss !== null) {
+      element.style.cssText = state.savedCss;
+      if (state.visibleDisplay) {
+        state.vis.setDisplay(state.visibleDisplay, false);
+      } else {
+        state.vis.setDisplay(null);
+      }
+    }
+
+    initializeContext(element, path);
+    pendingIn = {
+      element,
+      parent: element.parentElement,
+      nextSibling: element.nextElementSibling,
+    };
+    const currentPath = element.getAttribute("data-ssgoi-transition") ?? path;
+    handleArrival(currentPath, "in");
+  };
+
+  const handleRemoval = (element: HTMLElement, path: string) => {
+    const state = hiddenState.get(element);
+    if (state) {
+      state.vis.stop();
+      hiddenState.delete(element);
+      owner.delete(element);
+      // An Activity page evicted WHILE hidden (e.g. dropped from Next's bfcache)
+      // is just GC, not a navigation — don't animate it out. Drop any pending
+      // side that still points at this now-gone node so it can't mis-pair a
+      // later arrival onto a detached element.
+      if (state.intent === "hidden") {
+        if (pendingOut?.element === element) pendingOut = null;
+        if (pendingIn?.element === element) pendingIn = null;
+        return;
+      }
+    }
+
+    const anchor = readAnchor(element);
+    pendingOut = {
+      element,
+      parent: anchor.parent,
+      nextSibling: anchor.nextSibling,
+      mode: "unmount",
     };
     // Read the latest id from the DOM rather than the closure-captured path
     // so a mid-life id change (re-render with a new id prop on the same
@@ -294,13 +524,35 @@ export function createSggoiTransitionContext(
     registered.add(element);
 
     captureAnchor(element);
-    initializeContext(element, path);
-    pendingIn = {
-      element,
-      parent: element.parentElement,
-      nextSibling: element.nextElementSibling,
+
+    // Watch React <Activity> / cacheComponents display toggles for this node for
+    // the rest of its life. The node is registered ONCE; subsequent OUT/IN come
+    // from these handlers (display:none flips), not from mount/unmount.
+    const vis = watchVisibility(element, {
+      onHide: () => handleHide(element, path),
+      onShow: () => handleShow(element, path),
+    });
+    const state: HiddenState = {
+      vis,
+      savedCss: null,
+      intent: vis.isHidden ? "hidden" : "visible",
+      visibleDisplay: "",
+      computedDisplay: "block",
     };
-    handleArrival(path, "in");
+    hiddenState.set(element, state);
+
+    // A node that mounts already hidden (e.g. an inactive Activity sibling) is
+    // not "entering" — set it up but don't fire an IN until React reveals it.
+    if (!vis.isHidden) {
+      captureVisibleDisplay(element, state);
+      initializeContext(element, path);
+      pendingIn = {
+        element,
+        parent: element.parentElement,
+        nextSibling: element.nextElementSibling,
+      };
+      handleArrival(path, "in");
+    }
 
     watchUnmount(element, () => handleRemoval(element, path));
   };

--- a/packages/core/src/lib/ssgoi-transition/unmount-observer.test.ts
+++ b/packages/core/src/lib/ssgoi-transition/unmount-observer.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The shared unmount-observer must fire a node's leave callback ONLY on a real
+ * unmount — never on a MOVE. A `childList` "removed" record also fires when a
+ * node is detached and re-attached within one commit (e.g. Next.js reordering
+ * its bfcache `<Activity>` siblings on back/forward navigation). Firing on a
+ * move would tear down a kept-alive page's tracking and break later
+ * transitions. The package test env is `node`, so we fake the slice the module
+ * touches: HTMLElement, a MutationObserver whose records we dispatch by hand,
+ * and a minimal document.
+ */
+
+class FakeNode {
+  childNodes: FakeNode[] = [];
+  isConnected = false;
+}
+
+let observerCb: ((mutations: unknown[]) => void) | null = null;
+
+class FakeMutationObserver {
+  constructor(cb: (mutations: unknown[]) => void) {
+    observerCb = cb;
+  }
+  observe(): void {}
+  disconnect(): void {}
+  takeRecords(): unknown[] {
+    return [];
+  }
+}
+
+function fireRemoval(node: FakeNode): void {
+  observerCb?.([{ removedNodes: [node] }]);
+}
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  vi.stubGlobal("HTMLElement", FakeNode);
+  vi.stubGlobal("Node", FakeNode);
+  vi.stubGlobal("MutationObserver", FakeMutationObserver);
+  vi.stubGlobal("document", {
+    body: new FakeNode(),
+    addEventListener() {},
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("watchUnmount", () => {
+  it("fires the leave callback on a real unmount (node stays detached)", async () => {
+    const { watchUnmount } = await import("./unmount-observer");
+    const node = new FakeNode();
+    node.isConnected = false;
+    const cb = vi.fn();
+    watchUnmount(node as unknown as HTMLElement, cb);
+
+    fireRemoval(node);
+    await flushMicrotasks();
+
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT fire on a MOVE (node reattached -> isConnected), and keeps watching", async () => {
+    const { watchUnmount } = await import("./unmount-observer");
+    const node = new FakeNode();
+    node.isConnected = true; // re-inserted within the same commit (a reorder)
+    const cb = vi.fn();
+    watchUnmount(node as unknown as HTMLElement, cb);
+
+    fireRemoval(node);
+    await flushMicrotasks();
+    expect(cb).not.toHaveBeenCalled();
+
+    // The watch must survive the move: a later REAL removal still fires.
+    node.isConnected = false;
+    fireRemoval(node);
+    await flushMicrotasks();
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops firing after the returned disposer runs", async () => {
+    const { watchUnmount } = await import("./unmount-observer");
+    const node = new FakeNode();
+    node.isConnected = false;
+    const cb = vi.fn();
+    const dispose = watchUnmount(node as unknown as HTMLElement, cb);
+
+    dispose();
+    fireRemoval(node);
+    await flushMicrotasks();
+    expect(cb).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/lib/ssgoi-transition/unmount-observer.ts
+++ b/packages/core/src/lib/ssgoi-transition/unmount-observer.ts
@@ -19,7 +19,15 @@ let sharedObserver: MutationObserver | null = null;
 let initialized = false;
 
 function checkRemovedSubtree(node: Node): void {
-  if (node instanceof HTMLElement && watched.has(node)) {
+  // A childList "removed" record also fires when a node is MOVED (removed then
+  // re-inserted within the same commit) — e.g. Next.js reorders its bfcache
+  // `<Activity>` siblings on back/forward navigation, so React detaches and
+  // reattaches a kept-alive page's DOM node. By the time this observer callback
+  // runs the move is already complete, so `isConnected` distinguishes a real
+  // unmount (still detached) from a reorder (already reattached). Only a true
+  // unmount may fire the leave callback; a moved node keeps its watch, otherwise
+  // its visibility tracking would be torn down and later transitions break.
+  if (node instanceof HTMLElement && watched.has(node) && !node.isConnected) {
     const cb = watched.get(node)!;
     watched.delete(node);
     // Defer to microtask so we never mutate the DOM inside the observer

--- a/packages/core/src/lib/ssgoi-transition/visibility-observer.test.ts
+++ b/packages/core/src/lib/ssgoi-transition/visibility-observer.test.ts
@@ -1,0 +1,265 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { watchVisibility } from "./visibility-observer";
+
+/**
+ * The visibility-observer's whole job is to surface ONLY React-driven
+ * display:none hide/show edges while swallowing our own display writes (the
+ * reveal/re-hide we do to animate the outgoing page) and the opacity/transform
+ * writes every transition makes. These tests pin that filter.
+ *
+ * The package test env is `node` (no DOM), so we fake exactly the slice the
+ * module touches: a `style` with display get/set/priority/remove, and a
+ * MutationObserver whose records we dispatch by hand. React's writes are modeled
+ * the way they are actually observed: a hide is `display:none !important`, a
+ * reveal is a plain `display:<value>` (no priority).
+ */
+
+let lastObserverCb: MutationCallback | null = null;
+
+class FakeMutationObserver {
+  constructor(cb: MutationCallback) {
+    lastObserverCb = cb;
+  }
+  observe(): void {}
+  disconnect(): void {}
+  takeRecords(): MutationRecord[] {
+    return [];
+  }
+}
+
+type FakeEl = HTMLElement & { __display: string; __priority: string };
+
+function makeEl(initialDisplay = ""): FakeEl {
+  const el = {
+    __display: initialDisplay,
+    __priority: "",
+  } as FakeEl;
+  (el as { style: unknown }).style = {
+    getPropertyValue: (prop: string) =>
+      prop === "display" ? el.__display : "",
+    getPropertyPriority: (prop: string) =>
+      prop === "display" ? el.__priority : "",
+    setProperty: (prop: string, value: string, priority?: string) => {
+      if (prop !== "display") return;
+      el.__display = value;
+      el.__priority = priority === "important" ? "important" : "";
+    },
+    removeProperty: (prop: string) => {
+      if (prop !== "display") return;
+      el.__display = "";
+      el.__priority = "";
+    },
+  };
+  return el;
+}
+
+/** Simulate React's hide: display:none !important. */
+function reactHide(el: FakeEl): void {
+  el.__display = "none";
+  el.__priority = "important";
+}
+
+/** Simulate React's reveal: a plain `display:<value>` with no priority. */
+function reactShow(el: FakeEl, value = "flex"): void {
+  el.__display = value;
+  el.__priority = "";
+}
+
+/** Flush the observer as if the element's `style` attribute mutated. */
+function flush(el: FakeEl): void {
+  lastObserverCb?.(
+    [{ target: el } as unknown as MutationRecord],
+    {} as MutationObserver,
+  );
+}
+
+beforeEach(() => {
+  vi.stubGlobal("MutationObserver", FakeMutationObserver);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("watchVisibility", () => {
+  it("fires onHide when React sets display:none !important", () => {
+    const el = makeEl("flex");
+    const onHide = vi.fn();
+    const onShow = vi.fn();
+    watchVisibility(el, { onHide, onShow });
+
+    reactHide(el);
+    flush(el);
+
+    expect(onHide).toHaveBeenCalledTimes(1);
+    expect(onShow).not.toHaveBeenCalled();
+  });
+
+  it("fires onShow when React reveals a hidden element", () => {
+    const el = makeEl("none");
+    el.__priority = "important"; // mounted hidden
+    const onHide = vi.fn();
+    const onShow = vi.fn();
+    watchVisibility(el, { onHide, onShow });
+
+    reactShow(el, "flex");
+    flush(el);
+
+    expect(onShow).toHaveBeenCalledTimes(1);
+    expect(onHide).not.toHaveBeenCalled();
+  });
+
+  it("ignores our own reveal write (setDisplay), so no feedback loop", () => {
+    const el = makeEl("flex");
+    const onHide = vi.fn();
+    const onShow = vi.fn();
+    const handle = watchVisibility(el, { onHide, onShow });
+
+    // React hides -> onHide (expected)
+    reactHide(el);
+    flush(el);
+    expect(onHide).toHaveBeenCalledTimes(1);
+
+    // We reveal the real node to animate it out. This must NOT read back as a
+    // React show.
+    handle.setDisplay("flex", true); // display:flex !important
+    flush(el);
+    expect(onShow).not.toHaveBeenCalled();
+  });
+
+  it("ignores our own re-hide write (setDisplay none)", () => {
+    const el = makeEl("flex");
+    const onHide = vi.fn();
+    const onShow = vi.fn();
+    const handle = watchVisibility(el, { onHide, onShow });
+
+    reactHide(el);
+    flush(el);
+    handle.setDisplay("flex", true); // reveal
+    flush(el);
+    onHide.mockClear();
+
+    // Settle: we re-hide the reused node ourselves.
+    handle.setDisplay("none", true);
+    flush(el);
+    expect(onHide).not.toHaveBeenCalled();
+    expect(onShow).not.toHaveBeenCalled();
+  });
+
+  it("still catches a React reveal that interrupts our out-animation", () => {
+    // The crux: while we hold the node visible with `!important`, React decides
+    // to show it again (user navigated back). React's plain `display:` differs
+    // from our `!important` string, so the edge is still observable.
+    const el = makeEl("flex");
+    const onHide = vi.fn();
+    const onShow = vi.fn();
+    const handle = watchVisibility(el, { onHide, onShow });
+
+    reactHide(el);
+    flush(el); // onHide
+    handle.setDisplay("flex", true); // our reveal: flex !important
+    flush(el); // ignored
+    onShow.mockClear();
+    onHide.mockClear();
+
+    reactShow(el, "flex"); // React reveal: flex (no priority)
+    flush(el);
+    expect(onShow).toHaveBeenCalledTimes(1);
+    expect(onHide).not.toHaveBeenCalled();
+  });
+
+  it("ignores non-display style mutations (opacity/transform writes)", () => {
+    const el = makeEl("flex");
+    const onHide = vi.fn();
+    const onShow = vi.fn();
+    watchVisibility(el, { onHide, onShow });
+
+    // A transition writes opacity/transform — display is unchanged. Flushing a
+    // style mutation must not classify it as an edge.
+    flush(el);
+    expect(onHide).not.toHaveBeenCalled();
+    expect(onShow).not.toHaveBeenCalled();
+  });
+
+  it("sync() adopts an out-of-band display write without firing", () => {
+    // After restoring cssText (a non-setDisplay channel) the caller calls
+    // sync() so the resulting mutation is not mistaken for a React edge.
+    const el = makeEl("flex");
+    const onHide = vi.fn();
+    const onShow = vi.fn();
+    const handle = watchVisibility(el, { onHide, onShow });
+
+    // cssText restore lands display:none !important directly on the style.
+    el.__display = "none";
+    el.__priority = "important";
+    handle.sync();
+    flush(el);
+    expect(onHide).not.toHaveBeenCalled();
+  });
+
+  it("tracks a full hide -> reveal -> settle -> hide-again cycle", () => {
+    const el = makeEl("flex");
+    const onHide = vi.fn();
+    const onShow = vi.fn();
+    const handle = watchVisibility(el, { onHide, onShow });
+
+    // 1. React hides (nav away)
+    reactHide(el);
+    flush(el);
+    expect(onHide).toHaveBeenCalledTimes(1);
+
+    // 2. We reveal to animate out
+    handle.setDisplay("flex", true);
+    flush(el);
+
+    // 3. We settle: re-hide
+    handle.setDisplay("none", true);
+    flush(el);
+
+    // 4. React reveals (nav back) — must fire onShow
+    reactShow(el, "flex");
+    flush(el);
+    expect(onShow).toHaveBeenCalledTimes(1);
+
+    // 5. React hides again (nav away again) — must fire onHide again
+    reactHide(el);
+    flush(el);
+    expect(onHide).toHaveBeenCalledTimes(2);
+  });
+
+  it("ignores a plain display:none (only React's !important signature triggers)", () => {
+    // An app's own conditional `display:none` on a page boundary must NOT be
+    // hijacked into a hidden-mode OUT.
+    const el = makeEl("flex");
+    const onHide = vi.fn();
+    const onShow = vi.fn();
+    watchVisibility(el, { onHide, onShow });
+
+    el.__display = "none"; // plain, no priority
+    el.__priority = "";
+    flush(el);
+    expect(onHide).not.toHaveBeenCalled();
+    expect(onShow).not.toHaveBeenCalled();
+  });
+
+  it("does not fire onShow without a prior React hide (reactHidden latch)", () => {
+    const el = makeEl("flex");
+    const onHide = vi.fn();
+    const onShow = vi.fn();
+    watchVisibility(el, { onHide, onShow });
+
+    // A visible->visible display change (e.g. flex->block) is not a reveal.
+    el.__display = "block";
+    el.__priority = "";
+    flush(el);
+    expect(onShow).not.toHaveBeenCalled();
+  });
+
+  it("isHidden reflects the live inline display", () => {
+    const el = makeEl("flex");
+    const handle = watchVisibility(el, { onHide: vi.fn(), onShow: vi.fn() });
+    expect(handle.isHidden).toBe(false);
+    reactHide(el);
+    expect(handle.isHidden).toBe(true);
+  });
+});

--- a/packages/core/src/lib/ssgoi-transition/visibility-observer.ts
+++ b/packages/core/src/lib/ssgoi-transition/visibility-observer.ts
@@ -1,0 +1,162 @@
+/**
+ * Visibility observer — detects React `<Activity>` / Next `cacheComponents`
+ * hide/show of a registered page element.
+ *
+ * React's `<Activity mode="hidden">` does NOT unmount or wrap its children. It
+ * hides the subtree by writing, on the inline style of the TOP-MOST host node
+ * of that subtree:
+ *
+ *     topHostNode.style.setProperty("display", "none", "important")
+ *
+ * and reveals it again with `topHostNode.style.display = ""` (or the declared
+ * `style.display` prop value — always WITHOUT priority). There is no wrapper
+ * element and no `data-*` marker. (Verified against react-dom 19.2
+ * `ReactFiberConfigDOM.js` `hideInstance` / `unhideInstance`.) So the ONLY
+ * observable signal is a mutation of the element's `style` attribute whose
+ * `display` flips to / from `none`.
+ *
+ * Two design points make the detection robust:
+ *
+ *  1. The hide edge is gated on the EXACT React signature `display:none
+ *     !important`. A plain `display:none` (an app's own CSS-in-JS / conditional
+ *     style on a page boundary) is deliberately ignored — otherwise every
+ *     unrelated `display:none` would be hijacked into a bogus hidden-mode OUT.
+ *     React's reveal is plain `display:<value>`, which we tell apart from our
+ *     own reveal because we always write the override WITH `!important`.
+ *
+ *  2. Decisions key on the `display` VALUE only, and on a per-element
+ *     "accounted" value. A style mutation whose display equals the accounted
+ *     value (our own reveal/re-hide write, or a transition's opacity/transform
+ *     write that left display untouched) is ignored. Only React's writes — which
+ *     we did not account — surface as `onHide` / `onShow` edges. A `reactHidden`
+ *     latch ensures `onShow` only fires for a node we previously saw React hide.
+ */
+
+export type VisibilityHandlers = {
+  /** React drove this element to `display:none !important`. */
+  onHide: () => void;
+  /** React drove this element from its hidden state back to a visible display. */
+  onShow: () => void;
+};
+
+export type VisibilityHandle = {
+  /** Whether the element is currently React-hidden (`display:none !important`). */
+  readonly isHidden: boolean;
+  /**
+   * Write `display` as a LIBRARY-owned change that the observer will ignore.
+   * Pass `null` to remove the inline `display` property entirely. `important`
+   * defaults to false; pass `true` when overriding React's
+   * `display:none !important`.
+   */
+  setDisplay(value: string | null, important?: boolean): void;
+  /**
+   * Re-read the element's current `display` and accept it as the accounted
+   * value WITHOUT firing `onHide` / `onShow`. Call this after writing the
+   * element's style through a channel other than `setDisplay` (e.g. restoring
+   * `cssText`) so the resulting style mutation is not mistaken for a React edge.
+   */
+  sync(): void;
+  /** Stop reacting to this element's style mutations. */
+  stop(): void;
+};
+
+type Rec = {
+  accounted: string;
+  reactHidden: boolean;
+  onHide: () => void;
+  onShow: () => void;
+};
+
+// One shared observer watches every registered element's `style` attribute.
+// MutationObserver holds its observed nodes weakly, so a page element that React
+// removes is still GC-able even though there is no per-target `unobserve` —
+// `stop()` simply drops dispatch by deleting the record.
+const records = new WeakMap<HTMLElement, Rec>();
+let sharedObserver: MutationObserver | null = null;
+
+const HIDDEN = "none !important";
+
+function readDisplay(el: HTMLElement): string {
+  const value = el.style.getPropertyValue("display");
+  const priority = el.style.getPropertyPriority("display");
+  return priority ? `${value} !important` : value;
+}
+
+function ensureObserver(): MutationObserver {
+  if (sharedObserver) return sharedObserver;
+  sharedObserver = new MutationObserver((mutations) => {
+    for (const m of mutations) {
+      const el = m.target as HTMLElement;
+      const rec = records.get(el);
+      if (!rec) continue;
+      const current = readDisplay(el);
+      // Equal to what we last accounted -> our own write, a redundant write, or
+      // a non-display style change. Not a React intent edge.
+      if (current === rec.accounted) continue;
+      rec.accounted = current;
+      if (current === HIDDEN) {
+        // React Activity hide signature. (A plain `display:none` is some other
+        // code's doing — ignore it so we never hijack it into a hidden-mode OUT.)
+        rec.reactHidden = true;
+        rec.onHide();
+      } else if (current !== "none") {
+        // Became visible. Only meaningful if we previously saw React hide it.
+        if (rec.reactHidden) {
+          rec.reactHidden = false;
+          rec.onShow();
+        }
+      }
+    }
+  });
+  return sharedObserver;
+}
+
+/**
+ * Start watching `element` for React-driven `display:none !important` hide/show
+ * edges. Returns a handle that also lets the caller perform library-owned
+ * `display` writes the observer will not mistake for React edges.
+ */
+export function watchVisibility(
+  element: HTMLElement,
+  handlers: VisibilityHandlers,
+): VisibilityHandle {
+  const accounted = readDisplay(element);
+  const rec: Rec = {
+    accounted,
+    reactHidden: accounted === HIDDEN,
+    onHide: handlers.onHide,
+    onShow: handlers.onShow,
+  };
+  records.set(element, rec);
+
+  ensureObserver().observe(element, {
+    attributes: true,
+    attributeFilter: ["style"],
+  });
+
+  return {
+    get isHidden() {
+      return readDisplay(element) === HIDDEN;
+    },
+    setDisplay(value, important = false) {
+      if (value === null) {
+        element.style.removeProperty("display");
+      } else {
+        element.style.setProperty(
+          "display",
+          value,
+          important ? "important" : "",
+        );
+      }
+      // Pre-account our own write so the style mutation it produces is ignored.
+      rec.accounted = readDisplay(element);
+    },
+    sync() {
+      rec.accounted = readDisplay(element);
+      rec.reactHidden = rec.accounted === HIDDEN;
+    },
+    stop() {
+      records.delete(element);
+    },
+  };
+}

--- a/packages/core/src/lib/transitions/axis/transition.ts
+++ b/packages/core/src/lib/transitions/axis/transition.ts
@@ -32,6 +32,17 @@ function clearStyle(el: HTMLElement): void {
   el.style.clipPath = "";
 }
 
+// The outgoing (from) element is now the real, reused page node (React
+// Activity / Next cacheComponents) rather than a throwaway clone, so every
+// inline style we set on it must be cleared when the out animation completes —
+// otherwise the re-hidden node reappears stuck (invisible / translated /
+// non-interactive) on the next navigation. Mirrors `clearStyle` (the in-side
+// template) plus the out-only `pointerEvents` we set in `prepare`.
+function clearFromStyle(el: HTMLElement): void {
+  clearStyle(el);
+  el.style.pointerEvents = "";
+}
+
 export const axis = (options: AxisOptions = {}): TransitionConfig => {
   const direction = options.direction ?? "forward";
   const type = options.type ?? DEFAULT_TYPE;
@@ -65,12 +76,11 @@ export const axis = (options: AxisOptions = {}): TransitionConfig => {
         element: from,
         integrator: IntegratorProvider.from(provider.outPhysics),
         style: (t) => config.out.animate(t),
-        onComplete:
-          type === "z"
-            ? () => {
-                from.style.clipPath = "";
-              }
-            : undefined,
+        // Restore the reused from node's inline styles on complete. This
+        // covers willChange/backfaceVisibility/contain/transform/opacity (from
+        // applyStartStyle + the WAAPI final frame), pointerEvents (set in
+        // prepare), and clipPath (set above for z; harmless no-op otherwise).
+        onComplete: () => clearFromStyle(from),
       });
 
       const inAnim = new WebAnimation({

--- a/packages/core/src/lib/transitions/blind/transition.ts
+++ b/packages/core/src/lib/transitions/blind/transition.ts
@@ -84,6 +84,8 @@ function makeBlinds(
 }
 
 type BlindExtras = {
+  // Threaded through so the OUT cleanup can reach the reused `from` node.
+  fromEl: HTMLElement;
   fromBlinds: HTMLDivElement[];
   fromContainer: HTMLDivElement;
   toBlinds: HTMLDivElement[];
@@ -122,13 +124,20 @@ export const blind = (
         "right",
       );
       return {
+        fromEl,
         fromBlinds: fromData.blinds,
         fromContainer: fromData.container,
         toBlinds: toData.blinds,
         toContainer: toData.container,
       };
     },
-    animation: ({ fromBlinds, fromContainer, toBlinds, toContainer }) => {
+    animation: ({
+      fromEl,
+      fromBlinds,
+      fromContainer,
+      toBlinds,
+      toContainer,
+    }) => {
       // OUT: each blind grows in (t: 0 → 1). IN: each blind shrinks out
       // (`u`: 1 → 0). Default (0, 1) bounds for both.
       const out: Animation[] = fromBlinds.map(
@@ -157,6 +166,14 @@ export const blind = (
                 ? () => {
                     toContainer.remove();
                     fromContainer.remove();
+                    // The OUT (`from`) element is the real, reused page node now
+                    // (React Activity / Next cacheComponents re-show it on the
+                    // next navigation), so strip the inline styles `prepare`
+                    // wrote — `zIndex` (set directly) and `position` (set by
+                    // `makeBlinds` when the host was `static`) — or they stick
+                    // and corrupt the page the next time it appears.
+                    fromEl.style.zIndex = "";
+                    fromEl.style.position = "";
                   }
                 : undefined,
           }),

--- a/packages/core/src/lib/transitions/drill/transition.ts
+++ b/packages/core/src/lib/transitions/drill/transition.ts
@@ -44,6 +44,19 @@ export const drill = (options: DrillOptions = {}): TransitionConfig => {
         element: from,
         integrator: IntegratorProvider.from(physicsOptions),
         style: (t) => config.out.animate(t),
+        // The outgoing node is the real, reused element (re-hidden on navigate),
+        // so clear every inline style we set on it — mirroring the `to` cleanup,
+        // plus the out-only `pointerEvents` / `zIndex`.
+        onComplete: () => {
+          from.style.willChange = "auto";
+          from.style.backfaceVisibility = "";
+          (from.style as CSSStyleDeclaration & { contain: string }).contain =
+            "";
+          from.style.transform = "";
+          from.style.opacity = "";
+          from.style.pointerEvents = "";
+          from.style.zIndex = "";
+        },
       });
 
       const inAnim = new WebAnimation({

--- a/packages/core/src/lib/transitions/fade/transition.ts
+++ b/packages/core/src/lib/transitions/fade/transition.ts
@@ -38,7 +38,12 @@ export const fade = (options: FadeOptions = {}): TransitionConfig => {
         // forward, mapping opacity from fully visible to invisible.
         style: (_t, u) => ({ opacity: u }),
         onComplete: () => {
+          // The outgoing node is the real page and gets reused (re-hidden,
+          // shown again next navigation), so clear every inline style we
+          // wrote — willChange and the final opacity:0 frame — exactly like
+          // the incoming cleanup below, or the page stays invisible.
           from.style.willChange = "auto";
+          from.style.opacity = "";
         },
       });
 

--- a/packages/core/src/lib/transitions/film/transition.ts
+++ b/packages/core/src/lib/transitions/film/transition.ts
@@ -467,8 +467,13 @@ export const film = (
           transform: `translateY(${s.translateY}px) scale(${s.scale})`,
         }),
         () => {
+          // The outgoing node is reused (re-hidden, shown on the next
+          // navigation), so every inline style this transition wrote to `from`
+          // must be reset here — mirroring the `to` cleanup below — or the
+          // stale clip/origin/transform corrupts the page when it reappears.
           from.style.clipPath = "";
           from.style.transformOrigin = "";
+          from.style.transform = "";
         },
       );
 

--- a/packages/core/src/lib/transitions/hero/provider/chrome/static.ts
+++ b/packages/core/src/lib/transitions/hero/provider/chrome/static.ts
@@ -1,4 +1,9 @@
-import type { HeroPrepareCtx, HeroStrategy } from "../../types";
+import type { Animation } from "../../../../animation";
+import type {
+  HeroContributeCtx,
+  HeroPrepareCtx,
+  HeroStrategy,
+} from "../../types";
 
 /**
  * Chrome handling for `type: "static"`.
@@ -10,10 +15,24 @@ import type { HeroPrepareCtx, HeroStrategy } from "../../types";
  * Equivalent to v5/v6 hero default behavior.
  */
 class SnapHideChromeStrategy implements HeroStrategy {
+  private previousFromOpacity = "";
+
   prepare(ctx: HeroPrepareCtx): void {
     ctx.from.then((el) => {
+      this.previousFromOpacity = el.style.opacity;
       el.style.opacity = "0";
     });
+  }
+
+  contribute(ctx: HeroContributeCtx): Animation[] {
+    // `from` is the real outgoing node and gets re-shown on the next
+    // navigation (React Activity / Next cacheComponents), so restore the
+    // opacity we snapped to "0" in `prepare` — otherwise the reused page
+    // stays invisible.
+    ctx.onComplete(() => {
+      ctx.from.style.opacity = this.previousFromOpacity;
+    });
+    return [];
   }
 }
 

--- a/packages/core/src/lib/transitions/jaemin/transition.ts
+++ b/packages/core/src/lib/transitions/jaemin/transition.ts
@@ -69,6 +69,13 @@ export const jaemin = (options: JaeminOptions = {}): TransitionConfig => {
         element: from,
         integrator: IntegratorProvider.from(OUT_PHYSICS),
         style: (_t, u) => ({ opacity: u }),
+        // The outgoing node is reused (re-hidden, shown again on the next
+        // navigation), so reset every inline style we wrote to it — mirroring
+        // the "to" cleanup below. prepare sets opacity and the out style fades
+        // it toward 0, so clear opacity or the reused node stays invisible.
+        onComplete: () => {
+          from.style.opacity = "";
+        },
       });
 
       const inAnim = new WebAnimation({

--- a/packages/core/src/lib/transitions/rotate/transition.ts
+++ b/packages/core/src/lib/transitions/rotate/transition.ts
@@ -37,6 +37,15 @@ export const rotate = (options: RotateOptions = {}): TransitionConfig => {
           transform: `rotate(${t * 180}deg)`,
           opacity: t < 0.5 ? 1 : 0,
         }),
+        // The outgoing node is reused (re-hidden, shown again on the next
+        // navigation), so clear every inline style we wrote to `from`
+        // (prepare + the final WAAPI frame), mirroring the `to` cleanup.
+        onComplete: () => {
+          from.style.willChange = "auto";
+          from.style.transform = "";
+          from.style.transformOrigin = "";
+          from.style.opacity = "";
+        },
       });
 
       const inAnim = new WebAnimation({

--- a/packages/core/src/lib/transitions/scroll/transition.ts
+++ b/packages/core/src/lib/transitions/scroll/transition.ts
@@ -56,6 +56,20 @@ export const scroll = (options: ScrollOptions = {}): TransitionConfig => {
           const translateY = isUp ? -height * t : height * t;
           return { transform: `translate3d(0, ${translateY}px, 0)` };
         },
+        // The outgoing node is the real, reused element (re-hidden then shown
+        // again on the next navigation), so mirror the incoming cleanup and
+        // also reset the out-only props applied in prepare (zIndex,
+        // pointerEvents) — otherwise the leftover inline styles corrupt the
+        // page the next time it appears.
+        onComplete: () => {
+          from.style.willChange = "auto";
+          from.style.backfaceVisibility = "";
+          (from.style as CSSStyleDeclaration & { contain: string }).contain =
+            "";
+          from.style.transform = "";
+          from.style.pointerEvents = "";
+          from.style.zIndex = "";
+        },
       });
 
       const inAnim = new WebAnimation({

--- a/packages/core/src/lib/transitions/sheet/transition.ts
+++ b/packages/core/src/lib/transitions/sheet/transition.ts
@@ -62,6 +62,17 @@ export const sheet = (options: SheetOptions = {}): TransitionConfig => {
         direction === "enter" ? "to" : "from",
       );
 
+      // The outgoing (`from`) node is now reused across navigations (it is
+      // re-hidden with display:none and shown again next time), so any inline
+      // style we leave on it would corrupt the page when it reappears. Reset
+      // the `from`-only prepare props that the per-element onComplete below
+      // does not already clear (the `to`-side cleanup is the template). For
+      // `enter` the `from` is the background; for `exit` it is the sheet.
+      const resetFromInteractionProps = () => {
+        from.style.pointerEvents = "";
+        from.style.zIndex = "";
+      };
+
       // Clip the moving sheet to its visible viewport slice — without this it
       // can paint outside the chrome (top nav / player bar) during translate.
       sheetEl.style.clipPath = `inset(${sheetRect.top}px 0 calc(100% - ${sheetRect.top + sheetRect.height}px) 0)`;
@@ -86,6 +97,11 @@ export const sheet = (options: SheetOptions = {}): TransitionConfig => {
             "";
           sheetEl.style.clipPath = "";
           sheetEl.style.transform = "";
+          // The sheet animation always settles, so use it to clear the
+          // pointerEvents/zIndex that prepare put on the reused `from` node
+          // (the sheet itself on `exit`, the background on `enter`). The rest
+          // of the `from` background props on `enter` are cleared by bgAnim.
+          resetFromInteractionProps();
         },
       });
 
@@ -112,6 +128,12 @@ export const sheet = (options: SheetOptions = {}): TransitionConfig => {
         element: backgroundEl,
         integrator: IntegratorProvider.from(physics),
         style: bgStyle,
+        // On `exit` the background is the incoming (`to`) node; on `enter` it is
+        // the reused outgoing (`from`) node — in both cases its inline styles
+        // must be restored when the animation settles, so the reused node is
+        // not left scaled/faded/clipped the next time it is shown. The `enter`
+        // branch mirrors the `exit` cleanup and additionally clears the
+        // transform/opacity final frame WAAPI leaves behind.
         onComplete:
           direction === "exit"
             ? () => {
@@ -125,7 +147,19 @@ export const sheet = (options: SheetOptions = {}): TransitionConfig => {
                 backgroundEl.style.clipPath = "";
                 backgroundEl.style.transformOrigin = "";
               }
-            : undefined,
+            : () => {
+                backgroundEl.style.willChange = "auto";
+                backgroundEl.style.backfaceVisibility = "";
+                (
+                  backgroundEl.style as CSSStyleDeclaration & {
+                    contain: string;
+                  }
+                ).contain = "";
+                backgroundEl.style.clipPath = "";
+                backgroundEl.style.transformOrigin = "";
+                backgroundEl.style.transform = "";
+                backgroundEl.style.opacity = "";
+              },
       });
 
       return new MultiAnimation([sheetAnim, bgAnim], { mode: "parallel" });

--- a/packages/core/src/lib/transitions/slide/transition.ts
+++ b/packages/core/src/lib/transitions/slide/transition.ts
@@ -48,6 +48,17 @@ export const slide = (options: SlideOptions = {}): TransitionConfig => {
           const translateX = isLeft ? -100 * t : 100 * t;
           return { transform: `translate3d(${translateX}%, 0, 0)` };
         },
+        // The outgoing node is the real Activity page and gets reused on the
+        // next navigation, so reset every inline style we wrote to it (mirror
+        // the incoming cleanup, plus the out-only pointerEvents).
+        onComplete: () => {
+          from.style.willChange = "auto";
+          from.style.backfaceVisibility = "";
+          (from.style as CSSStyleDeclaration & { contain: string }).contain =
+            "";
+          from.style.transform = "";
+          from.style.pointerEvents = "";
+        },
       });
 
       const inAnim = new WebAnimation({

--- a/packages/core/src/lib/transitions/strip/transition.ts
+++ b/packages/core/src/lib/transitions/strip/transition.ts
@@ -47,6 +47,17 @@ export const strip = (options: StripOptions = {}): TransitionConfig => {
             transform: `perspective(${PERSPECTIVE}px) rotateY(${rotate}deg) translate3d(${translateX}%, 0, 0)`,
           };
         },
+        // The outgoing node is reused (Activity/cacheComponents re-hide it),
+        // so restore every inline style we wrote to `from` — mirroring the
+        // incoming cleanup below, plus the out-only `pointerEvents`.
+        onComplete: () => {
+          from.style.transform = "";
+          from.style.willChange = "auto";
+          from.style.backfaceVisibility = "";
+          (from.style as CSSStyleDeclaration & { contain: string }).contain =
+            "";
+          from.style.pointerEvents = "";
+        },
       });
 
       const inAnim = new WebAnimation({

--- a/packages/core/src/lib/transitions/zoom/transition.ts
+++ b/packages/core/src/lib/transitions/zoom/transition.ts
@@ -176,6 +176,24 @@ class TileStrategy implements ZoomStrategy {
       tileEl.style.transformOrigin = "";
       (tileEl.style as CSSStyleDeclaration & { contain: string }).contain = "";
       from.style.zIndex = previousFromZIndex;
+      // `from` is the REAL outgoing page now (React <Activity> / Next
+      // cacheComponents re-hide and reuse this node on the next nav), so any
+      // inline style left on it persists and corrupts the page when it
+      // reappears. Mirror the tile-side (`to`) reset above for every prop the
+      // prepare hook / out animations write to `from`, regardless of mode:
+      //   - prepare(): willChange, backfaceVisibility, contain.
+      //   - background/tile out animations: transformOrigin (set here for the
+      //     `from`-owned config) plus the WAAPI forwards-fill final frame
+      //     (transform on the expand/blur background, transform + clipPath on
+      //     the exit-mode tile). When `tileEl === from` (exit) the resets
+      //     above already cover those props; the lines below make the cleanup
+      //     correct in enter mode too, where `tileEl === to`.
+      from.style.willChange = "auto";
+      from.style.backfaceVisibility = "";
+      from.style.transformOrigin = "";
+      (from.style as CSSStyleDeclaration & { contain: string }).contain = "";
+      from.style.transform = "";
+      from.style.clipPath = "";
     });
 
     return [

--- a/packages/core/src/lib/transitions/zoom/transition.ts
+++ b/packages/core/src/lib/transitions/zoom/transition.ts
@@ -1,5 +1,5 @@
 import type { PhysicsOptions, TransitionConfig } from "@types";
-import { getRect } from "@utils";
+import { getClientRect } from "@utils";
 import {
   IntegratorProvider,
   MultiAnimation,
@@ -106,11 +106,11 @@ function buildInput(
   scrollOffset: { x: number; y: number },
 ): ZoomAnimationInput {
   return {
-    enterRect: getRect(
+    enterRect: getClientRect(
       resolved.mode === "enter" ? toNode : fromNode,
       resolved.enterEl,
     ),
-    exitRect: getRect(
+    exitRect: getClientRect(
       resolved.mode === "enter" ? fromNode : toNode,
       resolved.exitEl,
     ),
@@ -393,6 +393,24 @@ export const zoom = (
               console.error("[zoom] cleanup error", e);
             }
           }
+        };
+      }
+
+      // Release each animation's WAAPI forwards-fill once its OWN run settles,
+      // so the inline styles (cleared during playback, reset by the cleanups
+      // above) govern the resting visual instead of a lingering fill. Wrapped on
+      // each animation's own onComplete — which fires after its onfinish but
+      // before MultiAnimation's completion count — so every child is still
+      // counted as done. Without this the exit tile stays shrunk to the card and
+      // the background stays scaled; React <Activity> / Next cacheComponents then
+      // preserve that on the real node, so the NEXT transition measures (and
+      // renders) the page at the wrong size.
+      for (const anim of anims) {
+        if (!(anim instanceof WebAnimation)) continue;
+        const prev = anim.onComplete;
+        anim.onComplete = () => {
+          prev?.();
+          anim.releaseFill();
         };
       }
 

--- a/packages/core/src/lib/utils/get-client-rect.ts
+++ b/packages/core/src/lib/utils/get-client-rect.ts
@@ -1,0 +1,37 @@
+/**
+ * Viewport-accurate counterpart to {@link getRect}: `el`'s position relative to
+ * `root`, measured with getBoundingClientRect. Same `(root, el)` shape and
+ * meaning as `getRect`, but because gBCR is the on-screen box it REFLECTS any
+ * transform / nested-scroll BETWEEN `root` and `el` — e.g. a translate-based
+ * horizontal scroller — which is the position the zoom tile must animate from.
+ * `getRect` walks the offsetParent chain and ignores transforms, so the
+ * page-edge transitions (film, and sheet/jaemin/axis via getViewportRect) keep
+ * using it.
+ *
+ * Safety net: it also normalizes out any scale on `root` itself. The completion
+ * cleanup releases each animation's WAAPI fill, so a SETTLED page is back at its
+ * natural transform before the next transition measures it — but a page can
+ * still be mid-scale when measured by an INTERRUPTED transition (a back-tap
+ * before the previous one settles): `buildInput` runs before the orchestrator
+ * completes the prior transition, so the zoom background tween may still be
+ * scaling the page. gBCR is post-transform while `offsetWidth/Height` is the
+ * untransformed layout size, so their ratio is the live scale; dividing returns
+ * the rect in `root`'s layout space — the space the zoom translate operates in.
+ * An in-page translate (a scrolled row) is scaled by the same factor and so
+ * survives the division. (No-op when `root` is at scale 1.)
+ *
+ * Page-level scroll OUTSIDE `root` cancels in the `el − root` subtraction; the
+ * per-page scroll delta is reintroduced separately via context.scrollOffset.
+ */
+export function getClientRect(root: HTMLElement, el: HTMLElement): DOMRect {
+  const rootRect = root.getBoundingClientRect();
+  const elRect = el.getBoundingClientRect();
+  const sx = root.offsetWidth > 0 ? rootRect.width / root.offsetWidth : 1;
+  const sy = root.offsetHeight > 0 ? rootRect.height / root.offsetHeight : 1;
+  return new DOMRect(
+    (elRect.left - rootRect.left) / sx,
+    (elRect.top - rootRect.top) / sy,
+    elRect.width / sx,
+    elRect.height / sy,
+  );
+}

--- a/packages/core/src/lib/utils/index.ts
+++ b/packages/core/src/lib/utils/index.ts
@@ -3,6 +3,7 @@ export { getScrollingElement } from "./get-scrolling-element";
 export { getPositionedParent } from "./get-positioned-parent";
 export { sleep } from "./sleep";
 export { getRect } from "./get-rect";
+export { getClientRect } from "./get-client-rect";
 export { getViewportRect } from "./get-viewport-rect";
 export { round, floor, ceil, toFixed } from "./number";
 export { withResolvers } from "./with-resolvers";

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/react",
-  "version": "6.5.0-beta.0",
+  "version": "6.5.0-beta.2",
   "description": "React bindings for SSGOI - Native app-like page transitions for React applications",
   "private": false,
   "type": "module",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/react",
-  "version": "6.5.0-beta.2",
+  "version": "6.5.0",
   "description": "React bindings for SSGOI - Native app-like page transitions for React applications",
   "private": false,
   "type": "module",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/react",
-  "version": "6.4.0",
+  "version": "6.5.0-beta.0",
   "description": "React bindings for SSGOI - Native app-like page transitions for React applications",
   "private": false,
   "type": "module",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/solid",
-  "version": "6.4.0",
+  "version": "6.5.0",
   "description": "Solid.js bindings for SSGOI - Native app-like page transitions for Solid applications",
   "private": false,
   "type": "module",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/svelte",
-  "version": "6.4.0",
+  "version": "6.5.0",
   "description": "Svelte bindings for SSGOI - Native app-like page transitions for Svelte and SvelteKit applications",
   "private": false,
   "main": "./dist/index.js",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/vue",
-  "version": "6.4.0",
+  "version": "6.5.0",
   "description": "Vue bindings for SSGOI - Native app-like page transitions for Vue applications",
   "private": false,
   "type": "module",


### PR DESCRIPTION
## Release v6.5.0 — React `<Activity>` / Next.js `cacheComponents` page transitions

Promotes the `6.5.0-beta` line to a **stable minor** and publishes the entire family in lockstep:

| Package | 6.4.0 → |
| --- | --- |
| `@ssgoi/core` | **6.5.0** |
| `@ssgoi/react` | **6.5.0** |
| `@ssgoi/svelte` | **6.5.0** |
| `@ssgoi/vue` | **6.5.0** |
| `@ssgoi/angular` | **6.5.0** |
| `@ssgoi/solid` | **6.5.0** |

All six are already published to the npm `latest` tag at `6.5.0`.

---

### 🚀 Headline: page transitions for kept-mounted routes

Until now ssgoi could only animate a page out when its DOM node was **unmounted**. Modern React keeps the previous route **mounted** and merely hidden with `display:none` to preserve its state:

- **React `<Activity mode="hidden">`** (formerly `<Offscreen>`)
- **Next.js App Router with `cacheComponents`** (PPR), which wraps each cached segment in `<Activity>` and keeps the prior page as a hidden sibling

In those modes nothing unmounted, so **no out/in pair formed and transitions never ran**. `6.5.0` makes them work — and work correctly under rapid, interrupted back-and-forth navigation. (#353)

**What changed under the hood:**

- **Visibility detection without feedback loops** (`visibility-observer.ts`) — a shared `MutationObserver` watches each page boundary's `style` and fires only on React's exact hide signature `display:none !important`. An app's own plain `display:none` is never hijacked into a bogus transition, and the library's own reveal/transform writes never re-trigger it (decisions key on the `display` value vs a per-element *accounted* value).
- **Real-node reuse, no clone** — the outgoing page animates out on its **real DOM node**, so live page state (scroll, inputs, counters) is preserved and the pose handoff (`matchInto`, which keys on element identity) stays continuous across interrupts. On settle the node is re-hidden and every inline style the transition leaked is wiped via a `cssText` snapshot.
- **Ownership-epoch reconciliation** — each run stamps the nodes it drives with a monotonic epoch, so an interrupted run never clobbers the resting state owned by the run that superseded it. No page is left vanished, stuck-hidden, or non-interactive.
- **Two repeated-navigation bugs fixed** — React committing the same hide twice (deduped by *intent*, so a real navigation is never swallowed) and Next's bfcache **reordering** a kept-alive `<Activity>` (a DOM *move*, which `unmount-observer` now distinguishes from a true unmount via `isConnected`).

The unmount/clone path (SPA frameworks, Next without `cacheComponents`) is **byte-for-byte the baseline** — the visibility watcher is inert unless `display` toggles to/from `none !important`.

---

### 🐞 Fixes & tuning

- **Zoom tile measurement in client space** (#354) — new `getClientRect()` measures via `getBoundingClientRect` (page-relative), so a card scrolled inside an in-page transform / nested horizontal scroller is measured at its **real on-screen position** and the zoom tile lands on the right spot. `getRect` is left untouched for the page-edge transitions that rely on its transform-ignoring behavior.
- **WAAPI fill release** (#354) — `WebAnimation` no longer keeps `fill: forwards` after settling. Previously, under `<Activity>` / `cacheComponents` (where the real node is preserved), the outgoing zoom tile stayed shrunk and clip/scale appeared to "not apply" from the **2nd transition onward**. Now every transition renders correctly, not just the first.
- **Built-in transitions restore the outgoing node** — now that hidden mode reuses the real node, every built-in transition resets the inline styles (`opacity`/`transform`, plus out-only `pointer-events`/`z-index`) it writes to `from` on completion, mirroring the existing `to` cleanup. Keeps each transition symmetric and correct on its own.
- **Axis settle thresholds loosened 10×** (#350) — the axis family (x snappy/fluid, y directional/non-directional, z directional/non-directional) now sets explicit `restDelta`/`restSpeed: 0.1`. Perceived motion is unchanged; only the imperceptible sub-pixel tail past ~98% is cut, so chained navigations hand off faster.

---

### 📚 Docs

- Per-transition detail pages with variants and live demos.
- SEO/AEO foundation + IA redesign (showcase home, docs hub, blog), sitemap/robots.

---

### ✅ Verification

- `@ssgoi/core` build + **29 unit tests passing** (incl. new `visibility-observer.test.ts`), all packages build clean.
- React `<Activity>` driven headless end-to-end: initial state, single nav both ways, **state preservation**, 4× rapid-interrupt stress, and interactivity after interrupts.
- Real Next App Router + `cacheComponents` (docs gamja-market): outgoing page animates out on the real node and settles to a clean hidden state; repeated back/forward (bfcache reorder) keeps exactly one page visible across many cycles.
- Published `@ssgoi/react@6.5.0` correctly pins `@ssgoi/core@^6.5.0` (workspace ranges resolved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
