### PR TITLE
feat(core): functional `transitions` config receiving { isMobile }

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/core",
-  "version": "6.5.1",
+  "version": "6.6.0",
   "description": "Core animation engine for SSGOI - Native app-like page transitions with spring physics",
   "private": false,
   "type": "module",

--- a/packages/core/src/lib/ssgoi-transition/create-context-manager.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-context-manager.ts
@@ -262,5 +262,8 @@ export function createContextManager(options: ContextManagerOptions = {}) {
     getScrollContainer,
     getPositionedParentElement,
     getScrollPosition,
+    // Same measurement that drives `preserveScroll`'s `isMobile`, exposed so a
+    // functional `transitions` config can branch on it too.
+    getIsMobile: detectIsMobile,
   };
 }

--- a/packages/core/src/lib/ssgoi-transition/create-ssgoi-transition-context.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-ssgoi-transition-context.ts
@@ -4,6 +4,7 @@ import type {
   SsgoiContext,
   SsgoiPathTransition,
   SsgoiPathTransitionInput,
+  SsgoiTransitionsFn,
   SsgoiTransitionContext,
   PrepareArgs,
   CreateElement,
@@ -94,9 +95,13 @@ export function createSggoiTransitionContext(
   const host = contextOptions.host ?? new HostAnimation();
 
   const detector = createNavigationDetector();
-  const processedTransitions = processSymmetricTransitions(
-    flattenTransitions(transitions),
-  );
+
+  // Normalize both accepted shapes to the functional form up front so the rest
+  // of the file deals with exactly one shape: a static list becomes a function
+  // that ignores its args and returns that list. No `typeof transitions` branch
+  // ever leaks past this line.
+  const resolveTransitions: SsgoiTransitionsFn =
+    typeof transitions === "function" ? transitions : () => transitions;
 
   const swipeDetector = createSwipeBackDetector();
   swipeDetector.initialize();
@@ -109,7 +114,26 @@ export function createSggoiTransitionContext(
     getScrollContainer,
     getPositionedParentElement,
     getScrollPosition,
+    getIsMobile,
   } = createContextManager({ preserveScroll });
+
+  // Resolve + flatten + process the path-transition list lazily. `isMobile` is
+  // only reliable once the scroll container is known (measured on the first IN),
+  // which always precedes findMatchingTransition. Memoized per device class so a
+  // static list is processed at most once per `isMobile` value and the resolver
+  // never runs on the hot path more than necessary.
+  const processedByIsMobile = new Map<boolean, SsgoiPathTransition[]>();
+  const getProcessedTransitions = (): SsgoiPathTransition[] => {
+    const isMobile = getIsMobile();
+    let processed = processedByIsMobile.get(isMobile);
+    if (!processed) {
+      processed = processSymmetricTransitions(
+        flattenTransitions(resolveTransitions({ isMobile })),
+      );
+      processedByIsMobile.set(isMobile, processed);
+    }
+    return processed;
+  };
 
   let pendingOut: PendingSide | null = null;
   let pendingIn: PendingSide | null = null;
@@ -384,7 +408,7 @@ export function createSggoiTransitionContext(
       const config = findMatchingTransition(
         transformedFrom,
         transformedTo,
-        processedTransitions,
+        getProcessedTransitions(),
       );
 
       const outSide = pendingOut;

--- a/packages/core/src/lib/types/index.ts
+++ b/packages/core/src/lib/types/index.ts
@@ -196,8 +196,32 @@ export type PreserveScrollValue =
 export type PreserveScrollFn = (isMobile: boolean) => PreserveScrollValue;
 export type PreserveScrollOption = PreserveScrollValue | PreserveScrollFn;
 
+/**
+ * Argument handed to a functional `transitions` config. Destructured at the
+ * call site (`({ isMobile }) => …`) so the boolean's meaning is self-documenting
+ * — and so the object can grow more fields later without breaking signatures.
+ */
+export type TransitionsResolverArgs = { isMobile: boolean };
+
+/**
+ * Functional form of `transitions`: receives device context and returns the
+ * path-transition list. Lets a config branch on viewport (e.g. drawer on
+ * mobile, fade on desktop) without an outer wrapper.
+ */
+export type SsgoiTransitionsFn = (
+  args: TransitionsResolverArgs,
+) => readonly SsgoiPathTransitionInput[];
+
+/**
+ * `transitions` accepts either the plain list (existing form) or a function of
+ * device context. Both normalize to the functional form internally.
+ */
+export type SsgoiTransitionsOption =
+  | readonly SsgoiPathTransitionInput[]
+  | SsgoiTransitionsFn;
+
 export type SsgoiConfig = {
-  transitions?: readonly SsgoiPathTransitionInput[];
+  transitions?: SsgoiTransitionsOption;
   middleware?: (from: string, to: string) => { from: string; to: string };
   preserveScroll?: PreserveScrollOption;
 };


### PR DESCRIPTION
## What

Lets `transitions` in `SsgoiConfig` be a **function of device context** in addition to the existing plain list:

```ts
// existing form — still works, fully type-compatible
const config = {
  transitions: [
    { from: "/", to: "/about", transition: fade() },
  ],
};

// new functional form — receives a named boolean, no positional guessing
const config = {
  transitions: ({ isMobile }) => [
    { from: "/", to: "/detail", transition: isMobile ? drawer() : fade() },
  ],
};
```

This mirrors how `preserveScroll` already receives `isMobile`. The functional form destructures `({ isMobile })` (rather than the positional `(isMobile)` of `preserveScroll`) so the boolean's meaning is self-documenting at the call site, and the args object can grow more fields later without breaking signatures.

## How

The two accepted shapes are **normalized to a single functional form** at context creation:

```ts
const resolveTransitions =
  typeof transitions === "function" ? transitions : () => transitions;
```

A static list becomes a function that ignores its args and returns that list, so **no `typeof transitions` branch leaks past this line** — the rest of the dispatcher only ever deals with one shape.

Resolution + `flatten` + `processSymmetricTransitions` then happen **lazily**, because `isMobile` is only reliable once the scroll container has been measured (on the first IN, which always precedes `findMatchingTransition`). Results are **memoized per `isMobile` value**, so a static list is processed at most once per device class and the resolver never re-runs unnecessarily on the hot path.

`getIsMobile` is exposed from the context manager — the same measurement that already drives `preserveScroll`'s `isMobile`, so both options branch on a single source of truth.

## Compatibility

- Existing `transitions: [...]` configs are unchanged and fully type-compatible (`SsgoiTransitionsOption = readonly SsgoiPathTransitionInput[] | SsgoiTransitionsFn`).
- All framework adapters (react/svelte/vue/solid/angular) inherit the change automatically via `@ssgoi/core` types — no adapter changes needed.

## Versioning

⚠️ **Requires a core minor bump** (additive, backwards-compatible API). Bumped `@ssgoi/core` `6.5.1 → 6.6.0` in this PR.

## Test

- `tsc` + `vite build` pass.
- Existing `ssgoi-transition` suite passes (25 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)