### PR TITLE
feat(core): non-negative page-transition stacking (drop caller stacking-context requirement)

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/core",
-  "version": "6.5.0",
+  "version": "6.5.1",
   "description": "Core animation engine for SSGOI - Native app-like page transitions with spring physics",
   "private": false,
   "type": "module",

--- a/packages/core/src/lib/transitions/drill/transition.ts
+++ b/packages/core/src/lib/transitions/drill/transition.ts
@@ -5,6 +5,7 @@ import {
   WebAnimation,
 } from "../../animation";
 import { DRILL_PROVIDERS } from "./provider";
+import { Z_BACKGROUND, Z_FOREGROUND } from "../stacking";
 import type { DrillOptions, DrillSideConfig, DrillType } from "./types";
 
 export type { DrillOptions, DrillType } from "./types";
@@ -27,15 +28,24 @@ export const drill = (options: DrillOptions = {}): TransitionConfig => {
   const physicsOptions = provider.physics;
   const config = provider.build(direction);
 
+  // enter: the incoming `to` covers the outgoing `from`; exit: the outgoing
+  // `from` drills back out on top of the revealed `to`.
+  const fromZ = direction === "enter" ? Z_BACKGROUND : Z_FOREGROUND;
+  const toZ = direction === "enter" ? Z_FOREGROUND : Z_BACKGROUND;
+
   return {
     prepare: ({ from, to }) => {
       from.then((el) => {
         applyStartStyle(el, config.out);
         el.style.pointerEvents = "none";
-        el.style.zIndex = direction === "enter" ? "0" : "100";
+        el.style.zIndex = fromZ;
       });
       to.then((el) => {
         applyStartStyle(el, config.in);
+        // `to` is in normal flow; promote it so its z-index takes effect and it
+        // can stack above/below the out-of-flow `from`. Reset on complete.
+        el.style.position = "relative";
+        el.style.zIndex = toZ;
       });
       return {};
     },
@@ -69,6 +79,13 @@ export const drill = (options: DrillOptions = {}): TransitionConfig => {
           (to.style as CSSStyleDeclaration & { contain: string }).contain = "";
           to.style.transform = "";
           to.style.opacity = "";
+          // `to` is the surviving page; clear the stacking props prepare set on
+          // it (unmount mode gives the persistent `to` node no other cleanup).
+          // Guard: if a follow-up navigation already re-claimed this node (e.g.
+          // as the next outgoing `from`, now position:absolute), leave its
+          // fresh stacking intact instead of stripping it.
+          if (to.style.position === "relative") to.style.position = "";
+          if (to.style.zIndex === toZ) to.style.zIndex = "";
         },
       });
 

--- a/packages/core/src/lib/transitions/drill/transition.ts
+++ b/packages/core/src/lib/transitions/drill/transition.ts
@@ -89,6 +89,18 @@ export const drill = (options: DrillOptions = {}): TransitionConfig => {
         },
       });
 
+      // Drop each WAAPI forwards-fill once its own run settles, so the inline
+      // resets above (not a lingering final frame) govern the resting visual —
+      // mirrors the zoom transition. Without this a reused node (React
+      // <Activity>) reappears holding its animated transform/opacity.
+      for (const anim of [outAnim, inAnim]) {
+        const prev = anim.onComplete;
+        anim.onComplete = () => {
+          prev?.();
+          anim.releaseFill();
+        };
+      }
+
       return new MultiAnimation([outAnim, inAnim], { mode: "parallel" });
     },
   };

--- a/packages/core/src/lib/transitions/drill/transition.ts
+++ b/packages/core/src/lib/transitions/drill/transition.ts
@@ -32,7 +32,7 @@ export const drill = (options: DrillOptions = {}): TransitionConfig => {
       from.then((el) => {
         applyStartStyle(el, config.out);
         el.style.pointerEvents = "none";
-        el.style.zIndex = direction === "enter" ? "-1" : "100";
+        el.style.zIndex = direction === "enter" ? "0" : "100";
       });
       to.then((el) => {
         applyStartStyle(el, config.in);

--- a/packages/core/src/lib/transitions/scroll/transition.ts
+++ b/packages/core/src/lib/transitions/scroll/transition.ts
@@ -103,6 +103,18 @@ export const scroll = (options: ScrollOptions = {}): TransitionConfig => {
         },
       });
 
+      // Drop each WAAPI forwards-fill once its own run settles, so the inline
+      // resets above (not a lingering final frame) govern the resting visual —
+      // mirrors the zoom transition. Without this a reused node (React
+      // <Activity>) reappears displaced by the leftover transform.
+      for (const anim of [outAnim, inAnim]) {
+        const prev = anim.onComplete;
+        anim.onComplete = () => {
+          prev?.();
+          anim.releaseFill();
+        };
+      }
+
       return new MultiAnimation([outAnim, inAnim], { mode: "parallel" });
     },
   };

