### PR TITLE
fix(core): reuse detached outgoing node instead of cloning it

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/core",
-  "version": "6.6.0",
+  "version": "6.6.1",
   "description": "Core animation engine for SSGOI - Native app-like page transitions with spring physics",
   "private": false,
   "type": "module",

--- a/packages/core/src/lib/ssgoi-transition/create-ssgoi-transition-context.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-ssgoi-transition-context.ts
@@ -15,7 +15,7 @@ import { createContextManager } from "./create-context-manager";
 import { createSwipeBackDetector } from "./create-swipe-back-detector";
 import { findMatchingTransition } from "./find-matching-transition";
 import { createNavigationDetector } from "./navigation-detector-strategy";
-import { watchUnmount } from "./unmount-observer";
+import { watchUnmount, type UnmountAnchor } from "./unmount-observer";
 import { watchVisibility, type VisibilityHandle } from "./visibility-observer";
 import { HostAnimation } from "../animation/host-animation";
 
@@ -43,13 +43,13 @@ type TransitionMode = "unmount" | "hidden";
 
 type PendingSide = {
   element: HTMLElement;
-  parent: Element | null;
-  nextSibling: Element | null;
+  parent: Node | null;
+  nextSibling: Node | null;
   /**
    * How the outgoing page left (meaningful on the OUT side only):
    *  - "unmount": real DOM removal (SPA frameworks, Next without
-   *    cacheComponents). The outgoing page is cloned and the clone is removed on
-   *    settle — the battle-tested baseline path.
+   *    cacheComponents). The detached real node is reinserted for the OUT
+   *    animation, then removed on settle.
    *  - "hidden":  React `<Activity>` / Next `cacheComponents` toggled it to
    *    `display:none`. The REAL node is reused (page state preserved) and
    *    re-hidden on settle.
@@ -59,8 +59,8 @@ type PendingSide = {
 };
 
 type ElementAnchor = {
-  parent: Element | null;
-  nextSibling: Element | null;
+  parent: Node | null;
+  nextSibling: Node | null;
 };
 
 /**
@@ -68,10 +68,10 @@ type ElementAnchor = {
  *
  * Pure promise plumbing: the framework adapter calls `in(element)` on mount
  * and `out(element)` on unmount; the dispatcher pairs them by path via
- * NavigationDetector, then `.then`-chains the prepare result, the cloned
- * `from` element, and the `to` element. `animation()` runs once the chain
- * resolves — never via blocking `await` — so a follow-up navigation can
- * start its own pair while a prior one is still building.
+ * NavigationDetector, then `.then`-chains the prepare result, the `from`
+ * element, and the `to` element. `animation()` runs once the chain resolves —
+ * never via blocking `await` — so a follow-up navigation can start its own pair
+ * while a prior one is still building.
  */
 export interface CreateSsgoiTransitionContextOptions {
   /**
@@ -142,8 +142,8 @@ export function createSggoiTransitionContext(
 
   const captureAnchor = (element: HTMLElement) => {
     elementAnchors.set(element, {
-      parent: element.parentElement,
-      nextSibling: element.nextElementSibling,
+      parent: element.parentNode,
+      nextSibling: element.nextSibling,
     });
   };
 
@@ -151,8 +151,8 @@ export function createSggoiTransitionContext(
     const cached = elementAnchors.get(element);
     if (cached) return cached;
     return {
-      parent: element.parentElement,
-      nextSibling: element.nextElementSibling,
+      parent: element.parentNode,
+      nextSibling: element.nextSibling,
     };
   };
 
@@ -260,8 +260,8 @@ export function createSggoiTransitionContext(
     };
 
     // The element handed to the animation as `from`:
-    //  - unmount mode: a throwaway deep clone (the real node is being destroyed
-    //    by the host framework), inserted after `prepare` and removed on settle.
+    //  - unmount mode: the detached real node, reinserted after `prepare` and
+    //    removed on settle.
     //  - hidden mode: the REAL outgoing node, already revealed + taken out of
     //    flow by `handleHide`. Reusing it keeps page state alive AND lets a
     //    follow-up navigation hand its motion back continuously (matchInto keys
@@ -280,10 +280,11 @@ export function createSggoiTransitionContext(
         toState.savedCss = toElement.style.cssText;
       }
     } else {
-      // Clone while the original is still mounted; the host framework will
-      // detach the original right after `out()` returns.
-      fromElement = fromOriginal.cloneNode(true) as HTMLElement;
-      fromElement.setAttribute("data-ssgoi-clone", "");
+      // The host framework already detached the original. Reuse that exact
+      // node so DOM state (input values, canvas contents, media state, etc.)
+      // survives through the outgoing animation instead of being flattened by
+      // cloneNode().
+      fromElement = fromOriginal;
       // Outgoing page goes absolute so the incoming page can take its slot.
       // Style only; insertion is deferred until after `prepare`.
       prepareOutgoing(fromElement, ssgoiContext);
@@ -294,7 +295,9 @@ export function createSggoiTransitionContext(
     // Stamp ownership BEFORE host.attach force-completes any prior run (below):
     // the prior run's settle checks ownership and must already see THIS run
     // owning the shared real nodes, so it skips them instead of fighting us.
-    // Only hidden mode reuses/owns real nodes; unmount mode stays clone-based.
+    // Hidden mode reuses mounted real nodes; unmount mode reuses a detached real
+    // node and removes it on settle, so ownership guards are only needed for
+    // hidden mode's persistent nodes.
     const epoch = isHidden ? ++transitionEpoch : 0;
     if (isHidden) {
       owner.set(toElement, epoch);
@@ -334,7 +337,7 @@ export function createSggoiTransitionContext(
       extras: extrasPromise,
     }).then(({ from: resolvedFrom, to: resolvedTo, extras }) => {
       // Now that prepare's microtasks have all run (initial styles, extras
-      // built), drop the outgoing clone into place. Order is:
+      // built), drop the outgoing node into place. Order is:
       //   prepare → out insert → animation create/play
       // Hidden mode skips insertion: the real node is already in place.
       if (!isHidden && parent) {
@@ -365,11 +368,11 @@ export function createSggoiTransitionContext(
           // no-op if a newer run now owns the node.
           reconcileResting(fromOriginal, epoch);
           reconcileResting(toElement, epoch);
-        } else if (fromElement.parentElement) {
-          fromElement.parentElement.removeChild(fromElement);
+        } else if (fromElement.parentNode) {
+          fromElement.parentNode.removeChild(fromElement);
         }
         for (const extra of createdElements) {
-          if (extra.parentElement) extra.parentElement.removeChild(extra);
+          if (extra.parentNode) extra.parentNode.removeChild(extra);
         }
       };
 
@@ -507,7 +510,11 @@ export function createSggoiTransitionContext(
     handleArrival(currentPath, "in");
   };
 
-  const handleRemoval = (element: HTMLElement, path: string) => {
+  const handleRemoval = (
+    element: HTMLElement,
+    path: string,
+    removalAnchor?: UnmountAnchor,
+  ) => {
     const state = hiddenState.get(element);
     if (state) {
       state.vis.stop();
@@ -524,7 +531,7 @@ export function createSggoiTransitionContext(
       }
     }
 
-    const anchor = readAnchor(element);
+    const anchor = removalAnchor ?? readAnchor(element);
     pendingOut = {
       element,
       parent: anchor.parent,
@@ -578,7 +585,7 @@ export function createSggoiTransitionContext(
       handleArrival(path, "in");
     }
 
-    watchUnmount(element, () => handleRemoval(element, path));
+    watchUnmount(element, (anchor) => handleRemoval(element, path, anchor));
   };
 
   // Per-path ref callbacks are cached so adapters can drop `refFor(path)`

--- a/packages/core/src/lib/ssgoi-transition/unmount-observer.test.ts
+++ b/packages/core/src/lib/ssgoi-transition/unmount-observer.test.ts
@@ -29,8 +29,17 @@ class FakeMutationObserver {
   }
 }
 
-function fireRemoval(node: FakeNode): void {
-  observerCb?.([{ removedNodes: [node] }]);
+function fireRemoval(
+  node: FakeNode,
+  record: { target?: FakeNode; nextSibling?: FakeNode | null } = {},
+): void {
+  observerCb?.([
+    {
+      target: record.target ?? new FakeNode(),
+      nextSibling: record.nextSibling ?? null,
+      removedNodes: [node],
+    },
+  ]);
 }
 
 async function flushMicrotasks(): Promise<void> {
@@ -64,6 +73,27 @@ describe("watchUnmount", () => {
     await flushMicrotasks();
 
     expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes the removal anchor to the leave callback", async () => {
+    const { watchUnmount } = await import("./unmount-observer");
+    const parent = new FakeNode();
+    const nextSibling = new FakeNode();
+    const node = new FakeNode();
+    const child = new FakeNode();
+    node.childNodes = [child];
+    node.isConnected = false;
+    child.isConnected = false;
+
+    const cb = vi.fn();
+    watchUnmount(child as unknown as HTMLElement, cb);
+
+    fireRemoval(node, { target: parent, nextSibling });
+    await flushMicrotasks();
+
+    const anchor = cb.mock.calls[0]?.[0];
+    expect(anchor?.parent).toBe(parent);
+    expect(anchor?.nextSibling).toBe(nextSibling);
   });
 
   it("does NOT fire on a MOVE (node reattached -> isConnected), and keeps watching", async () => {

--- a/packages/core/src/lib/ssgoi-transition/unmount-observer.ts
+++ b/packages/core/src/lib/ssgoi-transition/unmount-observer.ts
@@ -11,14 +11,19 @@
  *  - lower memory / browser overhead than dozens of observers
  */
 
-type UnmountCallback = () => void;
+export type UnmountAnchor = {
+  parent: Node;
+  nextSibling: Node | null;
+};
+
+type UnmountCallback = (anchor?: UnmountAnchor) => void;
 
 const watched = new Map<HTMLElement, UnmountCallback>();
 
 let sharedObserver: MutationObserver | null = null;
 let initialized = false;
 
-function checkRemovedSubtree(node: Node): void {
+function checkRemovedSubtree(node: Node, anchor: UnmountAnchor): void {
   // A childList "removed" record also fires when a node is MOVED (removed then
   // re-inserted within the same commit) — e.g. Next.js reorders its bfcache
   // `<Activity>` siblings on back/forward navigation, so React detaches and
@@ -32,10 +37,10 @@ function checkRemovedSubtree(node: Node): void {
     watched.delete(node);
     // Defer to microtask so we never mutate the DOM inside the observer
     // callback (some browsers complain).
-    queueMicrotask(cb);
+    queueMicrotask(() => cb(anchor));
   }
   for (const child of Array.from(node.childNodes)) {
-    checkRemovedSubtree(child);
+    checkRemovedSubtree(child, anchor);
   }
 }
 
@@ -45,8 +50,12 @@ function init(): void {
 
   sharedObserver = new MutationObserver((mutations) => {
     for (const m of mutations) {
+      const anchor = {
+        parent: m.target,
+        nextSibling: m.nextSibling,
+      };
       for (const removed of Array.from(m.removedNodes)) {
-        checkRemovedSubtree(removed);
+        checkRemovedSubtree(removed, anchor);
       }
     }
   });


### PR DESCRIPTION
## Summary

In **unmount mode** (SPA frameworks, Next.js without `cacheComponents`), the outgoing page was animated on a throwaway deep clone (`cloneNode(true)`) because the host framework destroys the real node right after `out()` returns. `cloneNode` flattens live DOM state — input values, canvas contents, media playback position, scroll, etc. — so the exit animation showed a visibly "reset" version of the page.

This change reuses the **detached real node** instead. The framework has already removed it from the document by the time we animate, so we reinsert that exact node for the OUT animation and remove it on settle. Page state survives through the transition.

## How

- Thread the removal **anchor** (`parent` + `nextSibling`) out of the shared `MutationObserver` record (`unmount-observer.ts`) so we know where to reinsert the detached node. `watchUnmount`'s callback now receives an optional `UnmountAnchor`.
- `handleRemoval` accepts that anchor and prefers it over `readAnchor`.
- In the OUT path, `fromElement` is now `fromOriginal` itself (no clone, no `data-ssgoi-clone` marker) for unmount mode; hidden mode is unchanged.
- Anchor/cleanup plumbing switched from `parentElement`/`nextElementSibling`/`Element` to `parentNode`/`nextSibling`/`Node` so text nodes and non-element siblings don't shift the reinsertion point.
- Ownership-epoch guards stay scoped to hidden mode's persistent nodes; the detached unmount node is removed on settle as before.

## Test

- New `unmount-observer` test asserting the removal anchor (`parent`, `nextSibling`) is forwarded to the leave callback.
- `pnpm run core:build` ✓ and full core suite (30 tests) ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)