--- a/packages/core/src/lib/transitions/scroll/transition.ts
+++ b/packages/core/src/lib/transitions/scroll/transition.ts
@@ -4,6 +4,7 @@ import {
   MultiAnimation,
   WebAnimation,
 } from "../../animation";
+import { Z_BACKGROUND, Z_FOREGROUND } from "../stacking";
 
 export interface ScrollOptions {
   direction?: "up" | "down";
@@ -25,10 +26,15 @@ export const scroll = (options: ScrollOptions = {}): TransitionConfig => {
   const physicsOptions: PhysicsOptions = options.physics ?? DEFAULT_PHYSICS;
   const isUp = direction === "up";
 
+  // up: the incoming `to` slides up over the outgoing `from`; down: the
+  // outgoing `from` slides down on top of the revealed `to`.
+  const fromZ = isUp ? Z_BACKGROUND : Z_FOREGROUND;
+  const toZ = isUp ? Z_FOREGROUND : Z_BACKGROUND;
+
   return {
     prepare: ({ from, to }) => {
       from.then((el) => {
-        el.style.zIndex = isUp ? "0" : "1";
+        el.style.zIndex = fromZ;
         el.style.willChange = "transform";
         el.style.backfaceVisibility = "hidden";
         (el.style as CSSStyleDeclaration & { contain: string }).contain =
@@ -40,6 +46,9 @@ export const scroll = (options: ScrollOptions = {}): TransitionConfig => {
         el.style.backfaceVisibility = "hidden";
         (el.style as CSSStyleDeclaration & { contain: string }).contain =
           "layout paint";
+        // `to` is in normal flow; promote it so its z-index takes effect.
+        el.style.position = "relative";
+        el.style.zIndex = toZ;
       });
       return {};
     },
@@ -84,6 +93,13 @@ export const scroll = (options: ScrollOptions = {}): TransitionConfig => {
           to.style.backfaceVisibility = "";
           (to.style as CSSStyleDeclaration & { contain: string }).contain = "";
           to.style.transform = "";
+          // `to` is the surviving page; clear the stacking props prepare set on
+          // it (unmount mode gives the persistent `to` node no other cleanup).
+          // Guard: if a follow-up navigation already re-claimed this node (e.g.
+          // as the next outgoing `from`, now position:absolute), leave its
+          // fresh stacking intact instead of stripping it.
+          if (to.style.position === "relative") to.style.position = "";
+          if (to.style.zIndex === toZ) to.style.zIndex = "";
         },
       });
 

--- a/packages/core/src/lib/transitions/scroll/transition.ts
+++ b/packages/core/src/lib/transitions/scroll/transition.ts
@@ -28,7 +28,7 @@ export const scroll = (options: ScrollOptions = {}): TransitionConfig => {
   return {
     prepare: ({ from, to }) => {
       from.then((el) => {
-        el.style.zIndex = isUp ? "-1" : "1";
+        el.style.zIndex = isUp ? "0" : "1";
         el.style.willChange = "transform";
         el.style.backfaceVisibility = "hidden";
         (el.style as CSSStyleDeclaration & { contain: string }).contain =

--- a/packages/core/src/lib/transitions/sheet/transition.ts
+++ b/packages/core/src/lib/transitions/sheet/transition.ts
@@ -98,6 +98,18 @@ export const sheet = (options: SheetOptions = {}): TransitionConfig => {
         if (to.style.zIndex === toZ) to.style.zIndex = "";
       };
 
+      // Drop a WAAPI forwards-fill once its run settles, so the inline resets
+      // in onComplete (not a lingering final frame) govern the resting visual —
+      // mirrors the zoom transition. Without this a reused node (React
+      // <Activity>) reappears holding its animated transform/clip.
+      const releaseFillOnSettle = (anim: WebAnimation) => {
+        const prev = anim.onComplete;
+        anim.onComplete = () => {
+          prev?.();
+          anim.releaseFill();
+        };
+      };
+
       // Clip the moving sheet to its visible viewport slice — without this it
       // can paint outside the chrome (top nav / player bar) during translate.
       sheetEl.style.clipPath = `inset(${sheetRect.top}px 0 calc(100% - ${sheetRect.top + sheetRect.height}px) 0)`;
@@ -131,6 +143,7 @@ export const sheet = (options: SheetOptions = {}): TransitionConfig => {
           resetToStackProps();
         },
       });
+      releaseFillOnSettle(sheetAnim);
 
       if (!animatesBackground) {
         // Static: the background sits untouched for the whole duration.
@@ -155,39 +168,24 @@ export const sheet = (options: SheetOptions = {}): TransitionConfig => {
         element: backgroundEl,
         integrator: IntegratorProvider.from(physics),
         style: bgStyle,
-        // On `exit` the background is the incoming (`to`) node; on `enter` it is
-        // the reused outgoing (`from`) node — in both cases its inline styles
-        // must be restored when the animation settles, so the reused node is
-        // not left scaled/faded/clipped the next time it is shown. The `enter`
-        // branch mirrors the `exit` cleanup and additionally clears the
-        // transform/opacity final frame WAAPI leaves behind.
-        onComplete:
-          direction === "exit"
-            ? () => {
-                backgroundEl.style.willChange = "auto";
-                backgroundEl.style.backfaceVisibility = "";
-                (
-                  backgroundEl.style as CSSStyleDeclaration & {
-                    contain: string;
-                  }
-                ).contain = "";
-                backgroundEl.style.clipPath = "";
-                backgroundEl.style.transformOrigin = "";
-              }
-            : () => {
-                backgroundEl.style.willChange = "auto";
-                backgroundEl.style.backfaceVisibility = "";
-                (
-                  backgroundEl.style as CSSStyleDeclaration & {
-                    contain: string;
-                  }
-                ).contain = "";
-                backgroundEl.style.clipPath = "";
-                backgroundEl.style.transformOrigin = "";
-                backgroundEl.style.transform = "";
-                backgroundEl.style.opacity = "";
-              },
+        // The background is the reused outgoing (`from`) node on `enter` and the
+        // surviving incoming (`to`) node on `exit` — in both cases its inline
+        // styles must be cleared on settle so the reused node is not left
+        // scaled/faded/clipped the next time it is shown. releaseFill below
+        // drops the WAAPI fill so these resets actually take effect.
+        onComplete: () => {
+          backgroundEl.style.willChange = "auto";
+          backgroundEl.style.backfaceVisibility = "";
+          (
+            backgroundEl.style as CSSStyleDeclaration & { contain: string }
+          ).contain = "";
+          backgroundEl.style.clipPath = "";
+          backgroundEl.style.transformOrigin = "";
+          backgroundEl.style.transform = "";
+          backgroundEl.style.opacity = "";
+        },
       });
+      releaseFillOnSettle(bgAnim);
 
       return new MultiAnimation([sheetAnim, bgAnim], { mode: "parallel" });
     },

--- a/packages/core/src/lib/transitions/sheet/transition.ts
+++ b/packages/core/src/lib/transitions/sheet/transition.ts
@@ -6,6 +6,7 @@ import {
   WebAnimation,
 } from "../../animation";
 import { SHEET_PROVIDERS } from "./provider";
+import { Z_BACKGROUND, Z_FOREGROUND } from "../stacking";
 import type { SheetOptions, SheetType } from "./types";
 
 export type { SheetOptions, SheetType } from "./types";
@@ -32,9 +33,15 @@ export const sheet = (options: SheetOptions = {}): TransitionConfig => {
         el.style.backfaceVisibility = "hidden";
         (el.style as CSSStyleDeclaration & { contain: string }).contain =
           "layout paint";
-        if (direction === "exit") {
+        // The sheet is always the foreground layer.
+        el.style.zIndex = Z_FOREGROUND;
+        if (direction === "enter") {
+          // sheet is the incoming `to`, still in normal flow — promote it so
+          // its z-index takes effect.
+          el.style.position = "relative";
+        } else {
+          // sheet is the outgoing `from` (already absolute); keep it inert.
           el.style.pointerEvents = "none";
-          el.style.zIndex = "100";
         }
       });
 
@@ -45,10 +52,16 @@ export const sheet = (options: SheetOptions = {}): TransitionConfig => {
           (el.style as CSSStyleDeclaration & { contain: string }).contain =
             "layout paint";
         }
+        // The background sits beneath the sheet. An explicit z-index forms its
+        // own stacking context so its descendants stay trapped below.
+        el.style.zIndex = Z_BACKGROUND;
         if (direction === "enter") {
-          // Make sure the cloned outgoing page stays beneath the rising sheet.
+          // background is the outgoing `from` (absolute); keep it inert.
           el.style.pointerEvents = "none";
-          el.style.zIndex = "0";
+        } else {
+          // background is the incoming `to`, in normal flow — promote it so its
+          // z-index takes effect.
+          el.style.position = "relative";
         }
       });
 
@@ -71,6 +84,18 @@ export const sheet = (options: SheetOptions = {}): TransitionConfig => {
       const resetFromInteractionProps = () => {
         from.style.pointerEvents = "";
         from.style.zIndex = "";
+      };
+
+      // `to` is the surviving page and now also carries stacking props (the
+      // foreground sheet on `enter`, the promoted background on `exit`). Clear
+      // them too — in unmount mode the context never cleans the persistent `to`.
+      const resetToStackProps = () => {
+        // Guard: if a follow-up navigation already re-claimed this node (e.g.
+        // as the next outgoing `from`, now position:absolute), leave its fresh
+        // stacking intact instead of stripping it.
+        const toZ = direction === "enter" ? Z_FOREGROUND : Z_BACKGROUND;
+        if (to.style.position === "relative") to.style.position = "";
+        if (to.style.zIndex === toZ) to.style.zIndex = "";
       };
 
       // Clip the moving sheet to its visible viewport slice — without this it
@@ -99,9 +124,11 @@ export const sheet = (options: SheetOptions = {}): TransitionConfig => {
           sheetEl.style.transform = "";
           // The sheet animation always settles, so use it to clear the
           // pointerEvents/zIndex that prepare put on the reused `from` node
-          // (the sheet itself on `exit`, the background on `enter`). The rest
-          // of the `from` background props on `enter` are cleared by bgAnim.
+          // (the sheet itself on `exit`, the background on `enter`) and the
+          // stacking props on the surviving `to` node. The rest of the `from`
+          // background props on `enter` are cleared by bgAnim.
           resetFromInteractionProps();
+          resetToStackProps();
         },
       });
 

--- a/packages/core/src/lib/transitions/sheet/transition.ts
+++ b/packages/core/src/lib/transitions/sheet/transition.ts
@@ -48,7 +48,7 @@ export const sheet = (options: SheetOptions = {}): TransitionConfig => {
         if (direction === "enter") {
           // Make sure the cloned outgoing page stays beneath the rising sheet.
           el.style.pointerEvents = "none";
-          el.style.zIndex = "-1";
+          el.style.zIndex = "0";
         }
       });
 

--- a/packages/core/src/lib/transitions/stacking.ts
+++ b/packages/core/src/lib/transitions/stacking.ts
@@ -1,0 +1,30 @@
+/**
+ * Non-negative stacking tiers shared by the page transitions.
+ *
+ * During a page transition the outgoing `from` page is taken out of flow
+ * (`position: absolute`, applied by the context) while the incoming `to` page
+ * stays in normal flow. A *positioned* element with `z-index: auto`/`0` always
+ * paints **above** in-flow content, so simply lowering `from`'s z-index to `0`
+ * does NOT put it beneath `to`. To control which page sits on top we instead:
+ *
+ *   1. give the BACKGROUND page an explicit `z-index` (`Z_BACKGROUND`) so it
+ *      forms its own stacking context and its positioned descendants stay
+ *      trapped beneath the foreground, and
+ *   2. give the FOREGROUND page a higher `z-index` (`Z_FOREGROUND`),
+ *      promoting it to `position: relative` when it is the still-in-flow `to`
+ *      so the index actually takes effect.
+ *
+ * Every tier is `>= 0` on purpose. A negative z-index escapes upward to the
+ * nearest ancestor stacking context, so it bleeds *behind* the page wrapper
+ * whenever the caller has not given that wrapper its own stacking context
+ * (`isolation: isolate` / `z-index: 0`). Keeping the whole scheme non-negative
+ * removes that caller requirement entirely.
+ *
+ * NOTE: because the foreground is now expressed by raising the *surviving*
+ * `to` node (not by pushing the disposable `from` clone), every transition that
+ * uses these tiers MUST restore `to`'s `zIndex`/`position` on settle — in
+ * unmount mode the context provides no cleanup for the persistent `to` node.
+ */
+export const Z_BACKGROUND = "0";
+export const Z_OVERLAY = "1";
+export const Z_FOREGROUND = "2";

--- a/packages/core/src/lib/transitions/zoom/provider/blur.ts
+++ b/packages/core/src/lib/transitions/zoom/provider/blur.ts
@@ -14,6 +14,7 @@ import {
   WebAnimation,
 } from "../../../animation";
 import { createZoomIn, createZoomOut } from "../zoom-element";
+import { Z_OVERLAY } from "../../stacking";
 
 export const BLUR_PHYSICS: PhysicsOptions = {
   spring: {
@@ -64,13 +65,9 @@ const overlay: ZoomOverlayConfig = {
     position: "absolute",
     inset: "0",
     pointerEvents: "none",
-    // z-index is mode-dependent and applied in OverlayStrategy.contribute
-    // once `resolved.mode` is known. Sits between the background page and
-    // the zoomed tile:
-    //   enter — tile (`to`) is default(0), background (`from`) at -2,
-    //           overlay at -1.
-    //   exit  — tile (`from`) is at +2, background (`to`) default(0),
-    //           overlay at +1.
+    // z-index is applied in OverlayStrategy.contribute. The overlay always
+    // sits at Z_OVERLAY, between the background page (Z_BACKGROUND) and the
+    // zoomed tile (Z_FOREGROUND), in both enter and exit.
     backdropFilter: "blur(0px)",
     WebkitBackdropFilter: "blur(0px)",
   },
@@ -132,10 +129,10 @@ export class OverlayStrategy implements ZoomStrategy {
   contribute(ctx: ZoomContributeCtx): Animation[] {
     const overlayEl = ctx.extras.overlay;
     if (!overlayEl) return [];
-    // Mirrors the from-only z-index scheme in TileStrategy. Overlay is fully
-    // transparent (blur(0px)) until the first tick fires, so applying the
-    // z-index here — after prepare, before paint — has no visual cost.
-    overlayEl.style.zIndex = ctx.resolved.mode === "enter" ? "0" : "1";
+    // Sits at the middle tier between background and tile (see TileStrategy).
+    // Overlay is fully transparent (blur(0px)) until the first tick fires, so
+    // applying the z-index here — after prepare, before paint — has no cost.
+    overlayEl.style.zIndex = Z_OVERLAY;
     return [
       new WebAnimation({
         element: overlayEl,

--- a/packages/core/src/lib/transitions/zoom/provider/blur.ts
+++ b/packages/core/src/lib/transitions/zoom/provider/blur.ts
@@ -135,7 +135,7 @@ export class OverlayStrategy implements ZoomStrategy {
     // Mirrors the from-only z-index scheme in TileStrategy. Overlay is fully
     // transparent (blur(0px)) until the first tick fires, so applying the
     // z-index here — after prepare, before paint — has no visual cost.
-    overlayEl.style.zIndex = ctx.resolved.mode === "enter" ? "-1" : "1";
+    overlayEl.style.zIndex = ctx.resolved.mode === "enter" ? "0" : "1";
     return [
       new WebAnimation({
         element: overlayEl,

--- a/packages/core/src/lib/transitions/zoom/transition.ts
+++ b/packages/core/src/lib/transitions/zoom/transition.ts
@@ -8,6 +8,7 @@ import {
 } from "../../animation";
 import { OverlayStrategy, createBackgroundStrategy } from "./provider";
 import { createZoomIn, createZoomOut } from "./zoom-element";
+import { Z_BACKGROUND, Z_FOREGROUND } from "../stacking";
 import type {
   NormalizedZoomOptions,
   ZoomAnimationInput,
@@ -154,21 +155,26 @@ class TileStrategy implements ZoomStrategy {
 
     if (tileConfig) tileEl.style.transformOrigin = tileConfig.transformOrigin;
 
-    // Only mutate `from`'s z-index — never `to`. The page that remains
-    // after the transition keeps its natural stacking, so any failed
-    // cleanup is self-healing (the `from` clone is removed anyway).
-    // enter: push `from` (background) down to -2, leaving -1 for the
-    //   optional blur overlay; the incoming tile (`to`) sits at default
-    //   and ends up on top by virtue of negative z-index stacking below
-    //   normal flow.
-    // exit: lift `from` (the shrinking tile) above the new background at
-    //   +2, with overlay at +1 in between.
-    // Callers are expected to provide a stacking context above this
-    // boundary (e.g. `isolation: isolate` or `z-index: 0` on the page
-    // wrapper) so negative z-indices stay scoped.
-    const fromZ = isEnter ? "-2" : "2";
+    // Non-negative three-tier stacking: background < overlay < tile.
+    // enter: `from` is the background (Z_BACKGROUND), the incoming tile (`to`)
+    //   is raised to the foreground (Z_FOREGROUND); the blur overlay sits at
+    //   Z_OVERLAY in between (see OverlayStrategy).
+    // exit: `from` is the shrinking tile (Z_FOREGROUND) above the revealed
+    //   background (`to`, Z_BACKGROUND), overlay in between.
+    // Giving the background page an explicit z-index forms its own stacking
+    // context so its descendants stay trapped beneath the tile. Keeping every
+    // tier >= 0 means the layering no longer depends on the caller wrapping the
+    // pages in a stacking context (a negative z-index would bleed behind it).
+    const fromZ = isEnter ? Z_BACKGROUND : Z_FOREGROUND;
+    const toZ = isEnter ? Z_FOREGROUND : Z_BACKGROUND;
     const previousFromZIndex = from.style.zIndex;
     from.style.zIndex = fromZ;
+    // `to` is the surviving incoming page; raise/lower it and promote it to
+    // position:relative (it is in normal flow) so the z-index takes effect.
+    const previousToZIndex = to.style.zIndex;
+    const previousToPosition = to.style.position;
+    to.style.zIndex = toZ;
+    to.style.position = "relative";
 
     onComplete(() => {
       tileEl.style.willChange = "auto";
@@ -176,6 +182,16 @@ class TileStrategy implements ZoomStrategy {
       tileEl.style.transformOrigin = "";
       (tileEl.style as CSSStyleDeclaration & { contain: string }).contain = "";
       from.style.zIndex = previousFromZIndex;
+      // `to` is the surviving page; restore the stacking props raised above.
+      // Guard each reset: if a follow-up navigation already re-claimed this
+      // node (e.g. as the next outgoing `from`, now position:absolute), its
+      // stacking has changed — don't strip the fresh values.
+      if (to.style.zIndex === toZ) to.style.zIndex = previousToZIndex;
+      if (to.style.position === "relative")
+        to.style.position = previousToPosition;
+      // The exit-mode background animation writes transformOrigin onto `to`
+      // (bgEl === to) and nothing else clears it — reset it here too.
+      to.style.transformOrigin = "";
       // `from` is the REAL outgoing page now (React <Activity> / Next
       // cacheComponents re-hide and reuse this node on the next nav), so any
       // inline style left on it persists and corrupts the page when it


### PR DESCRIPTION
> 🚧 **Draft for review/testing.** Commit `52fd3af` is the throwaway naive `-1 → 0` flip (kept only to show *why* it's wrong); `d65d133` is the stacking redesign; `1458f14` fixes the WAAPI fill-release gap. Review against the latter two.

## TL;DR

Replace the **negative-z-index** page-transition scheme — which bleeds *behind* the page wrapper whenever the caller hasn't given that wrapper its own stacking context (the "looks awkward when the parent is missing `z-0`" report) — with an **all-non-negative** scheme, and restore `from`/`to` symmetrically now that React `<Activity>`/Next cacheComponents make both nodes persistent.

## Why the naive `-1 → 0` flip (commit 1) is wrong

A *positioned* element with `z-index: auto`/`0` paints **above** in-flow content (CSS 2.1 §E, step 6 vs step 3). The outgoing `from` is forced `position: absolute`; the incoming `to` stays in normal flow. So lowering `from` to `z-index: 0` does **not** put it under `to` — it stays on top. The flip visibly breaks `sheet` (background covers the rising sheet) and `zoom` (overlay covers the detail page) and inverts `drill`/`scroll`.

## The fix

Shared tiers in `transitions/stacking.ts`:

```
Z_BACKGROUND = "0"   Z_OVERLAY = "1"   Z_FOREGROUND = "2"
```

- **Background page** → `Z_BACKGROUND` (explicit, so it forms its *own* stacking context and its positioned descendants stay trapped beneath the foreground — the robustness the old negative value gave for free).
- **Foreground page** → `Z_FOREGROUND`, promoted to `position: relative` when it's the still-in-flow `to` (z-index only applies to positioned elements; well-precedented — `blind`/`jaemin` already do this).
- **zoom blur overlay** → `Z_OVERLAY`, between the two.

Every tier is `>= 0`, so layering no longer depends on the caller wrapping the pages in `isolation: isolate` / `z-index: 0`. The "callers are expected to provide a stacking context" note in `zoom/transition.ts` is removed.

| transition | direction | foreground | background |
|---|---|---|---|
| drill | enter / exit | `to` / `from` | `from` / `to` |
| scroll | up / down | `to` / `from` | `from` / `to` |
| sheet | enter / exit | sheet (`to`/`from`) | bg (`from`/`to`) |
| zoom | enter / exit | tile (`to`/`from`) | bg (`from`/`to`), overlay between |

### Symmetric restore (the `from`/`to` point)

The old code deliberately **never touched `to`** because `from` was a disposable clone (sloppiness self-healed on removal). With `<Activity>`, `from` is a reused real node too — and raising the foreground via `to` now mutates the *surviving* page. So every transition restores `to`'s `position`/`zIndex` on settle. In **unmount mode the context gives the persistent `to` node no cleanup**, so each transition's own `onComplete` is the only safety net (in hidden mode `reconcileResting`'s cssText snapshot also covers it). The reset is **guarded** (`if (to.style.position === "relative") …`) so an interrupted run can't strip the stacking a follow-up reverse-navigation already set on a re-claimed node. Zoom also now clears the exit-mode `transformOrigin` its background animation left on `to`.

### WAAPI fill release (commit 3)

`drill`/`scroll`/`sheet` reset `transform`/`opacity` to `""` in `onComplete`, but the natural `onfinish` path never cancels the WAAPI animation (`fill: "forwards"`), so the lingering final frame overrode those resets — a reused node (`<Activity>`) reappeared holding its animated transform (`scroll`: displaced off-screen; the others were benign only because the terminal frame equalled rest). Now each child's `onComplete` calls `releaseFill()` after the inline resets — mirroring the fix `zoom` already had. `sheet`'s asymmetric `bgAnim` cleanup (exit branch omitted `transform`/`opacity`) is collapsed into one full reset.

## How it was verified

- `tsc` + `vite build` pass.
- Two background agent workflows: (1) mapped the from/to lifecycle + restore/settle machinery (unmount vs hidden, `savedCss`/`reconcileResting`, ownership epochs); (2) adversarial per-transition verification against CSS paint-order rules. All report the steady-state stacking **provably correct** in every direction, with descendants trapped and no negatives, and `position:relative` confirmed not to break any transform/clip/scale/fade animation. The fill-release gap they surfaced is fixed in commit 3.

## Known / out of scope (pre-existing, not introduced here)

- **Overlay stacking-context assumption**: zoom's blur overlay is appended to `positionedParent`; its 3-tier ordering assumes intermediate ancestors don't form stacking contexts. Pre-existing; this change *improves* robustness by giving `to` an explicit index.
- **`position:relative` re-anchoring**: promoting `to` makes it the containing block for its own `position:absolute` descendants for the transition's duration. Low risk on full-bleed pages; same pattern already shipped in `blind`/`jaemin`.
- Docs still tell users to add `relative z-0` on the wrapper — `relative` is still needed (the absolute `from` needs a positioned ancestor), but `z-0` is now optional. Follow-up doc cleanup.

## Test

Run drill / scroll / sheet / zoom(blur) page transitions, **including with a page wrapper that has no `z-0`/`isolation`** — the outgoing page should no longer bleed behind the wrapper. Compare against `latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
