### PR TITLE
Use React pathname boundaries and strengthen wildcard matching (#362)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,16 @@ Web pages don't transition—they just swap. SSGOI changes that.
 npm install @ssgoi/react
 ```
 
-### 1. Wrap your app (layout.tsx)
+### 1. Wrap your React app
 
 ```tsx
+// app/ssgoi-provider.tsx
 "use client";
 
+import { type ReactNode } from "react";
 import { Ssgoi } from "@ssgoi/react";
 import { drill, fade } from "@ssgoi/react/view-transitions";
+import { SsgoiTransitionBoundary } from "./ssgoi-transition-boundary";
 
 const config = {
   transitions: [
@@ -61,43 +64,126 @@ const config = {
   ],
 };
 
-export default function RootLayout({ children }) {
+export function SsgoiProvider({ children }: { children: ReactNode }) {
   return (
-    <html>
+    <Ssgoi config={config}>
+      {/* Routed content marker. Layout positioning belongs to the outer wrapper. */}
+      <SsgoiTransitionBoundary className="min-h-full bg-black">
+        {children}
+      </SsgoiTransitionBoundary>
+    </Ssgoi>
+  );
+}
+
+// app/layout.tsx
+import { type ReactNode } from "react";
+import { SsgoiProvider } from "./ssgoi-provider";
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
       <body>
-        <Ssgoi config={config}>
-          {/* relative + z-0: the outgoing page is cloned with position:absolute */}
-          <div className="relative z-0">{children}</div>
-        </Ssgoi>
+        {/* Layout shell: positioned ancestor + stacking context for the OUT clone. */}
+        <main className="relative z-0 min-h-dvh overflow-x-clip bg-black">
+          <SsgoiProvider>{children}</SsgoiProvider>
+        </main>
       </body>
     </html>
   );
 }
 ```
 
-### 2. Mark your pages
+### 2. Use a React boundary utility
 
 ```tsx
-// app/page.tsx
-export default function HomePage() {
-  return (
-    <main data-ssgoi-transition="/">
-      <h1>Home</h1>
-    </main>
-  );
-}
+// ssgoi-transition-boundary.tsx
+"use client";
 
-// app/post/[id]/page.tsx
-export default function PostPage({ params }) {
+import { type ElementType, type ReactNode } from "react";
+import { usePathname } from "next/navigation";
+
+export function SsgoiTransitionBoundary({
+  children,
+  as,
+  className,
+}: {
+  children: ReactNode;
+  as?: ElementType;
+  className?: string;
+}) {
+  const pathname = usePathname();
+  const Component = as ?? "div";
+
   return (
-    <main data-ssgoi-transition={`/post/${params.id}`}>
-      <h1>Post Detail</h1>
-    </main>
+    <Component
+      key={pathname}
+      data-ssgoi-transition={pathname}
+      className={className}
+    >
+      {children}
+    </Component>
   );
 }
 ```
 
-**That's it.** Your pages now transition like a native app.
+Then use it inside `<Ssgoi>`:
+
+```tsx
+<SsgoiTransitionBoundary className="min-h-full bg-black">
+  {children}
+</SsgoiTransitionBoundary>
+```
+
+React Router and TanStack Router use the same component body with their own
+pathname hook.
+
+The utility reads the current pathname internally and sets `key` plus
+`data-ssgoi-transition`. This is a React convenience pattern: SSGOI only needs a
+logical page id that matches config, and the utility uses the current pathname
+as that id. Match dynamic descendants with wildcard config like `/post/*`. Use
+`/docs/**` when the parent path itself should match too. **That's it.** Your
+pages now transition like a native app.
+
+This layout-level utility pattern is for React adapters. In SvelteKit,
+Nuxt/Vue, Solid, and Angular, mark each routed page boundary directly with
+`data-ssgoi-transition`. Use a stable logical id such as `/gallery`; it does not
+have to be the actual route pathname.
+
+Why mark each page directly instead of using one shared boundary? SvelteKit and
+Nuxt render slot/snippet content live, so a single route boundary in a parent
+layout would let the outgoing page wrapper render the _incoming_ page's children
+mid-navigation. Marking each page keeps the outgoing and incoming boundaries
+cleanly separated. React's utility sidesteps this by keying the subtree on the
+pathname.
+
+### Layout shell requirements
+
+The outer element that wraps the SSGOI provider / `<Ssgoi>` is the layout shell.
+Put `relative z-0` on that wrapper, and add `overflow-x-clip` when you use
+horizontal transitions such as `slide` or `drill`.
+
+Those classes are not route marker classes. Keep them off
+`SsgoiTransitionBoundary`; the boundary should only identify routed content with
+`key` and `data-ssgoi-transition`.
+
+| Class             | Why                                                                             |
+| ----------------- | ------------------------------------------------------------------------------- |
+| `relative`        | The OUT page clone uses `position: absolute`, so it needs a positioned ancestor |
+| `z-0`             | Creates a stacking context so the OUT page does not fall behind backgrounds     |
+| `overflow-x-clip` | Prevents horizontal overflow flashing during slide/drill transitions            |
+
+### Framework templates
+
+Use the templates as reference implementations for each router/framework:
+
+- [Next.js](https://github.com/meursyphus/ssgoi/tree/main/templates/nextjs)
+- [React Router](https://github.com/meursyphus/ssgoi/tree/main/templates/react-router)
+- [TanStack Router](https://github.com/meursyphus/ssgoi/tree/main/templates/tanstack-router)
+- [SvelteKit](https://github.com/meursyphus/ssgoi/tree/main/templates/sveltekit)
+- [Nuxt](https://github.com/meursyphus/ssgoi/tree/main/templates/nuxt)
+
+React templates use the pathname boundary utility. SvelteKit and Nuxt mark each
+routed page directly with `data-ssgoi-transition`.
 
 ---
 
@@ -140,13 +226,13 @@ See them all live at [ssgoi.dev](https://ssgoi.dev) or in [llms.txt](https://ssg
 
 ## Packages
 
-| Package          | Framework          |
-| ---------------- | ------------------ |
-| `@ssgoi/react`   | React, Next.js     |
-| `@ssgoi/svelte`  | Svelte, SvelteKit  |
-| `@ssgoi/vue`     | Vue, Nuxt          |
-| `@ssgoi/solid`   | Solid, SolidStart  |
-| `@ssgoi/angular` | Angular            |
+| Package          | Framework                 |
+| ---------------- | ------------------------- |
+| `@ssgoi/react`   | React, Next.js            |
+| `@ssgoi/svelte`  | Svelte, SvelteKit         |
+| `@ssgoi/vue`     | Vue, Nuxt                 |
+| `@ssgoi/solid`   | Solid, SolidStart         |
+| `@ssgoi/angular` | Angular                   |
 | `@ssgoi/core`    | Framework-agnostic engine |
 
 ---

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -4,6 +4,8 @@
 
 This document is for AI assistants to help developers set up SSGOI page transitions.
 
+**Current core package version:** `@ssgoi/core@6.6.2`
+
 **Per-transition reference (options, data keys, examples):** see the `Transitions` section below — each entry links to its own page like `https://ssgoi.dev/llms/<name>.txt`.
 
 ---
@@ -15,6 +17,16 @@ npm install @ssgoi/react
 # or @ssgoi/svelte, @ssgoi/vue, @ssgoi/solid, @ssgoi/angular
 ```
 
+Reference templates:
+
+- Next.js: https://github.com/meursyphus/ssgoi/tree/main/templates/nextjs
+- React Router: https://github.com/meursyphus/ssgoi/tree/main/templates/react-router
+- TanStack Router: https://github.com/meursyphus/ssgoi/tree/main/templates/tanstack-router
+- SvelteKit: https://github.com/meursyphus/ssgoi/tree/main/templates/sveltekit
+- Nuxt: https://github.com/meursyphus/ssgoi/tree/main/templates/nuxt
+
+React templates use a pathname-based `SsgoiTransitionBoundary` utility. SvelteKit and Nuxt templates mark each routed page directly with `data-ssgoi-transition`.
+
 ---
 
 ## Layout Setup
@@ -22,8 +34,8 @@ npm install @ssgoi/react
 SSGOI works on any web app. There are only three things to get right:
 
 1. **Decide your scroll element** — the element whose scroll position SSGOI should preserve across transitions. Often a `<main>` or a centered content container.
-2. **Apply `relative z-0` (and optionally `overflow-x-clip`) to the element that wraps `<Ssgoi>`.**
-3. **Set `data-ssgoi-transition="..."` on each page boundary** (see the next section).
+2. **Apply `relative z-0` (and optionally `overflow-x-clip`) to the outer element that wraps the SSGOI provider / `<Ssgoi>`.** This is the layout shell, not the `data-ssgoi-transition` boundary.
+3. **Mark routed content with `data-ssgoi-transition="..."`**. React adapters can use one layout-level boundary utility for this marker. SvelteKit, Nuxt/Vue, Solid, and Angular should mark each routed page boundary directly.
 
 Why those classes:
 
@@ -40,9 +52,13 @@ The scroll element and the `<Ssgoi>` wrapper are typically **the same element**,
 The library is most often used to ship app-like, mobile-width experiences, so this example shows that shape — a centered max-width column where the column itself scrolls. Adapt as needed for desktop layouts.
 
 ```tsx
-// src/app/layout.tsx
+// src/app/ssgoi-provider.tsx
+"use client";
+
+import { type ReactNode } from "react";
 import { Ssgoi } from "@ssgoi/react";
 import { drill, fade } from "@ssgoi/react/view-transitions";
+import { SsgoiTransitionBoundary } from "./ssgoi-transition-boundary";
 
 const config = {
   transitions: [
@@ -51,17 +67,33 @@ const config = {
   ],
 };
 
+export function SsgoiProvider({ children }: { children: ReactNode }) {
+  return (
+    <Ssgoi config={config}>
+      {/* Routed content marker. Layout positioning belongs to the outer wrapper. */}
+      <SsgoiTransitionBoundary className="min-h-full bg-black">
+        {children}
+      </SsgoiTransitionBoundary>
+    </Ssgoi>
+  );
+}
+
+// src/app/layout.tsx
+import { type ReactNode } from "react";
+import { SsgoiProvider } from "./ssgoi-provider";
+
 export default function RootLayout({
   children,
 }: {
-  children: React.ReactNode;
+  children: ReactNode;
 }) {
   return (
     <html>
       <body>
         <div className="mx-auto max-w-md h-dvh flex flex-col">
+          {/* Layout shell: scroll element + positioned ancestor for OUT clones. */}
           <main className="flex-1 overflow-y-auto relative z-0 overflow-x-clip">
-            <Ssgoi config={config}>{children}</Ssgoi>
+            <SsgoiProvider>{children}</SsgoiProvider>
           </main>
           {/* Optional: <BottomNav /> outside <main>, fixed-positioned */}
         </div>
@@ -73,28 +105,88 @@ export default function RootLayout({
 
 ---
 
-## Page Setup
+## React Route Boundary Setup
 
-Mark each page boundary with `data-ssgoi-transition`:
+For React, Next.js, React Router, and TanStack Router, you can mark routed content once with a small router-specific boundary utility. This is a React-specific convenience pattern: the utility uses the current pathname as the logical transition id and keys the routed subtree so React gives SSGOI a clear outgoing boundary and incoming boundary. Do not put `relative z-0 overflow-x-clip` on this utility; those belong to the outer wrapper shown above.
+
+Next.js implementation:
 
 ```tsx
-// app/page.tsx
-export default function HomePage() {
-  return (
-    <main data-ssgoi-transition="/">
-      <div>Home content</div>
-    </main>
-  );
-}
+"use client";
 
-// app/post/[id]/page.tsx
-export default function PostPage({ params }: { params: { id: string } }) {
+import { type ElementType, type ReactNode } from "react";
+import { usePathname } from "next/navigation";
+
+export function SsgoiTransitionBoundary({
+  children,
+  as,
+  className,
+}: {
+  children: ReactNode;
+  as?: ElementType;
+  className?: string;
+}) {
+  const pathname = usePathname();
+  const Component = as ?? "div";
+
   return (
-    <main data-ssgoi-transition={`/post/${params.id}`}>
-      <div>Post content</div>
-    </main>
+    <Component
+      key={pathname}
+      data-ssgoi-transition={pathname}
+      className={className}
+    >
+      {children}
+    </Component>
   );
 }
+```
+
+React Router uses the same component body, but reads `const { pathname } = useLocation()` from `react-router`. TanStack Router reads `const pathname = useRouterState({ select: (state) => state.location.pathname })`.
+
+```tsx
+import { SsgoiTransitionBoundary } from "./ssgoi-transition-boundary";
+
+export function AppShell({ children }: { children: React.ReactNode }) {
+  return (
+    <SsgoiTransitionBoundary className="min-h-full bg-black">
+      {children}
+    </SsgoiTransitionBoundary>
+  );
+}
+```
+
+`SsgoiTransitionBoundary` reads the current pathname internally and sets both `key` and `data-ssgoi-transition`. SSGOI itself only needs a logical page id that matches config; using the real pathname is the React utility's default convention. For dynamic routes, match descendants with wildcard patterns like `/post/*`. A suffix `*` matches one or more descendants; a suffix `**` also includes the prefix path itself, so `/docs/**` matches `/docs` and `/docs/install`.
+
+## Non-React Route Boundary Setup
+
+For SvelteKit, Nuxt/Vue, Solid, and Angular, set `data-ssgoi-transition` directly on each routed page boundary. The value can be a hard-coded logical page id; it does not have to be the framework's route pathname. It only needs to match the `from`, `to`, or `paths` values in `SsgoiConfig`.
+
+Do not put a single slot/snippet-based route boundary in a parent layout for SvelteKit or Nuxt. Their slot content is live, so the outgoing page wrapper can render the incoming page's children during navigation.
+
+SvelteKit:
+
+```svelte
+<main data-ssgoi-transition="/gallery">
+  <!-- page content -->
+</main>
+```
+
+Nuxt/Vue:
+
+```vue
+<template>
+  <main data-ssgoi-transition="/gallery">
+    <!-- page content -->
+  </main>
+</template>
+```
+
+Angular:
+
+```html
+<section data-ssgoi-transition="/home">
+  <h1>Home Page</h1>
+</section>
 ```
 
 ---

--- a/apps/docs/src/app/blog/[slug]/page.tsx
+++ b/apps/docs/src/app/blog/[slug]/page.tsx
@@ -103,10 +103,7 @@ export default async function BlogPostPage({
   ];
 
   return (
-    <main
-      data-ssgoi-transition={`/blog/${slug}`}
-      className="relative min-h-dvh bg-black"
-    >
+    <main className="relative min-h-dvh bg-black">
       <JsonLd data={schemas} />
       <div className="mx-auto max-w-3xl px-6 pb-24 pt-6">
         <Link

--- a/apps/docs/src/app/blog/page.tsx
+++ b/apps/docs/src/app/blog/page.tsx
@@ -47,7 +47,7 @@ export default function BlogIndexPage() {
   };
 
   return (
-    <main data-ssgoi-transition="/blog" className="relative min-h-dvh bg-black">
+    <main className="relative min-h-dvh bg-black">
       <JsonLd
         data={[
           blogSchema,

--- a/apps/docs/src/app/demo/(mobile)/instagram/profile/[id]/page.tsx
+++ b/apps/docs/src/app/demo/(mobile)/instagram/profile/[id]/page.tsx
@@ -1,10 +1,5 @@
 import ProfileGridPage from "@/demo/instagram/page/profile-grid";
 
-export default async function Page({
-  params,
-}: {
-  params: Promise<{ id: string }>;
-}) {
-  const { id } = await params;
-  return <ProfileGridPage id={id} />;
+export default function Page() {
+  return <ProfileGridPage />;
 }

--- a/apps/docs/src/app/demo/(mobile)/instagram/profile/[id]/reels/page.tsx
+++ b/apps/docs/src/app/demo/(mobile)/instagram/profile/[id]/reels/page.tsx
@@ -1,10 +1,5 @@
 import ProfileReelsPage from "@/demo/instagram/page/profile-reels";
 
-export default async function Page({
-  params,
-}: {
-  params: Promise<{ id: string }>;
-}) {
-  const { id } = await params;
-  return <ProfileReelsPage id={id} />;
+export default function Page() {
+  return <ProfileReelsPage />;
 }

--- a/apps/docs/src/app/demo/(mobile)/instagram/profile/[id]/remix/page.tsx
+++ b/apps/docs/src/app/demo/(mobile)/instagram/profile/[id]/remix/page.tsx
@@ -1,10 +1,5 @@
 import ProfileRemixPage from "@/demo/instagram/page/profile-remix";
 
-export default async function Page({
-  params,
-}: {
-  params: Promise<{ id: string }>;
-}) {
-  const { id } = await params;
-  return <ProfileRemixPage id={id} />;
+export default function Page() {
+  return <ProfileRemixPage />;
 }

--- a/apps/docs/src/app/demo/(mobile)/instagram/profile/[id]/tagged/page.tsx
+++ b/apps/docs/src/app/demo/(mobile)/instagram/profile/[id]/tagged/page.tsx
@@ -1,10 +1,5 @@
 import ProfileTaggedPage from "@/demo/instagram/page/profile-tagged";
 
-export default async function Page({
-  params,
-}: {
-  params: Promise<{ id: string }>;
-}) {
-  const { id } = await params;
-  return <ProfileTaggedPage id={id} />;
+export default function Page() {
+  return <ProfileTaggedPage />;
 }

--- a/apps/docs/src/app/docs/layout.tsx
+++ b/apps/docs/src/app/docs/layout.tsx
@@ -4,7 +4,7 @@ import { DocsSidebar, DocsMobileNav } from "@/page/docs/sidebar";
 
 export default function DocsLayout({ children }: { children: ReactNode }) {
   return (
-    <div data-ssgoi-transition="/docs" className="relative min-h-dvh bg-black">
+    <div className="relative min-h-dvh bg-black">
       <SiteNav active="docs" />
       <DocsMobileNav />
       <div className="mx-auto flex w-full max-w-6xl gap-10 px-6 pt-8 lg:gap-14 lg:pt-12">

--- a/apps/docs/src/app/showcase/layout.tsx
+++ b/apps/docs/src/app/showcase/layout.tsx
@@ -1,11 +1,4 @@
 import type { ReactNode } from "react";
 export default function ShowcaseLayout({ children }: { children: ReactNode }) {
-  return (
-    <div
-      data-ssgoi-transition="/showcase"
-      className="relative min-h-dvh bg-black"
-    >
-      {children}
-    </div>
-  );
+  return <div className="relative min-h-dvh bg-black">{children}</div>;
 }

--- a/apps/docs/src/components/docs-ssgoi-provider.tsx
+++ b/apps/docs/src/components/docs-ssgoi-provider.tsx
@@ -1,21 +1,39 @@
 "use client";
 
 import { useState, type ReactNode } from "react";
+import { usePathname } from "next/navigation";
 import { Ssgoi, type SsgoiConfig } from "@ssgoi/react";
 import { scroll } from "@ssgoi/react/view-transitions";
 import { HostAnimation } from "@ssgoi/core/internal";
 import { HostContext } from "@/lib/components/host-context";
 import { useShowcaseFrameBridge } from "@/lib/hooks";
+import { SsgoiTransitionBoundary } from "@/lib/components/ssgoi-transition-boundary";
 
 const config: SsgoiConfig = {
   preserveScroll: false,
   transitions: [
     scroll({
-      paths: ["/", "/showcase"],
+      paths: ["/", "/showcase/*"],
       type: "non-directional",
     }),
   ],
 };
+
+function DocsRouteBoundary({ children }: { children: ReactNode }) {
+  const pathname = usePathname();
+  const isShowcaseRoute =
+    pathname === "/" ||
+    pathname === "/showcase" ||
+    pathname.startsWith("/showcase/");
+
+  if (!isShowcaseRoute) return <>{children}</>;
+
+  return (
+    <SsgoiTransitionBoundary className="min-h-dvh bg-black">
+      {children}
+    </SsgoiTransitionBoundary>
+  );
+}
 
 /**
  * Top-level provider:
@@ -39,7 +57,7 @@ export function DocsSsgoiProvider({ children }: { children: ReactNode }) {
   return (
     <HostContext.Provider value={host}>
       <Ssgoi config={config} host={host}>
-        {children}
+        <DocsRouteBoundary>{children}</DocsRouteBoundary>
       </Ssgoi>
     </HostContext.Provider>
   );

--- a/apps/docs/src/components/transition-demo.tsx
+++ b/apps/docs/src/components/transition-demo.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { showcaseFrameProtocol } from "@/lib/hooks";
 import { ShowcasePhone } from "@/components/showcase-phone";
 import { DesktopFrame } from "@/components/desktop-frame";
@@ -34,15 +34,17 @@ export function TransitionDemo({
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const [hasBeenVisible, setHasBeenVisible] = useState(false);
   const [inView, setInView] = useState(false);
-  const [topLevel, setTopLevel] = useState(false);
-
-  useEffect(() => {
-    try {
-      setTopLevel(window.self === window.top);
-    } catch {
-      setTopLevel(false);
-    }
-  }, []);
+  const topLevel = useSyncExternalStore(
+    () => () => {},
+    () => {
+      try {
+        return window.self === window.top;
+      } catch {
+        return false;
+      }
+    },
+    () => false,
+  );
 
   useEffect(() => {
     const el = containerRef.current;

--- a/apps/docs/src/content/blog/nextjs-app-router-page-transitions.mdx
+++ b/apps/docs/src/content/blog/nextjs-app-router-page-transitions.mdx
@@ -6,7 +6,7 @@ author: "MeurSyphus"
 tags: ["nextjs", "react", "page transitions", "app router"]
 faq:
   - question: "Does this work with the Next.js App Router and Server Components?"
-    answer: "Yes. SSGOI wraps your app once in the root layout (a Client Component boundary) and marks pages with a data attribute. Your pages can stay Server Components; only the Ssgoi wrapper needs 'use client'."
+    answer: "Yes. Keep app/layout.tsx and pages as Server Components. Put SSGOI in a small Client Component provider, and let the boundary utility mark routed content with a data attribute."
   - question: "Do page transitions work in Safari and Firefox?"
     answer: "Yes. SSGOI is built on the Web Animations API, so transitions run the same way across Chrome, Safari, Firefox, and Edge — unlike the View Transition API, whose cross-document support is still limited outside Chromium."
   - question: "Will transitions break server-side rendering or SEO?"
@@ -29,14 +29,16 @@ Install the package:
 npm install @ssgoi/react
 ```
 
-Then wrap your app in the root layout. This is the only Client Component you need to add — your pages can remain Server Components.
+Then wrap your app from the root layout. Your layout and pages can remain Server Components; the SSGOI provider and pathname boundary utility are the small Client Components.
 
 ```tsx
-// app/layout.tsx
+// app/ssgoi-provider.tsx
 "use client";
 
+import { type ReactNode } from "react";
 import { Ssgoi } from "@ssgoi/react";
 import { drill, fade } from "@ssgoi/react/view-transitions";
+import { SsgoiTransitionBoundary } from "./ssgoi-transition-boundary";
 
 const config = {
   transitions: [
@@ -47,51 +49,81 @@ const config = {
   ],
 };
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export function SsgoiProvider({ children }: { children: ReactNode }) {
+  return (
+    <Ssgoi config={config}>
+      {/* Routed content marker. Layout positioning belongs to the outer wrapper. */}
+      <SsgoiTransitionBoundary className="min-h-full bg-black">
+        {children}
+      </SsgoiTransitionBoundary>
+    </Ssgoi>
+  );
+}
+
+// app/layout.tsx
+import { type ReactNode } from "react";
+import { SsgoiProvider } from "./ssgoi-provider";
+
+export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body>
-        <Ssgoi config={config}>
-          {/* relative + z-0: the outgoing page is cloned with position:absolute */}
-          <div className="relative z-0 min-h-dvh overflow-x-clip">
-            {children}
-          </div>
-        </Ssgoi>
+        {/* Layout shell: positioned ancestor + stacking context for the OUT clone. */}
+        <main className="relative z-0 min-h-dvh overflow-x-clip bg-black">
+          <SsgoiProvider>{children}</SsgoiProvider>
+        </main>
       </body>
     </html>
   );
 }
 ```
 
-The wrapper needs `relative z-0` (and `overflow-x-clip` for horizontal transitions) because SSGOI clones the leaving page with `position: absolute` so it can animate out while the new page mounts in.
+The wrapper above `<Ssgoi>` needs `relative z-0` (and `overflow-x-clip` for horizontal transitions) because SSGOI clones the leaving page with `position: absolute` so it can animate out while the new page mounts in. Keep those layout classes on that outer wrapper, not on the route boundary utility.
 
-## Step 2 — Mark your pages
+## Step 2 — Wrap routed content
 
-Add a `data-ssgoi-transition` attribute to each page's root element. The value is the path key your config matches against.
+In React/Next.js, use one router-specific `SsgoiTransitionBoundary` utility in your layout. It reads the current pathname internally and sets the path key your config matches against.
 
 ```tsx
-// app/page.tsx
-export default function HomePage() {
-  return (
-    <main data-ssgoi-transition="/">
-      <h1>Home</h1>
-    </main>
-  );
-}
+// ssgoi-transition-boundary.tsx
+"use client";
 
-// app/post/[id]/page.tsx
-export default function PostPage({ params }: { params: { id: string } }) {
+import { type ElementType, type ReactNode } from "react";
+import { usePathname } from "next/navigation";
+
+export function SsgoiTransitionBoundary({
+  children,
+  as,
+  className,
+}: {
+  children: ReactNode;
+  as?: ElementType;
+  className?: string;
+}) {
+  const pathname = usePathname();
+  const Component = as ?? "div";
+
   return (
-    <main data-ssgoi-transition={`/post/${params.id}`}>
-      <h1>Post Detail</h1>
-    </main>
+    <Component
+      key={pathname}
+      data-ssgoi-transition={pathname}
+      className={className}
+    >
+      {children}
+    </Component>
   );
 }
 ```
+
+Use it inside `<Ssgoi>`:
+
+```tsx
+<SsgoiTransitionBoundary className="min-h-full bg-black">
+  {children}
+</SsgoiTransitionBoundary>
+```
+
+Dynamic routes keep their real pathnames, such as `/post/123`; use wildcard config like `/post/*` to match them. Use `/docs/**` when the parent path itself should match too.
 
 That's it. Navigations now drill in and ease back out like a native app.
 
@@ -99,13 +131,13 @@ That's it. Navigations now drill in and ease back out like a native app.
 
 Each transition is a factory you drop into `config.transitions`:
 
-| Transition | Feel | Config shape |
-| ---------- | ---- | ------------ |
-| `fade` | calm cross-fade, safe default | `fade({ paths })` |
-| `drill` | iOS list → detail | `drill({ enter, exit })` |
-| `hero` | shared element morph | `hero({ paths })` |
-| `sheet` | bottom sheet | `sheet({ enter, exit })` |
-| `slide` | horizontal tabs | `slide({ paths })` |
+| Transition | Feel                          | Config shape             |
+| ---------- | ----------------------------- | ------------------------ |
+| `fade`     | calm cross-fade, safe default | `fade({ paths })`        |
+| `drill`    | iOS list → detail             | `drill({ enter, exit })` |
+| `hero`     | shared element morph          | `hero({ paths })`        |
+| `sheet`    | bottom sheet                  | `sheet({ enter, exit })` |
+| `slide`    | horizontal tabs               | `slide({ paths })`       |
 
 See all the transitions live on the [demos](/), or read the [docs](/docs).
 

--- a/apps/docs/src/demo/air-bnb/page/checkout/confirm-step.tsx
+++ b/apps/docs/src/demo/air-bnb/page/checkout/confirm-step.tsx
@@ -2,7 +2,6 @@
 
 import { Check } from "lucide-react";
 import { useCheckout } from "@/demo/air-bnb/state/checkout";
-import { CHECKOUT_STEP_TRANSITION_IDS } from "./steps";
 import { CheckoutTitle } from "./title";
 import { useCurrentListing } from "./use-current-listing";
 const METHOD_LABEL = {
@@ -16,7 +15,7 @@ export function ConfirmStep() {
     method: state.selectedMethod,
   }));
   return (
-    <div data-ssgoi-transition={CHECKOUT_STEP_TRANSITION_IDS.confirm}>
+    <div>
       <CheckoutTitle step="confirm" />
       <div className="px-5 pt-5">
         <p className="text-[13px] text-neutral-700">

--- a/apps/docs/src/demo/air-bnb/page/checkout/index.tsx
+++ b/apps/docs/src/demo/air-bnb/page/checkout/index.tsx
@@ -3,11 +3,12 @@
 import { useEffect, useMemo, type ReactNode } from "react";
 import { Ssgoi, type SsgoiConfig } from "@ssgoi/react";
 import { axis } from "@ssgoi/react/view-transitions";
+import { SsgoiTransitionBoundary } from "@/lib/components/ssgoi-transition-boundary";
 import { useListing, type ListingDetail } from "@/demo/air-bnb/state/listing";
 import { useCheckout } from "@/demo/air-bnb/state/checkout";
 import { CheckoutHeader } from "./header";
 import { CheckoutBottomBar } from "./bottom-bar";
-import { CHECKOUT_STEP_ORDER, CHECKOUT_STEP_TRANSITION_IDS } from "./steps";
+import { CHECKOUT_STEP_ORDER, getCheckoutStepHref } from "./steps";
 import { useShowcaseHost } from "@/lib/components/demo-shell";
 export default function CheckoutLayoutClient({
   initialData,
@@ -31,29 +32,28 @@ export default function CheckoutLayoutClient({
   const config: SsgoiConfig = useMemo(
     () => ({
       preserveScroll: {
-        key: `detail/checkout`,
+        key: `${initialData.id}/checkout`,
       },
       transitions: [
         axis({
-          paths: CHECKOUT_STEP_ORDER.map(
-            (step) => CHECKOUT_STEP_TRANSITION_IDS[step],
+          paths: CHECKOUT_STEP_ORDER.map((step) =>
+            getCheckoutStepHref(initialData.id, step),
           ),
           type: "x",
         }),
       ],
     }),
-    [],
+    [initialData.id],
   );
   const host = useShowcaseHost();
   return (
-    <div
-      data-ssgoi-transition={`/demo/air-bnb/listings/detail/checkout`}
-      className="relative flex min-h-full w-full flex-col bg-white"
-    >
+    <div className="relative flex min-h-full w-full flex-col bg-white">
       <CheckoutHeader />
       <div className="relative z-0 flex-1 pb-3">
         <Ssgoi config={config} host={host}>
-          {children}
+          <SsgoiTransitionBoundary className="min-h-full bg-white">
+            {children}
+          </SsgoiTransitionBoundary>
         </Ssgoi>
       </div>
       <CheckoutBottomBar />

--- a/apps/docs/src/demo/air-bnb/page/checkout/method-step.tsx
+++ b/apps/docs/src/demo/air-bnb/page/checkout/method-step.tsx
@@ -5,7 +5,6 @@ import {
   useCheckout,
   type CheckoutMethod,
 } from "@/demo/air-bnb/state/checkout";
-import { CHECKOUT_STEP_TRANSITION_IDS } from "./steps";
 import { CheckoutTitle } from "./title";
 type Option = {
   key: CheckoutMethod;
@@ -72,7 +71,7 @@ export function MethodStep() {
     actions: state.actions,
   }));
   return (
-    <div data-ssgoi-transition={CHECKOUT_STEP_TRANSITION_IDS.method}>
+    <div>
       <CheckoutTitle step="method" />
       <div className="px-5 pt-5">
         <p className="text-[13px] text-neutral-700">

--- a/apps/docs/src/demo/air-bnb/page/checkout/review-step.tsx
+++ b/apps/docs/src/demo/air-bnb/page/checkout/review-step.tsx
@@ -1,12 +1,11 @@
 "use client";
 
-import { CHECKOUT_STEP_TRANSITION_IDS } from "./steps";
 import { CheckoutTitle } from "./title";
 import { useCurrentListing } from "./use-current-listing";
 export function ReviewStep() {
   const detail = useCurrentListing();
   return (
-    <div data-ssgoi-transition={CHECKOUT_STEP_TRANSITION_IDS.review}>
+    <div>
       <CheckoutTitle step="review" />
       <div className="px-5 pt-5">
         <div className="rounded-2xl border border-neutral-200 p-3">

--- a/apps/docs/src/demo/air-bnb/page/checkout/steps.ts
+++ b/apps/docs/src/demo/air-bnb/page/checkout/steps.ts
@@ -1,11 +1,5 @@
 import type { CheckoutStep } from "@/demo/air-bnb/state/checkout";
 
-export const CHECKOUT_STEP_TRANSITION_IDS: Record<CheckoutStep, string> = {
-  review: "/checkout/review",
-  method: "/checkout/method",
-  confirm: "/checkout/confirm",
-};
-
 export const CHECKOUT_STEP_ORDER: CheckoutStep[] = [
   "review",
   "method",

--- a/apps/docs/src/demo/air-bnb/page/home/index.tsx
+++ b/apps/docs/src/demo/air-bnb/page/home/index.tsx
@@ -16,10 +16,7 @@ export default function HomePage() {
     listing.actions.loadFeed();
   }, [listing.actions]);
   return (
-    <div
-      data-ssgoi-transition="/demo/air-bnb"
-      className="flex min-h-full flex-col bg-white"
-    >
+    <div className="flex min-h-full flex-col bg-white">
       <HomeHeader />
       <CategoryTabs />
       <div className="flex-1 pb-6">

--- a/apps/docs/src/demo/air-bnb/page/layout/client.tsx
+++ b/apps/docs/src/demo/air-bnb/page/layout/client.tsx
@@ -13,14 +13,14 @@ const config: SsgoiConfig = {
   preserveScroll: true,
   transitions: [
     zoom({
-      paths: [BASE, `${BASE}/listings/*`],
+      paths: [BASE, `${BASE}/listings/:id`],
       type: "blur",
       variant: "fade",
     }),
     sheet({
       type: "static",
-      enter: `${BASE}/listings/detail/checkout`,
-      exit: `${BASE}/listings/detail`,
+      enter: `${BASE}/listings/:id/checkout/*`,
+      exit: `${BASE}/listings/:id`,
     }),
   ],
 };

--- a/apps/docs/src/demo/air-bnb/page/listing-detail/index.tsx
+++ b/apps/docs/src/demo/air-bnb/page/listing-detail/index.tsx
@@ -20,10 +20,7 @@ export default function ListingDetailPage({
   listing.actions.init(initialData);
   const detail = listing.current ?? initialData;
   return (
-    <div
-      data-ssgoi-transition={`/demo/air-bnb/listings/detail`}
-      className="relative block min-h-full w-full bg-white"
-    >
+    <div className="relative block min-h-full w-full bg-white">
       <DetailHero detail={detail} />
       <DetailHeader />
       <div className="relative -mt-6 rounded-t-3xl bg-white px-5 pt-5 pb-6">

--- a/apps/docs/src/demo/airbnb-photo-tour/page/gallery/index.tsx
+++ b/apps/docs/src/demo/airbnb-photo-tour/page/gallery/index.tsx
@@ -57,10 +57,7 @@ export default function GalleryPage({
     return () => observer.disconnect();
   }, [categories.length]);
   return (
-    <div
-      data-ssgoi-transition="/demo/airbnb-photo-tour"
-      className="block h-full overflow-y-auto bg-white text-neutral-900"
-    >
+    <div className="block h-full overflow-y-auto bg-white text-neutral-900">
       <GalleryHeader title={title} />
       <div className="mx-auto max-w-[1200px]">
         <CategoryStrip

--- a/apps/docs/src/demo/airbnb-photo-tour/page/layout/client.tsx
+++ b/apps/docs/src/demo/airbnb-photo-tour/page/layout/client.tsx
@@ -27,7 +27,12 @@ export function AirbnbPhotoTourLayoutClient({
 }) {
   return (
     <WebShowcaseShell>
-      <SsgoiWithHost config={config}>{children}</SsgoiWithHost>
+      <SsgoiWithHost
+        config={config}
+        boundaryClassName="h-full min-h-full bg-white"
+      >
+        {children}
+      </SsgoiWithHost>
     </WebShowcaseShell>
   );
 }

--- a/apps/docs/src/demo/airbnb-photo-tour/page/photo-detail/index.tsx
+++ b/apps/docs/src/demo/airbnb-photo-tour/page/photo-detail/index.tsx
@@ -17,10 +17,7 @@ export default function PhotoDetailPage({
   }));
   photo.actions.initDetail(initialData);
   return (
-    <div
-      data-ssgoi-transition={`/demo/airbnb-photo-tour/photos/${initialData.id}`}
-      className="relative block h-screen bg-white"
-    >
+    <div className="relative block h-screen bg-white">
       <DetailHeader
         categoryLabel={initialData.categoryLabel}
         indexInCategory={initialData.indexInCategory}

--- a/apps/docs/src/demo/gamja-market/page/home/index.tsx
+++ b/apps/docs/src/demo/gamja-market/page/home/index.tsx
@@ -19,10 +19,7 @@ export default function HomePage() {
     order.actions.loadOrders();
   }, [product.actions, order.actions]);
   return (
-    <div
-      data-ssgoi-transition="/demo/gamja-market"
-      className="flex min-h-full flex-col bg-[#FAF8F6]"
-    >
+    <div className="flex min-h-full flex-col bg-[#FAF8F6]">
       <HomeHeader />
       <SectionTitle />
       <div className="flex-1">

--- a/apps/docs/src/demo/gamja-market/page/order-detail/index.tsx
+++ b/apps/docs/src/demo/gamja-market/page/order-detail/index.tsx
@@ -19,10 +19,7 @@ export default function OrderDetailPage({
   order.actions.init(initialData);
   const data = order.current ?? initialData;
   return (
-    <div
-      data-ssgoi-transition={`/demo/gamja-market/orders/${initialData.id}`}
-      className="flex min-h-full flex-col bg-[#FAF8F6]"
-    >
+    <div className="flex min-h-full flex-col bg-[#FAF8F6]">
       <OrderDetailHeader />
       <StatusBanner order={data} />
       <ProductSummary order={data} />

--- a/apps/docs/src/demo/gamja-market/page/orders/index.tsx
+++ b/apps/docs/src/demo/gamja-market/page/orders/index.tsx
@@ -12,10 +12,7 @@ export default function OrdersPage() {
     order.actions.loadOrders();
   }, [order.actions]);
   return (
-    <div
-      data-ssgoi-transition="/demo/gamja-market/orders"
-      className="flex min-h-full flex-col bg-[#FAF8F6]"
-    >
+    <div className="flex min-h-full flex-col bg-[#FAF8F6]">
       <OrdersHeader />
       <div className="flex-1">
         <OrdersList />

--- a/apps/docs/src/demo/gamja-market/page/product-detail/index.tsx
+++ b/apps/docs/src/demo/gamja-market/page/product-detail/index.tsx
@@ -20,10 +20,7 @@ export default function ProductDetailPage({
   }));
   product.actions.init(initialData);
   return (
-    <div
-      data-ssgoi-transition={`/demo/gamja-market/products/${initialData.id}`}
-      className="flex min-h-full flex-col bg-[#FAF8F6]"
-    >
+    <div className="flex min-h-full flex-col bg-[#FAF8F6]">
       <DetailHeader />
       <ProductGallery images={initialData.images} alt={initialData.name} />
       <ProductInfo product={initialData} />

--- a/apps/docs/src/demo/gamja-market/page/review-write/index.tsx
+++ b/apps/docs/src/demo/gamja-market/page/review-write/index.tsx
@@ -14,10 +14,7 @@ export default function ReviewWritePage({
   }));
   order.actions.init(initialData);
   return (
-    <div
-      data-ssgoi-transition={`/demo/gamja-market/review/${initialData.id}`}
-      className="flex min-h-full flex-col bg-[#FAF8F6]"
-    >
+    <div className="flex min-h-full flex-col bg-[#FAF8F6]">
       <ReviewHeader />
       <ProductCard order={initialData} />
       <ReviewForm order={initialData} />

--- a/apps/docs/src/demo/google-photos/page/collage/index.tsx
+++ b/apps/docs/src/demo/google-photos/page/collage/index.tsx
@@ -18,10 +18,7 @@ export default function CollagePage({ photos }: { photos: PhotoSimple[] }) {
   const router = useRouter();
   const sections = bucket(photos);
   return (
-    <div
-      data-ssgoi-transition="/demo/google-photos/collage"
-      className="relative flex min-h-full flex-col bg-white"
-    >
+    <div className="relative flex min-h-full flex-col bg-white">
       <header className="sticky top-0 z-30 bg-white pt-3 pb-2">
         <p className="text-center text-[13px] text-neutral-500">
           Select 1–6 photos

--- a/apps/docs/src/demo/google-photos/page/collection-detail/index.tsx
+++ b/apps/docs/src/demo/google-photos/page/collection-detail/index.tsx
@@ -16,10 +16,7 @@ export default function CollectionDetailPage({
   }));
   collection.actions.init(initialData);
   return (
-    <div
-      data-ssgoi-transition={`/demo/google-photos/c/${initialData.id}`}
-      className="block min-h-full bg-white"
-    >
+    <div className="block min-h-full bg-white">
       <CollectionHeader collection={initialData} />
       <CollectionPhotoGrid photos={initialData.photos} />
     </div>

--- a/apps/docs/src/demo/google-photos/page/collections/index.tsx
+++ b/apps/docs/src/demo/google-photos/page/collections/index.tsx
@@ -14,10 +14,7 @@ export default function CollectionsPage() {
     collection.actions.loadAll();
   }, [collection.actions]);
   return (
-    <div
-      data-ssgoi-transition="/demo/google-photos/collections"
-      className="block min-h-full bg-white"
-    >
+    <div className="block min-h-full bg-white">
       <div className="px-4 pt-4">
         <UtilityRow />
       </div>

--- a/apps/docs/src/demo/google-photos/page/create/index.tsx
+++ b/apps/docs/src/demo/google-photos/page/create/index.tsx
@@ -4,10 +4,7 @@ import { HeroCard } from "./hero-card";
 import { ToolGrid } from "./tool-grid";
 export default function CreatePage() {
   return (
-    <div
-      data-ssgoi-transition="/demo/google-photos/create"
-      className="block min-h-full bg-white"
-    >
+    <div className="block min-h-full bg-white">
       <div className="space-y-6 px-4 py-4">
         <HeroCard />
         <section>

--- a/apps/docs/src/demo/google-photos/page/photo-detail/index.tsx
+++ b/apps/docs/src/demo/google-photos/page/photo-detail/index.tsx
@@ -14,10 +14,7 @@ export default function PhotoDetailPage({
   }));
   photo.actions.init(initialData);
   return (
-    <div
-      data-ssgoi-transition={`/demo/google-photos/p/${initialData.id}`}
-      className="relative block h-full bg-white"
-    >
+    <div className="relative block h-full bg-white">
       <BackButton />
       <PhotoCanvas photo={initialData} />
       <PhotoMeta photo={initialData} />

--- a/apps/docs/src/demo/google-photos/page/photos/index.tsx
+++ b/apps/docs/src/demo/google-photos/page/photos/index.tsx
@@ -13,10 +13,7 @@ export default function PhotosPage() {
     photo.actions.loadAll();
   }, [photo.actions]);
   return (
-    <div
-      data-ssgoi-transition="/demo/google-photos"
-      className="block min-h-full bg-white"
-    >
+    <div className="block min-h-full bg-white">
       {photo.photos.isLoading && photo.photos.data.items.length === 0 ? (
         <div className="flex items-center justify-center py-16 text-neutral-400">
           <Loader2 className="h-5 w-5 animate-spin" />

--- a/apps/docs/src/demo/google-photos/page/tabs-shell/client.tsx
+++ b/apps/docs/src/demo/google-photos/page/tabs-shell/client.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import type { ReactNode } from "react";
-import { usePathname } from "next/navigation";
 import { Ssgoi, type SsgoiConfig } from "@ssgoi/react";
 import { axis } from "@ssgoi/react/view-transitions";
+import { SsgoiTransitionBoundary } from "@/lib/components/ssgoi-transition-boundary";
 import { TopAppBar } from "../shared/top-app-bar";
 import { FloatingBottomNav } from "../shared/floating-bottom-nav";
 const BASE = "/demo/google-photos";
@@ -18,28 +18,20 @@ const innerConfig: SsgoiConfig = {
   ],
 };
 
-// Wrap the whole tabs layout as one Ssgoi page identified by the current
-// pathname, so the outer Ssgoi (hero/drill) can pair the tabs area with
-// detail routes that live outside the (tabs) group.
-//
-// The transition boundary is the flex-column wrapper itself (not nested inside one).
-// `min-h-full` here only resolves when the *parent's* height is explicit; with
-// an extra `block min-h-full` div in between the chain broke (parent had
-// min-height but no height), the wrapper collapsed to content height, and
-// FloatingBottomNav's `sticky bottom-0` stuck to the short wrapper instead of
-// the scroll viewport — making the nav float above the bottom on short pages.
+// Keep the layout shell outside the transition boundary. Its flex/stacking
+// context is stable chrome; only the routed tab page below it changes.
 export function GooglePhotosTabsShell({ children }: { children: ReactNode }) {
-  const pathname = usePathname();
   return (
-    <div
-      data-ssgoi-transition={pathname}
-      className="relative flex min-h-full flex-col bg-white"
-    >
+    <div className="relative flex min-h-full flex-col bg-white">
       <div className="sticky top-0 z-30 bg-white">
         <TopAppBar />
       </div>
       <Ssgoi config={innerConfig}>
-        <div className="relative z-0 flex-1">{children}</div>
+        <div className="relative z-0 flex-1 bg-white">
+          <SsgoiTransitionBoundary className="min-h-full bg-white">
+            {children}
+          </SsgoiTransitionBoundary>
+        </div>
       </Ssgoi>
       <FloatingBottomNav />
     </div>

--- a/apps/docs/src/demo/honeydrop/page/court/index.tsx
+++ b/apps/docs/src/demo/honeydrop/page/court/index.tsx
@@ -4,10 +4,7 @@ const BG =
   "https://images.unsplash.com/photo-1518407613690-d9fc990e795f?auto=format&fit=crop&w=2400&q=80";
 export default function CourtPage() {
   return (
-    <div
-      data-ssgoi-transition="/demo/honeydrop"
-      className="relative h-full w-full"
-    >
+    <div className="relative h-full w-full">
       <div className="relative h-full w-full overflow-hidden">
         <img
           src={BG}

--- a/apps/docs/src/demo/honeydrop/page/drop/index.tsx
+++ b/apps/docs/src/demo/honeydrop/page/drop/index.tsx
@@ -4,10 +4,7 @@ const BG =
   "https://images.unsplash.com/photo-1542291026-7eec264c27ff?auto=format&fit=crop&w=2400&q=80";
 export default function DropPage() {
   return (
-    <div
-      data-ssgoi-transition="/demo/honeydrop/drop"
-      className="relative h-full w-full"
-    >
+    <div className="relative h-full w-full">
       <div className="relative h-full w-full overflow-hidden">
         <img
           src={BG}

--- a/apps/docs/src/demo/honeydrop/page/layout/client.tsx
+++ b/apps/docs/src/demo/honeydrop/page/layout/client.tsx
@@ -19,7 +19,10 @@ export function HoneydropLayoutClient({ children }: { children: ReactNode }) {
   return (
     <DemoShell>
       <div className="relative h-dvh w-full overflow-hidden bg-black text-white">
-        <SsgoiWithHost config={config}>
+        <SsgoiWithHost
+          config={config}
+          boundaryClassName="h-full min-h-full bg-black"
+        >
           <main className="relative h-full w-full">{children}</main>
         </SsgoiWithHost>
         {/* fixed chrome — outside Ssgoi so it doesn't rotate with the page */}

--- a/apps/docs/src/demo/instagram/page/feed-detail/index.tsx
+++ b/apps/docs/src/demo/instagram/page/feed-detail/index.tsx
@@ -3,6 +3,7 @@
 import { useEffect } from "react";
 import { usePost, type PostDetail } from "@/demo/instagram/state/post";
 import { useProfile } from "@/demo/instagram/state/profile";
+import { SsgoiTransitionBoundary } from "@/lib/components/ssgoi-transition-boundary";
 import { FeedDetailHeader } from "./header";
 import { FeedDetailImage } from "./image";
 import { FeedDetailActions } from "./actions";
@@ -27,16 +28,13 @@ export default function FeedDetailPage({
   const detail = post.current ?? initialData;
   const me = profile.me.data;
   return (
-    <div
-      data-ssgoi-transition={`/demo/instagram/feed/${detail.id}`}
-      className="relative block min-h-full w-full bg-white"
-    >
+    <SsgoiTransitionBoundary className="relative block min-h-full w-full bg-white">
       <FeedDetailHeader
         backHref={`/demo/instagram/profile/${me?.username ?? "deaseungseung94"}`}
       />
       <FeedDetailImage post={detail} author={me} />
       <FeedDetailActions />
       <FeedDetailMeta post={detail} author={me} />
-    </div>
+    </SsgoiTransitionBoundary>
   );
 }

--- a/apps/docs/src/demo/instagram/page/layout/client.tsx
+++ b/apps/docs/src/demo/instagram/page/layout/client.tsx
@@ -21,5 +21,9 @@ const config: SsgoiConfig = {
 };
 
 export function InstagramLayoutClient({ children }: { children: ReactNode }) {
-  return <MobileShowcaseShell config={config}>{children}</MobileShowcaseShell>;
+  return (
+    <MobileShowcaseShell config={config} withTransitionBoundary={false}>
+      {children}
+    </MobileShowcaseShell>
+  );
 }

--- a/apps/docs/src/demo/instagram/page/profile-grid/index.tsx
+++ b/apps/docs/src/demo/instagram/page/profile-grid/index.tsx
@@ -4,7 +4,8 @@ import { useEffect } from "react";
 import { usePost } from "@/demo/instagram/state/post";
 import { GridSkeleton } from "./grid-skeleton";
 import { GridItem } from "./grid-item";
-export default function ProfileGridPage({ id }: { id: string }) {
+
+export default function ProfileGridPage() {
   const post = usePost((state) => ({
     posts: state.posts,
     actions: state.actions,
@@ -13,10 +14,7 @@ export default function ProfileGridPage({ id }: { id: string }) {
     post.actions.loadPosts();
   }, [post.actions]);
   return (
-    <div
-      data-ssgoi-transition={`/demo/instagram/profile/${id}`}
-      className="min-h-screen"
-    >
+    <div className="min-h-screen">
       {post.posts.isLoading && post.posts.data.length === 0 ? (
         <GridSkeleton />
       ) : (

--- a/apps/docs/src/demo/instagram/page/profile-layout/client.tsx
+++ b/apps/docs/src/demo/instagram/page/profile-layout/client.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, type ReactNode } from "react";
 import { Ssgoi, type SsgoiConfig } from "@ssgoi/react";
 import { slide } from "@ssgoi/react/view-transitions";
+import { SsgoiTransitionBoundary } from "@/lib/components/ssgoi-transition-boundary";
 import { useProfile } from "@/demo/instagram/state/profile";
 import { ProfileHeader } from "../profile-shell/header";
 import { ProfileHeaderSkeleton } from "../profile-shell/header-skeleton";
@@ -39,8 +40,8 @@ export function InstagramProfileLayoutClient({
   }, [profile.actions]);
   const me = profile.me.data;
   return (
-    <div
-      data-ssgoi-transition={base}
+    <SsgoiTransitionBoundary
+      id={base}
       className="relative block min-h-full w-full bg-white text-neutral-900"
     >
       <div className="sticky top-0 z-30 bg-white">
@@ -52,11 +53,15 @@ export function InstagramProfileLayoutClient({
       {me ? <ProfileHeader me={me} /> : <ProfileHeaderSkeleton />}
       <ProfileTabs id={id} />
       <Ssgoi config={innerConfig}>
-        <div className="relative z-0">{children}</div>
+        <div className="relative z-0 bg-white">
+          <SsgoiTransitionBoundary className="min-h-full bg-white">
+            {children}
+          </SsgoiTransitionBoundary>
+        </div>
       </Ssgoi>
       <div className="sticky bottom-0 z-30 bg-white">
         <ProfileBottomBar avatar={me?.avatar} />
       </div>
-    </div>
+    </SsgoiTransitionBoundary>
   );
 }

--- a/apps/docs/src/demo/instagram/page/profile-reels/index.tsx
+++ b/apps/docs/src/demo/instagram/page/profile-reels/index.tsx
@@ -3,7 +3,8 @@
 import { useEffect } from "react";
 import { usePost } from "@/demo/instagram/state/post";
 import { ReelItem } from "./reel-item";
-export default function ProfileReelsPage({ id }: { id: string }) {
+
+export default function ProfileReelsPage() {
   const post = usePost((state) => ({
     reels: state.reels,
     actions: state.actions,
@@ -12,10 +13,7 @@ export default function ProfileReelsPage({ id }: { id: string }) {
     post.actions.loadReels();
   }, [post.actions]);
   return (
-    <div
-      data-ssgoi-transition={`/demo/instagram/profile/${id}/reels`}
-      className="min-h-screen"
-    >
+    <div className="min-h-screen">
       {post.reels.isLoading && post.reels.data.length === 0 ? (
         <div className="grid grid-cols-3 gap-[2px] bg-white">
           {Array.from({

--- a/apps/docs/src/demo/instagram/page/profile-remix/index.tsx
+++ b/apps/docs/src/demo/instagram/page/profile-remix/index.tsx
@@ -1,11 +1,8 @@
 "use client";
 
-export default function ProfileRemixPage({ id }: { id: string }) {
+export default function ProfileRemixPage() {
   return (
-    <div
-      data-ssgoi-transition={`/demo/instagram/profile/${id}/remix`}
-      className="min-h-screen"
-    >
+    <div className="min-h-screen">
       <div className="flex min-h-[400px] flex-col items-center justify-center px-10 py-16 text-center">
         <div className="grid h-16 w-16 place-items-center rounded-full border-2 border-neutral-900">
           <svg

--- a/apps/docs/src/demo/instagram/page/profile-tagged/index.tsx
+++ b/apps/docs/src/demo/instagram/page/profile-tagged/index.tsx
@@ -3,7 +3,8 @@
 import { useEffect } from "react";
 import { usePost } from "@/demo/instagram/state/post";
 import { TaggedItem } from "./tagged-item";
-export default function ProfileTaggedPage({ id }: { id: string }) {
+
+export default function ProfileTaggedPage() {
   const post = usePost((state) => ({
     tagged: state.tagged,
     actions: state.actions,
@@ -12,10 +13,7 @@ export default function ProfileTaggedPage({ id }: { id: string }) {
     post.actions.loadTagged();
   }, [post.actions]);
   return (
-    <div
-      data-ssgoi-transition={`/demo/instagram/profile/${id}/tagged`}
-      className="min-h-screen"
-    >
+    <div className="min-h-screen">
       {post.tagged.isLoading && post.tagged.data.length === 0 ? (
         <div className="grid grid-cols-3 gap-[2px] bg-white">
           {Array.from({

--- a/apps/docs/src/demo/kakao-talk/page/chat-detail/index.tsx
+++ b/apps/docs/src/demo/kakao-talk/page/chat-detail/index.tsx
@@ -14,10 +14,7 @@ export default function ChatDetailPage({
   }));
   chat.actions.init(initialData);
   return (
-    <div
-      data-ssgoi-transition={`/demo/kakao-talk/chats/${initialData.id}`}
-      className="flex min-h-full flex-col bg-[#A4BFD2]"
-    >
+    <div className="flex min-h-full flex-col bg-[#A4BFD2]">
       <ChatHeader thread={initialData} />
       <MessageList messages={initialData.messages} />
       <Composer />

--- a/apps/docs/src/demo/kakao-talk/page/chats/index.tsx
+++ b/apps/docs/src/demo/kakao-talk/page/chats/index.tsx
@@ -14,10 +14,7 @@ export default function ChatsPage() {
     chat.actions.loadThreads();
   }, [chat.actions]);
   return (
-    <div
-      data-ssgoi-transition="/demo/kakao-talk/chats"
-      className="flex min-h-full flex-col bg-white"
-    >
+    <div className="flex min-h-full flex-col bg-white">
       <ChatsHeader />
       <div className="flex-1 overflow-y-auto pb-16">
         <AdBanner />

--- a/apps/docs/src/demo/kakao-talk/page/home/index.tsx
+++ b/apps/docs/src/demo/kakao-talk/page/home/index.tsx
@@ -18,10 +18,7 @@ export default function HomePage() {
   const { me, birthday, favorites, friends, friendsCountLabel } =
     friend.groups.data;
   return (
-    <div
-      data-ssgoi-transition="/demo/kakao-talk"
-      className="flex min-h-full flex-col bg-white"
-    >
+    <div className="flex min-h-full flex-col bg-white">
       <TopHeader me={me} />
       <div className="flex-1 overflow-y-auto pb-16">
         <PromoBanner />

--- a/apps/docs/src/demo/kakao-talk/page/profile-detail/index.tsx
+++ b/apps/docs/src/demo/kakao-talk/page/profile-detail/index.tsx
@@ -14,10 +14,7 @@ export default function ProfileDetailPage({
   }));
   friend.actions.init(initialData);
   return (
-    <div
-      data-ssgoi-transition={`/demo/kakao-talk/profile/${initialData.id}`}
-      className="relative flex min-h-full flex-col bg-[#A6AEBE]"
-    >
+    <div className="relative flex min-h-full flex-col bg-[#A6AEBE]">
       <ProfileHeader />
       <ProfileHero profile={initialData} />
       <ProfileActions />

--- a/apps/docs/src/demo/lumen/page/cinematic-eye/index.tsx
+++ b/apps/docs/src/demo/lumen/page/cinematic-eye/index.tsx
@@ -6,7 +6,6 @@ export default function CinematicEyePage() {
   return (
     <CoursePage
       data={{
-        routeId: "/demo/lumen/cinematic-eye",
         eyebrow: "Cinematography",
         title: "The Cinematic Eye",
         overview:

--- a/apps/docs/src/demo/lumen/page/foundations/index.tsx
+++ b/apps/docs/src/demo/lumen/page/foundations/index.tsx
@@ -6,7 +6,6 @@ export default function FoundationsPage() {
   return (
     <CoursePage
       data={{
-        routeId: "/demo/lumen",
         eyebrow: "Documentary",
         title: "Foundations",
         overview:

--- a/apps/docs/src/demo/lumen/page/layout/client.tsx
+++ b/apps/docs/src/demo/lumen/page/layout/client.tsx
@@ -17,7 +17,12 @@ export function LumenLayoutClient({ children }: { children: ReactNode }) {
   return (
     <DemoShell>
       <div className="relative h-dvh w-full overflow-hidden bg-black text-white">
-        <SsgoiWithHost config={config}>{children}</SsgoiWithHost>
+        <SsgoiWithHost
+          config={config}
+          boundaryClassName="h-full min-h-full bg-black"
+        >
+          {children}
+        </SsgoiWithHost>
       </div>
     </DemoShell>
   );

--- a/apps/docs/src/demo/lumen/page/shared/course-page.tsx
+++ b/apps/docs/src/demo/lumen/page/shared/course-page.tsx
@@ -7,7 +7,6 @@ type Meta = {
   value: string;
 };
 export type CoursePageData = {
-  routeId: string;
   eyebrow: string;
   title: string;
   overview: string;
@@ -18,10 +17,7 @@ export type CoursePageData = {
 };
 export function CoursePage({ data }: { data: CoursePageData }) {
   return (
-    <div
-      data-ssgoi-transition={data.routeId}
-      className="relative h-full w-full overflow-hidden"
-    >
+    <div className="relative h-full w-full overflow-hidden">
       {/* fullscreen cinematic background — absolute so it animates with the page */}
       <div className="pointer-events-none absolute inset-0 -z-10">
         <video

--- a/apps/docs/src/demo/material-mail/page/compose/index.tsx
+++ b/apps/docs/src/demo/material-mail/page/compose/index.tsx
@@ -5,10 +5,7 @@ import { ComposeForm } from "./compose-form";
 import { ComposeToolbar } from "./compose-toolbar";
 export default function ComposePage() {
   return (
-    <div
-      data-ssgoi-transition="/demo/material-mail/compose"
-      className="relative flex min-h-full flex-col bg-white"
-    >
+    <div className="relative flex min-h-full flex-col bg-white">
       <ComposeBar />
       <div className="flex-1 overflow-y-auto">
         <ComposeForm />

--- a/apps/docs/src/demo/material-mail/page/inbox/index.tsx
+++ b/apps/docs/src/demo/material-mail/page/inbox/index.tsx
@@ -13,17 +13,11 @@ export default function InboxPage() {
     mail.actions.loadMails();
   }, [mail.actions]);
 
-  // Two siblings inside the mobile-frame scroll container:
-  //  1. data-ssgoi-transition wrapper — the transition target (TopBar + list).
-  //  2. The FAB row — sticky to the bottom of the scroll container, but
-  //     *outside* the transition boundary so the sheet/scale animation doesn't drag
-  //     it along. Same approach as gamja-market's FloatingBottom.
+  // The FAB row stays outside the scrolled content block so the compose sheet
+  // does not drag it along. Same approach as gamja-market's FloatingBottom.
   return (
     <>
-      <div
-        data-ssgoi-transition="/demo/material-mail"
-        className="flex min-h-full flex-col bg-[#FAFAFE]"
-      >
+      <div className="flex min-h-full flex-col bg-[#FAFAFE]">
         <TopBar />
         <div className="flex-1 pb-4">
           <InboxList />

--- a/apps/docs/src/demo/nora-hale/page/about/index.tsx
+++ b/apps/docs/src/demo/nora-hale/page/about/index.tsx
@@ -38,10 +38,7 @@ const PORTRAITS = [
 ];
 export default function AboutPage() {
   return (
-    <div
-      data-ssgoi-transition="/demo/nora-hale/about"
-      className="relative h-full w-full"
-    >
+    <div className="relative h-full w-full">
       <div className="relative h-full w-full overflow-y-auto px-6 lg:px-10">
         {PORTRAITS.map((p) => (
           <img

--- a/apps/docs/src/demo/nora-hale/page/layout/client.tsx
+++ b/apps/docs/src/demo/nora-hale/page/layout/client.tsx
@@ -19,7 +19,10 @@ export function NoraHaleLayoutClient({ children }: { children: ReactNode }) {
     <DemoShell>
       <div className="relative h-dvh w-full overflow-hidden bg-[#f4ecdd] text-[#1a1a1a]">
         <SiteHeader />
-        <SsgoiWithHost config={config}>
+        <SsgoiWithHost
+          config={config}
+          boundaryClassName="h-full min-h-full bg-[#f4ecdd]"
+        >
           <main className="relative h-full w-full">{children}</main>
         </SsgoiWithHost>
       </div>

--- a/apps/docs/src/demo/nora-hale/page/work-archive/index.tsx
+++ b/apps/docs/src/demo/nora-hale/page/work-archive/index.tsx
@@ -24,10 +24,7 @@ const PROJECTS = [
 ];
 export default function WorkArchivePage() {
   return (
-    <div
-      data-ssgoi-transition="/demo/nora-hale"
-      className="relative h-full w-full"
-    >
+    <div className="relative h-full w-full">
       <div className="relative flex h-full w-full flex-col overflow-y-auto px-6 lg:px-10">
         <section className="flex flex-col items-center pt-36 lg:pt-44">
           <p className="text-[11px] tracking-[0.32em] text-[#1a1a1a]/55 uppercase">

--- a/apps/docs/src/demo/pinterest/page/feed-detail/index.tsx
+++ b/apps/docs/src/demo/pinterest/page/feed-detail/index.tsx
@@ -15,10 +15,7 @@ export default function FeedDetailPage({
   }));
   pinState.actions.init(initialData);
   return (
-    <div
-      data-ssgoi-transition={`/demo/pinterest/feed/${initialData.id}`}
-      className="flex min-h-full flex-col bg-white"
-    >
+    <div className="flex min-h-full flex-col bg-white">
       <div className="">
         <BackButton />
         <HeroImage pin={initialData} />

--- a/apps/docs/src/demo/pinterest/page/home/index.tsx
+++ b/apps/docs/src/demo/pinterest/page/home/index.tsx
@@ -14,10 +14,7 @@ export default function HomePage() {
     pinState.actions.loadPins();
   }, [pinState.actions]);
   return (
-    <div
-      data-ssgoi-transition="/demo/pinterest"
-      className="flex min-h-full flex-col bg-white"
-    >
+    <div className="flex min-h-full flex-col bg-white">
       <HomeHeader />
       <TabBar />
       <div className="flex-1 pt-2">

--- a/apps/docs/src/demo/pinterest/page/search-result/index.tsx
+++ b/apps/docs/src/demo/pinterest/page/search-result/index.tsx
@@ -13,10 +13,7 @@ export default function SearchResultPage({ query }: { query: string }) {
     pinState.actions.search(query);
   }, [pinState.actions, query]);
   return (
-    <div
-      data-ssgoi-transition={`/demo/pinterest/search/${query}`}
-      className="flex min-h-full flex-col bg-white"
-    >
+    <div className="flex min-h-full flex-col bg-white">
       <ResultHeader query={query} />
       <ChipRow query={query} />
       <div className="flex-1 pb-6">

--- a/apps/docs/src/demo/pinterest/page/search/index.tsx
+++ b/apps/docs/src/demo/pinterest/page/search/index.tsx
@@ -14,10 +14,7 @@ export default function SearchPage() {
     cat.actions.loadCategories();
   }, [cat.actions]);
   return (
-    <div
-      data-ssgoi-transition="/demo/pinterest/search"
-      className="flex min-h-full flex-col bg-white"
-    >
+    <div className="flex min-h-full flex-col bg-white">
       <SearchInput />
       <div className="flex-1 pb-6">
         <HeroBanner />

--- a/apps/docs/src/demo/silent-room/page/layout/client.tsx
+++ b/apps/docs/src/demo/silent-room/page/layout/client.tsx
@@ -19,7 +19,10 @@ export function SilentRoomLayoutClient({ children }: { children: ReactNode }) {
   return (
     <DemoShell>
       <div className="relative h-dvh w-full overflow-hidden bg-[#0c0c0c] text-[#f5f1ea]">
-        <SsgoiWithHost config={config}>
+        <SsgoiWithHost
+          config={config}
+          boundaryClassName="h-full min-h-full bg-[#0c0c0c]"
+        >
           <main className="relative h-full w-full">{children}</main>
         </SsgoiWithHost>
         <GalleryChrome />

--- a/apps/docs/src/demo/silent-room/page/light/index.tsx
+++ b/apps/docs/src/demo/silent-room/page/light/index.tsx
@@ -6,7 +6,6 @@ export default function LightPage() {
   return (
     <RoomShell
       data={{
-        routeId: "/demo/silent-room/light",
         index: "III",
         ordinal: "03",
         title: "Light",

--- a/apps/docs/src/demo/silent-room/page/shared/room-shell.tsx
+++ b/apps/docs/src/demo/silent-room/page/shared/room-shell.tsx
@@ -5,10 +5,7 @@ export function RoomShell({ data }: { data: RoomData }) {
   const alignClass = data.align === "left" ? "items-start" : "items-end";
   const textAlignClass = data.align === "left" ? "text-left" : "text-right";
   return (
-    <div
-      data-ssgoi-transition={data.routeId}
-      className="relative h-full w-full"
-    >
+    <div className="relative h-full w-full">
       <div className="relative h-full w-full overflow-hidden">
         <img
           src={data.bg}

--- a/apps/docs/src/demo/silent-room/page/shared/types.ts
+++ b/apps/docs/src/demo/silent-room/page/shared/types.ts
@@ -1,5 +1,4 @@
 export type RoomData = {
-  routeId: string;
   index: "I" | "II" | "III";
   ordinal: "01" | "02" | "03";
   title: string;

--- a/apps/docs/src/demo/silent-room/page/stillness/index.tsx
+++ b/apps/docs/src/demo/silent-room/page/stillness/index.tsx
@@ -6,7 +6,6 @@ export default function StillnessPage() {
   return (
     <RoomShell
       data={{
-        routeId: "/demo/silent-room",
         index: "I",
         ordinal: "01",
         title: "Stillness",

--- a/apps/docs/src/demo/silent-room/page/tension/index.tsx
+++ b/apps/docs/src/demo/silent-room/page/tension/index.tsx
@@ -6,7 +6,6 @@ export default function TensionPage() {
   return (
     <RoomShell
       data={{
-        routeId: "/demo/silent-room/tension",
         index: "II",
         ordinal: "02",
         title: "Tension",

--- a/apps/docs/src/demo/youtube-music-web/page/home/index.tsx
+++ b/apps/docs/src/demo/youtube-music-web/page/home/index.tsx
@@ -5,10 +5,7 @@ import { ChipBar } from "./chip-bar";
 import { Shelf } from "./shelf";
 export default function HomePage({ initialData }: { initialData: HomeData }) {
   return (
-    <div
-      data-ssgoi-transition="/demo/youtube-music-web"
-      className="h-full overflow-y-auto bg-[#030303] text-white"
-    >
+    <div className="h-full overflow-y-auto bg-[#030303] text-white">
       <div className="mx-auto max-w-[1280px] px-6 pt-3 pb-16 lg:px-10">
         <ChipBar />
         <div className="mt-6 flex flex-col gap-10">

--- a/apps/docs/src/demo/youtube-music-web/page/layout/client.tsx
+++ b/apps/docs/src/demo/youtube-music-web/page/layout/client.tsx
@@ -30,7 +30,12 @@ export function YoutubeMusicLayoutClient({
         <div className="flex min-h-0 flex-1">
           <Sidebar />
           <main className="relative z-0 min-w-0 flex-1 overflow-hidden">
-            <SsgoiWithHost config={config}>{children}</SsgoiWithHost>
+            <SsgoiWithHost
+              config={config}
+              boundaryClassName="h-full min-h-full bg-[#030303]"
+            >
+              {children}
+            </SsgoiWithHost>
           </main>
         </div>
         <PlayerBar />

--- a/apps/docs/src/demo/youtube-music-web/page/watch/index.tsx
+++ b/apps/docs/src/demo/youtube-music-web/page/watch/index.tsx
@@ -17,10 +17,7 @@ export default function WatchPage({
   }));
   song.actions.init(initialData);
   return (
-    <div
-      data-ssgoi-transition="/demo/youtube-music-web/watch"
-      className="h-full overflow-y-auto bg-gradient-to-b from-[#161616] via-[#0a0a0a] to-[#030303] text-white"
-    >
+    <div className="h-full overflow-y-auto bg-gradient-to-b from-[#161616] via-[#0a0a0a] to-[#030303] text-white">
       <div className="mx-auto flex max-w-[1300px] flex-col px-4 pb-12 pt-4 lg:px-8">
         <TabBar />
         <div className="mt-6 grid gap-8 lg:grid-cols-[minmax(0,420px)_1fr]">

--- a/apps/docs/src/demo/yuzu-club/page/flavors/index.tsx
+++ b/apps/docs/src/demo/yuzu-club/page/flavors/index.tsx
@@ -61,10 +61,7 @@ const FLAVORS: Flavor[] = [
 ];
 export default function FlavorsPage() {
   return (
-    <div
-      data-ssgoi-transition="/demo/yuzu-club/flavors"
-      className="relative h-full w-full"
-    >
+    <div className="relative h-full w-full">
       <div className="relative h-full w-full overflow-y-auto bg-[#8ed1a4]">
         <span
           aria-hidden

--- a/apps/docs/src/demo/yuzu-club/page/home/index.tsx
+++ b/apps/docs/src/demo/yuzu-club/page/home/index.tsx
@@ -17,10 +17,7 @@ const STATS = [
 ];
 export default function HomePage() {
   return (
-    <div
-      data-ssgoi-transition="/demo/yuzu-club"
-      className="relative h-full w-full"
-    >
+    <div className="relative h-full w-full">
       <div className="relative h-full w-full overflow-y-auto bg-[#ffd2a4]">
         {/* floating shapes */}
         <span

--- a/apps/docs/src/demo/yuzu-club/page/layout/client.tsx
+++ b/apps/docs/src/demo/yuzu-club/page/layout/client.tsx
@@ -18,7 +18,10 @@ export function YuzuClubLayoutClient({ children }: { children: ReactNode }) {
   return (
     <DemoShell>
       <div className="relative h-dvh w-full overflow-hidden bg-[#fff5d6] text-[#1a1a2e]">
-        <SsgoiWithHost config={config}>
+        <SsgoiWithHost
+          config={config}
+          boundaryClassName="h-full min-h-full bg-[#fff5d6]"
+        >
           <main className="relative h-full w-full">{children}</main>
         </SsgoiWithHost>
         <FloatingHeader />

--- a/apps/docs/src/lib/components/demo-shell.tsx
+++ b/apps/docs/src/lib/components/demo-shell.tsx
@@ -3,6 +3,7 @@
 import { type ReactNode } from "react";
 import { Ssgoi, type SsgoiConfig } from "@ssgoi/react";
 import { useShowcaseHost } from "./host-context";
+import { SsgoiTransitionBoundary } from "./ssgoi-transition-boundary";
 
 // Re-export so existing imports (`from "@/lib/components/demo-shell"`) keep
 // working after the host moved up to `DocsSsgoiProvider`.
@@ -28,14 +29,26 @@ export function DemoShell({ children }: { children: ReactNode }) {
 export function SsgoiWithHost({
   config,
   children,
+  boundaryClassName = "h-full min-h-full bg-black",
+  withTransitionBoundary = true,
 }: {
   config: SsgoiConfig;
   children: ReactNode;
+  boundaryClassName?: string;
+  withTransitionBoundary?: boolean;
 }) {
   const host = useShowcaseHost();
+  const content = withTransitionBoundary ? (
+    <SsgoiTransitionBoundary className={boundaryClassName}>
+      {children}
+    </SsgoiTransitionBoundary>
+  ) : (
+    children
+  );
+
   return (
     <Ssgoi config={config} host={host}>
-      {children}
+      {content}
     </Ssgoi>
   );
 }

--- a/apps/docs/src/lib/components/mobile-showcase-shell.tsx
+++ b/apps/docs/src/lib/components/mobile-showcase-shell.tsx
@@ -7,6 +7,7 @@ import { Toaster } from "sonner";
 import { StateProvider } from "@/lib/state";
 import { MobileFrame } from "@/lib/components/mobile-frame";
 import { DemoShell, SsgoiWithHost } from "@/lib/components/demo-shell";
+import { cn } from "@/lib/utils";
 
 /**
  * 모바일 쇼케이스용 셸. host/bridge/dock은 위쪽(`DocsSsgoiProvider` + `/demo/layout.tsx`)
@@ -18,6 +19,7 @@ export function MobileShowcaseShell({
   children,
   contentClassName,
   bottomSlot,
+  withTransitionBoundary = true,
 }: {
   config: SsgoiConfig;
   children: ReactNode;
@@ -31,6 +33,11 @@ export function MobileShowcaseShell({
    * page transition 영향을 받지 말아야 하는 요소를 넣는다.
    */
   bottomSlot?: ReactNode;
+  /**
+   * Most mobile demos can use the shared pathname boundary. Nested demos can
+   * opt out and place their boundary on the exact routed shell instead.
+   */
+  withTransitionBoundary?: boolean;
 }) {
   return (
     <DemoShell>
@@ -40,7 +47,16 @@ export function MobileShowcaseShell({
             contentClassName={contentClassName}
             bottomSlot={bottomSlot}
           >
-            <SsgoiWithHost config={config}>{children}</SsgoiWithHost>
+            <SsgoiWithHost
+              config={config}
+              withTransitionBoundary={withTransitionBoundary}
+              boundaryClassName={cn(
+                "h-full min-h-full bg-black",
+                contentClassName,
+              )}
+            >
+              {children}
+            </SsgoiWithHost>
           </MobileFrame>
           <Toaster position="top-center" richColors />
         </OverlayProvider>

--- a/apps/docs/src/lib/components/ssgoi-transition-boundary.tsx
+++ b/apps/docs/src/lib/components/ssgoi-transition-boundary.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { type ElementType, type ReactNode } from "react";
+import { usePathname } from "next/navigation";
+
+export function SsgoiTransitionBoundary({
+  children,
+  as,
+  className,
+  id,
+}: {
+  children: ReactNode;
+  as?: ElementType;
+  className?: string;
+  id?: string;
+}) {
+  const pathname = usePathname();
+  const transitionId = id ?? pathname;
+  const Component = as ?? "div";
+
+  return (
+    <Component
+      key={transitionId}
+      data-ssgoi-transition={transitionId}
+      className={className}
+    >
+      {children}
+    </Component>
+  );
+}

--- a/apps/docs/src/page/docs/sections.tsx
+++ b/apps/docs/src/page/docs/sections.tsx
@@ -133,7 +133,8 @@ export function InstallBody() {
         </h2>
         <p className="mt-3 max-w-xl text-sm leading-relaxed text-neutral-400">
           Two steps and the router feels native. The example below is React /
-          Next.js — the shape is identical in every framework.
+          Next.js; other frameworks place the page marker directly on each
+          routed page.
         </p>
 
         <SetupStep
@@ -143,15 +144,19 @@ export function InstallBody() {
             <>
               Add the{" "}
               <code className="font-mono text-neutral-200">&lt;Ssgoi&gt;</code>{" "}
-              provider in your root layout — the only client component you need.
-              Your pages stay server components.
+              provider from your root layout, then put the layout shell classes
+              on the wrapper above it. Keep the layout and pages as server
+              components; only the small provider/boundary files need client
+              hooks.
             </>
           }
-          code={`// app/layout.tsx
+          code={`// app/ssgoi-provider.tsx
 "use client";
 
+import { type ReactNode } from "react";
 import { Ssgoi } from "@ssgoi/react";
 import { drill, fade } from "@ssgoi/react/view-transitions";
+import { SsgoiTransitionBoundary } from "./ssgoi-transition-boundary";
 
 const config = {
   transitions: [
@@ -160,59 +165,283 @@ const config = {
   ],
 };
 
-export default function RootLayout({ children }) {
+export function SsgoiProvider({ children }: { children: ReactNode }) {
   return (
     <Ssgoi config={config}>
-      <div className="relative z-0 min-h-dvh overflow-x-clip">
+      {/* Routed content marker. Layout positioning belongs to the outer wrapper. */}
+      <SsgoiTransitionBoundary className="min-h-full bg-black">
         {children}
-      </div>
+      </SsgoiTransitionBoundary>
     </Ssgoi>
+  );
+}
+
+// app/layout.tsx
+import { type ReactNode } from "react";
+import { SsgoiProvider } from "./ssgoi-provider";
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        {/* Layout shell: positioned ancestor + stacking context for the OUT clone. */}
+        <main className="relative z-0 min-h-dvh overflow-x-clip bg-black">
+          <SsgoiProvider>{children}</SsgoiProvider>
+        </main>
+      </body>
+    </html>
   );
 }`}
         />
 
+        <WhyStructure />
+
         <SetupStep
           n="2"
-          title="Mark your pages"
+          title="Wrap React routed content"
           desc={
             <>
-              Give each page root a{" "}
+              In React adapters, use one pathname-based{" "}
               <code className="font-mono text-neutral-200">
                 data-ssgoi-transition
               </code>{" "}
-              key — that&apos;s the path your config matches against.
+              boundary utility in your layout. This is a React convenience
+              pattern: SSGOI only needs a logical page id, and the utility uses
+              the current pathname as that id. Match descendants with wildcards
+              like <code className="font-mono text-neutral-200">/post/*</code>{" "}
+              or include the parent path with{" "}
+              <code className="font-mono text-neutral-200">/docs/**</code>.
             </>
           }
-          code={`// app/page.tsx
-export default function HomePage() {
-  return <main data-ssgoi-transition="/">…</main>;
+          code={`// ssgoi-transition-boundary.tsx
+"use client";
+
+import { type ElementType, type ReactNode } from "react";
+import { usePathname } from "next/navigation";
+
+export function SsgoiTransitionBoundary({
+  children,
+  as,
+  className,
+}: {
+  children: ReactNode;
+  as?: ElementType;
+  className?: string;
+}) {
+  const pathname = usePathname();
+  const Component = as ?? "div";
+
+  return (
+    <Component
+      key={pathname}
+      data-ssgoi-transition={pathname}
+      className={className}
+    >
+      {children}
+    </Component>
+  );
 }
 
-// app/post/[id]/page.tsx
-export default function PostPage({ params }) {
-  return <main data-ssgoi-transition={\`/post/\${params.id}\`}>…</main>;
-}`}
+// app/ssgoi-provider.tsx
+import { Ssgoi } from "@ssgoi/react";
+
+return (
+  <Ssgoi config={config}>
+    <SsgoiTransitionBoundary className="min-h-full bg-black">
+      {children}
+    </SsgoiTransitionBoundary>
+  </Ssgoi>
+);`}
         />
 
-        <p className="mt-8 max-w-xl text-sm leading-relaxed text-neutral-500">
-          That&apos;s the whole integration. Which transition goes where is just
-          config — browse them in{" "}
-          <Link
-            href="/docs/transitions"
-            className="text-neutral-300 underline decoration-white/20 underline-offset-4 transition-colors hover:text-orange-400 hover:decoration-orange-400/60"
-          >
-            Transitions
-          </Link>
-          , and check the{" "}
-          <Link
-            href="/docs/layout"
-            className="text-neutral-300 underline decoration-white/20 underline-offset-4 transition-colors hover:text-orange-400 hover:decoration-orange-400/60"
-          >
-            wrapper classes
-          </Link>{" "}
-          if a transition ever looks off.
-        </p>
+        <NonReactBoundary />
       </div>
+
+      <ReferenceTemplates />
+
+      <p className="mt-10 max-w-xl text-sm leading-relaxed text-neutral-500">
+        Which transition goes where is just config — browse them in{" "}
+        <Link
+          href="/docs/transitions"
+          className="text-neutral-300 underline decoration-white/20 underline-offset-4 transition-colors hover:text-orange-400 hover:decoration-orange-400/60"
+        >
+          Transitions
+        </Link>
+        . If a transition ever looks off, the cause is almost always the wrapper
+        — see{" "}
+        <Link
+          href="/docs/layout"
+          className="text-neutral-300 underline decoration-white/20 underline-offset-4 transition-colors hover:text-orange-400 hover:decoration-orange-400/60"
+        >
+          Layout
+        </Link>{" "}
+        and{" "}
+        <Link
+          href="/docs/how-it-works"
+          className="text-neutral-300 underline decoration-white/20 underline-offset-4 transition-colors hover:text-orange-400 hover:decoration-orange-400/60"
+        >
+          How it works
+        </Link>
+        .
+      </p>
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Install — why the DOM structure                                            */
+/* -------------------------------------------------------------------------- */
+
+function WhyStructure() {
+  return (
+    <div className="mt-10 rounded-2xl border border-white/[0.06] bg-white/[0.015] p-6">
+      <p className="font-mono text-xs uppercase tracking-[0.18em] text-orange-500/80">
+        Why this shape
+      </p>
+      <h3 className="mt-3 text-base font-semibold tracking-tight text-neutral-100">
+        The wrapper classes aren&apos;t decoration
+      </h3>
+      <p className="mt-3 max-w-xl text-sm leading-relaxed text-neutral-400">
+        When you navigate, the framework unmounts the leaving page. SSGOI clones
+        it back into the DOM with{" "}
+        <code className="font-mono text-neutral-200">position: absolute</code>{" "}
+        so its exit animation can play <em>over</em> the incoming page. An
+        absolutely-positioned clone needs the right ancestor, or it jumps and
+        flickers — that&apos;s what these three classes on the layout shell are
+        for:
+      </p>
+
+      <ul className="mt-5 divide-y divide-white/[0.05] border-y border-white/[0.05]">
+        {LAYOUT_CLASSES.map(({ cls, why }) => (
+          <li
+            key={cls}
+            className="flex flex-col gap-1.5 py-3 md:flex-row md:items-baseline md:gap-5"
+          >
+            <code className="shrink-0 font-mono text-sm font-semibold text-orange-400">
+              {cls}
+            </code>
+            <span className="text-sm leading-relaxed text-neutral-400">
+              {why}
+            </span>
+          </li>
+        ))}
+      </ul>
+
+      <p className="mt-5 max-w-xl text-sm leading-relaxed text-neutral-500">
+        These belong on the outer layout shell that wraps{" "}
+        <code className="font-mono text-neutral-300">&lt;Ssgoi&gt;</code>, not
+        on the route marker. Full walkthrough in{" "}
+        <Link
+          href="/docs/layout"
+          className="text-neutral-300 underline decoration-white/20 underline-offset-4 transition-colors hover:text-orange-400 hover:decoration-orange-400/60"
+        >
+          Layout
+        </Link>{" "}
+        and{" "}
+        <Link
+          href="/docs/how-it-works"
+          className="text-neutral-300 underline decoration-white/20 underline-offset-4 transition-colors hover:text-orange-400 hover:decoration-orange-400/60"
+        >
+          How it works
+        </Link>
+        .
+      </p>
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Install — non-React route boundary                                         */
+/* -------------------------------------------------------------------------- */
+
+function NonReactBoundary() {
+  return (
+    <div className="mt-12 border-t border-white/[0.06] pt-10">
+      <p className="font-mono text-xs uppercase tracking-[0.18em] text-orange-500/80">
+        Svelte · Vue · Solid · Angular
+      </p>
+      <h3 className="mt-3 text-base font-semibold tracking-tight text-neutral-100">
+        Mark each routed page directly
+      </h3>
+      <p className="mt-3 max-w-xl text-sm leading-relaxed text-neutral-400">
+        Outside React, skip the boundary utility and put{" "}
+        <code className="font-mono text-neutral-200">
+          data-ssgoi-transition
+        </code>{" "}
+        right on each routed page. The value is a stable logical page id — it
+        does <em>not</em> have to be the framework&apos;s route pathname; it
+        only has to match the{" "}
+        <code className="font-mono text-neutral-200">from</code>/
+        <code className="font-mono text-neutral-200">to</code>/
+        <code className="font-mono text-neutral-200">paths</code> values in your
+        config.
+      </p>
+
+      <CodeBlock
+        className="mt-5"
+        language="xml"
+        code={`<!-- SvelteKit · src/routes/gallery/+page.svelte -->
+<main data-ssgoi-transition="/gallery">
+  <!-- page content -->
+</main>
+
+<!-- Nuxt / Vue · pages/gallery.vue -->
+<template>
+  <main data-ssgoi-transition="/gallery">
+    <!-- page content -->
+  </main>
+</template>
+
+<!-- Angular · gallery.component.html -->
+<section data-ssgoi-transition="/gallery">
+  <!-- page content -->
+</section>`}
+      />
+
+      <p className="mt-5 max-w-xl text-sm leading-relaxed text-neutral-500">
+        <span className="text-neutral-300">Why not one shared boundary?</span>{" "}
+        SvelteKit and Nuxt render slot/snippet content live, so a single route
+        boundary in a parent layout would let the outgoing page wrapper render
+        the <em>incoming</em> page&apos;s children mid-navigation. Marking each
+        page directly keeps the outgoing and incoming boundaries cleanly
+        separated. (React&apos;s utility sidesteps this by keying the subtree on
+        the pathname.)
+      </p>
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Install — reference templates                                              */
+/* -------------------------------------------------------------------------- */
+
+function ReferenceTemplates() {
+  return (
+    <div className="mt-12 border-t border-white/[0.06] pt-10">
+      <p className="font-mono text-xs uppercase tracking-[0.18em] text-orange-500/80">
+        Copy from a working app
+      </p>
+      <h2 className="mt-3 text-xl font-semibold tracking-tight text-neutral-100">
+        Reference templates
+      </h2>
+      <p className="mt-3 max-w-xl text-sm leading-relaxed text-neutral-400">
+        Each template is a runnable app wired up the recommended way for its
+        router — provider, layout shell, and route boundaries already in place.
+        Clone one and read the diff, or copy the pieces you need.
+      </p>
+      <RoutersBody />
+      <p className="mt-6 text-sm text-neutral-500">
+        Source lives in the monorepo at{" "}
+        <a
+          href="https://github.com/meursyphus/ssgoi/tree/main/templates"
+          target="_blank"
+          rel="noreferrer"
+          className="font-mono text-neutral-300 underline decoration-white/20 underline-offset-4 transition-colors hover:text-orange-400 hover:decoration-orange-400/60"
+        >
+          meursyphus/ssgoi/templates ↗
+        </a>
+        .
+      </p>
     </div>
   );
 }
@@ -440,12 +669,21 @@ function FlowStep({ n, body }: { n: string; body: string }) {
 const ROUTERS: Array<{
   name: string;
   icon: React.ComponentType<{ className?: string }>;
+  templatePath: string;
 }> = [
-  { name: "Next.js", icon: NextMark },
-  { name: "React Router", icon: ReactRouterMark },
-  { name: "TanStack Router", icon: TanStackRouterMark },
-  { name: "SvelteKit", icon: SvelteKitMark },
-  { name: "Nuxt", icon: NuxtMark },
+  { name: "Next.js", icon: NextMark, templatePath: "nextjs" },
+  {
+    name: "React Router",
+    icon: ReactRouterMark,
+    templatePath: "react-router",
+  },
+  {
+    name: "TanStack Router",
+    icon: TanStackRouterMark,
+    templatePath: "tanstack-router",
+  },
+  { name: "SvelteKit", icon: SvelteKitMark, templatePath: "sveltekit" },
+  { name: "Nuxt", icon: NuxtMark, templatePath: "nuxt" },
 ];
 
 const TEMPLATES_URL = "https://github.com/meursyphus/ssgoi/tree/main/templates";
@@ -454,20 +692,30 @@ export function RoutersBody() {
   return (
     <div className="mt-8">
       <div className="grid gap-3 sm:grid-cols-2">
-        {ROUTERS.map(({ name, icon: Icon }) => (
-          <div
+        {ROUTERS.map(({ name, icon: Icon, templatePath }) => (
+          <a
             key={name}
+            href={`${TEMPLATES_URL}/${templatePath}`}
+            target="_blank"
+            rel="noreferrer"
             className="flex items-center gap-4 rounded-xl border border-white/[0.06] bg-white/[0.015] p-5 transition-colors hover:border-white/15 hover:bg-white/[0.04]"
           >
             <Icon className="h-8 w-8 shrink-0" />
-            <span className="text-base font-semibold tracking-tight text-neutral-100">
-              {name}
+            <span className="min-w-0 flex-1">
+              <span className="block text-base font-semibold tracking-tight text-neutral-100">
+                {name}
+              </span>
+              <span className="mt-1 block font-mono text-xs text-neutral-500">
+                templates/{templatePath} ↗
+              </span>
             </span>
-          </div>
+          </a>
         ))}
       </div>
       <p className="mt-6 text-sm text-neutral-400">
-        Starter examples for each router are on GitHub —{" "}
+        These examples show the recommended framework-specific setup. React
+        templates use the pathname boundary utility; SvelteKit and Nuxt mark
+        routed pages directly. Full templates index:{" "}
         <a
           href={TEMPLATES_URL}
           target="_blank"

--- a/apps/docs/src/page/landing/index.tsx
+++ b/apps/docs/src/page/landing/index.tsx
@@ -21,7 +21,7 @@ const demoItemListSchema = {
 
 export default function HomePage() {
   return (
-    <main data-ssgoi-transition="/" className="relative min-h-dvh bg-black">
+    <main className="relative min-h-dvh bg-black">
       <JsonLd data={[softwareApplicationSchema, demoItemListSchema]} />
       <SiteNav />
       <Hero />

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -42,11 +42,12 @@ npm install @ssgoi/react
 
 ### Add Transitions in 30 Seconds
 
-#### 1. Wrap your app
+#### 1. Wrap your React app
 
 ```tsx
 import { Ssgoi } from "@ssgoi/react";
 import { fade } from "@ssgoi/react/view-transitions";
+import { SsgoiTransitionBoundary } from "./ssgoi-transition-boundary";
 
 const config = {
   transitions: [fade({ paths: ["/", "/about"] })],
@@ -54,26 +55,76 @@ const config = {
 
 export default function App() {
   return (
-    <Ssgoi config={config}>
-      {/* relative + z-0: the outgoing page is cloned with position:absolute */}
-      <div className="relative z-0">{/* Your app */}</div>
-    </Ssgoi>
+    <div className="relative z-0 min-h-dvh bg-white">
+      {/* Layout shell above: positioned ancestor + stacking context for the OUT clone. */}
+      <Ssgoi config={config}>
+        {/* Routed content marker. Layout positioning belongs to the outer wrapper. */}
+        <SsgoiTransitionBoundary className="min-h-full bg-white">
+          {/* Your app */}
+        </SsgoiTransitionBoundary>
+      </Ssgoi>
+    </div>
   );
 }
 ```
 
-#### 2. Mark your pages
+#### 2. Keep React pages unmarked
 
 ```tsx
 export default function HomePage() {
   return (
-    <main data-ssgoi-transition="/">
+    <main>
       <h1>Welcome</h1>
       {/* Page content */}
     </main>
   );
 }
 ```
+
+For React adapters, create one router-specific `SsgoiTransitionBoundary` utility
+in your layout. It reads the current pathname internally, sets the transition
+boundary key, and uses that pathname as a logical page id matched by config such
+as `/products/*`. Use `/products/**` when the parent path itself should match
+too.
+
+Next.js implementation:
+
+```tsx
+"use client";
+
+import { type ElementType, type ReactNode } from "react";
+import { usePathname } from "next/navigation";
+
+export function SsgoiTransitionBoundary({
+  children,
+  as,
+  className,
+}: {
+  children: ReactNode;
+  as?: ElementType;
+  className?: string;
+}) {
+  const pathname = usePathname();
+  const Component = as ?? "div";
+
+  return (
+    <Component
+      key={pathname}
+      data-ssgoi-transition={pathname}
+      className={className}
+    >
+      {children}
+    </Component>
+  );
+}
+```
+
+React Router and TanStack Router use the same component body with their own
+pathname hook.
+
+For SvelteKit, Nuxt/Vue, Solid, and Angular, mark each routed page boundary
+directly with `data-ssgoi-transition` instead of using a layout-level utility.
+The value can be a hard-coded logical id; it only has to match your config.
 
 **That's it!** Your configured pages now transition smoothly with a fade effect.
 
@@ -161,9 +212,15 @@ For mount/unmount of individual elements (not whole pages):
 
 ## Layout Requirements
 
-The element wrapping `<Ssgoi>` needs `position: relative` and `z-index: 0`.
+The outer element wrapping the SSGOI provider / `<Ssgoi>` needs
+`position: relative` and `z-index: 0`.
 
-When a page leaves, SSGOI clones it back into the DOM with `position: absolute` so it can animate out while the new page animates in. Without a positioned, stacking-context ancestor the clone jumps to the wrong place or falls behind the background. Add `overflow-x-clip` too if you use horizontal transitions (`slide`, `drill`).
+When a page leaves, SSGOI clones it back into the DOM with `position: absolute`
+so it can animate out while the new page animates in. Without a positioned,
+stacking-context ancestor the clone jumps to the wrong place or falls behind the
+background. Add `overflow-x-clip` too if you use horizontal transitions
+(`slide`, `drill`). Keep these layout classes on the outer wrapper, not on the
+route boundary marker.
 
 ```tsx
 <div className="relative z-0 overflow-x-clip">

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/core",
-  "version": "6.6.1",
+  "version": "6.6.2",
   "description": "Core animation engine for SSGOI - Native app-like page transitions with spring physics",
   "private": false,
   "type": "module",

--- a/packages/core/src/lib/ssgoi-transition/find-matching-transition.test.ts
+++ b/packages/core/src/lib/ssgoi-transition/find-matching-transition.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+import type { TransitionConfig } from "@types";
+import { findMatchingTransition, matchPath } from "./find-matching-transition";
+
+function transition(id: string): TransitionConfig {
+  return { animation: (() => id) as unknown as TransitionConfig["animation"] };
+}
+
+describe("matchPath", () => {
+  it("normalizes query, hash, leading slash, and trailing slash", () => {
+    expect(matchPath("posts/1?sort=top#comments", "/posts/*")).toBe(true);
+    expect(matchPath("/posts/1/", "posts/:id")).toBe(true);
+    expect(matchPath("/", "")).toBe(true);
+  });
+
+  it("supports global, prefix, and segment wildcards", () => {
+    expect(matchPath("/anything", "*")).toBe(true);
+    expect(matchPath("/products/123", "/products/*")).toBe(true);
+    expect(matchPath("/products", "/products/*")).toBe(false);
+    expect(matchPath("/products/123", "/products/:id")).toBe(true);
+    expect(matchPath("/products/123", "/products/[id]")).toBe(true);
+    expect(matchPath("/products/123", "/products/{id}")).toBe(true);
+    expect(matchPath("/products/123/reviews", "/products/:id")).toBe(false);
+  });
+
+  it("supports deep wildcard suffixes that include the prefix path", () => {
+    expect(matchPath("/", "/**")).toBe(true);
+    expect(matchPath("/products", "/products/**")).toBe(true);
+    expect(matchPath("/products/123", "/products/**")).toBe(true);
+    expect(matchPath("/products/123/reviews", "/products/**")).toBe(true);
+    expect(matchPath("/productivity", "/products/**")).toBe(false);
+    expect(matchPath("/products", "/products/*")).toBe(false);
+  });
+});
+
+describe("findMatchingTransition", () => {
+  it("chooses exact matches over wildcard matches", () => {
+    const fallback = transition("fallback");
+    const exact = transition("exact");
+
+    expect(
+      findMatchingTransition("/posts", "/posts/1", [
+        { from: "*", to: "*", transition: fallback },
+        { from: "/posts", to: "/posts/1", transition: exact },
+      ]),
+    ).toBe(exact);
+  });
+
+  it("chooses the most specific wildcard match", () => {
+    const broad = transition("broad");
+    const specific = transition("specific");
+
+    expect(
+      findMatchingTransition("/demo/google-photos", "/demo/google-photos/p/1", [
+        {
+          from: "/demo/google-photos/*",
+          to: "/demo/google-photos/*",
+          transition: broad,
+        },
+        {
+          from: "/demo/google-photos",
+          to: "/demo/google-photos/p/*",
+          transition: specific,
+        },
+      ]),
+    ).toBe(specific);
+  });
+
+  it("chooses an exact match over a deep wildcard that also matches", () => {
+    const deep = transition("deep");
+    const exact = transition("exact");
+
+    expect(
+      findMatchingTransition("/docs/install", "/docs", [
+        { from: "/docs/**", to: "/docs/**", transition: deep },
+        { from: "/docs/install", to: "/docs", transition: exact },
+      ]),
+    ).toBe(exact);
+  });
+
+  it("keeps config order as the tie-breaker for equal specificity", () => {
+    const first = transition("first");
+    const second = transition("second");
+
+    expect(
+      findMatchingTransition("/profile/1", "/profile/1/reels", [
+        { from: "/profile/:id", to: "/profile/:id/reels", transition: first },
+        {
+          from: "/profile/{id}",
+          to: "/profile/{id}/reels",
+          transition: second,
+        },
+      ]),
+    ).toBe(first);
+  });
+});

--- a/packages/core/src/lib/ssgoi-transition/find-matching-transition.ts
+++ b/packages/core/src/lib/ssgoi-transition/find-matching-transition.ts
@@ -1,37 +1,153 @@
 import type { TransitionConfig } from "@types";
 
+type PathMatch = {
+  matched: boolean;
+  specificity: number;
+};
+
+const EXACT_MATCH_BONUS = 1_000_000;
+const STATIC_SEGMENT_SCORE = 100;
+const DYNAMIC_SEGMENT_SCORE = 10;
+
+function stripQueryAndHash(path: string): string {
+  const trimmed = path.trim();
+  const hashIndex = trimmed.indexOf("#");
+  const queryIndex = trimmed.indexOf("?");
+  const cutIndex = [hashIndex, queryIndex]
+    .filter((index) => index >= 0)
+    .reduce((min, index) => Math.min(min, index), trimmed.length);
+
+  return trimmed.slice(0, cutIndex);
+}
+
+function normalizePath(path: string): string {
+  const stripped = stripQueryAndHash(path);
+
+  try {
+    if (/^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(stripped)) {
+      return normalizePath(new URL(stripped).pathname);
+    }
+  } catch {
+    // Fall through and treat it as a path-like value.
+  }
+
+  const withLeadingSlash = stripped.startsWith("/") ? stripped : `/${stripped}`;
+  const collapsed = withLeadingSlash.replace(/\/+/g, "/");
+  const withoutTrailingSlash =
+    collapsed.length > 1 ? collapsed.replace(/\/+$/g, "") : collapsed;
+
+  return withoutTrailingSlash || "/";
+}
+
+function normalizePattern(pattern: string): string {
+  const trimmed = pattern.trim();
+  if (trimmed === "*") return "*";
+  return normalizePath(trimmed);
+}
+
+function splitSegments(path: string): string[] {
+  if (path === "/") return [];
+  return path.slice(1).split("/");
+}
+
+function isDynamicSegment(segment: string): boolean {
+  return (
+    segment.startsWith(":") ||
+    (segment.startsWith("[") && segment.endsWith("]")) ||
+    (segment.startsWith("{") && segment.endsWith("}"))
+  );
+}
+
+function getPathMatch(path: string, pattern: string): PathMatch {
+  const normalizedPath = normalizePath(path);
+  const normalizedPattern = normalizePattern(pattern);
+
+  if (normalizedPattern === "*") {
+    return { matched: true, specificity: 0 };
+  }
+
+  if (normalizedPath === normalizedPattern) {
+    return {
+      matched: true,
+      specificity:
+        EXACT_MATCH_BONUS +
+        splitSegments(normalizedPattern).length * STATIC_SEGMENT_SCORE,
+    };
+  }
+
+  const pathSegments = splitSegments(normalizedPath);
+  const patternSegments = splitSegments(normalizedPattern);
+  let specificity = 0;
+
+  for (let index = 0; index < patternSegments.length; index++) {
+    const patternSegment = patternSegments[index];
+    const pathSegment = pathSegments[index];
+    const isLastPatternSegment = index === patternSegments.length - 1;
+
+    if (patternSegment === undefined) {
+      return { matched: false, specificity: 0 };
+    }
+
+    if (
+      (patternSegment === "*" || patternSegment === "**") &&
+      isLastPatternSegment
+    ) {
+      return {
+        matched:
+          patternSegment === "**"
+            ? pathSegments.length >= index
+            : pathSegments.length > index,
+        specificity,
+      };
+    }
+
+    if (pathSegment === undefined) {
+      return { matched: false, specificity: 0 };
+    }
+
+    if (patternSegment === "*" || isDynamicSegment(patternSegment)) {
+      specificity += DYNAMIC_SEGMENT_SCORE;
+      continue;
+    }
+
+    if (patternSegment !== pathSegment) {
+      return { matched: false, specificity: 0 };
+    }
+
+    specificity += STATIC_SEGMENT_SCORE;
+  }
+
+  return {
+    matched: pathSegments.length === patternSegments.length,
+    specificity,
+  };
+}
+
 /**
  * Matches a path against a pattern
- * Supports exact matches and wildcard patterns
+ * Supports exact matches, wildcard patterns, and common route segment params
  *
  * @example
  * matchPath('/products', '/products') // true
  * matchPath('/products/123', '/products/*') // true
+ * matchPath('/products', '/products/**') // true
+ * matchPath('/products/123/reviews', '/products/**') // true
+ * matchPath('/products/123', '/products/:id') // true
+ * matchPath('/products/123', '/products/[id]') // true
+ * matchPath('/products/123', '/products/{id}') // true
  * matchPath('/products/123', '/products') // false
  * matchPath('/anything', '*') // true
  */
 export function matchPath(path: string, pattern: string): boolean {
-  // Universal match - asterisk matches any path
-  if (pattern === "*") {
-    return true;
-  }
-
-  // Wildcard match - pattern ending with /* matches only subpaths (not the prefix itself)
-  // e.g., "/posts/*" matches "/posts/123" but NOT "/posts" or "/posts/"
-  if (pattern.endsWith("/*")) {
-    const prefix = pattern.slice(0, -1); // "/posts/"
-    return path.startsWith(prefix) && path.length > prefix.length;
-  }
-
-  // Exact match - paths must be identical
-  return path === pattern;
+  return getPathMatch(path, pattern).matched;
 }
 
 /**
  * Finds a matching transition configuration for the given from and to paths
  *
- * First tries to find exact match for both from and to paths,
- * then falls back to wildcard matches if no exact match is found.
+ * Chooses the most specific matching config. Exact paths outrank wildcard
+ * paths, deeper static wildcard prefixes outrank broader fallbacks, and equal
+ * specificity preserves the original config order.
  */
 export function findMatchingTransition(
   from: string,
@@ -42,22 +158,25 @@ export function findMatchingTransition(
     transition: TransitionConfig;
   }>,
 ): TransitionConfig | null {
-  // First try to find exact match for both from and to paths
+  let best:
+    | {
+        transition: TransitionConfig;
+        specificity: number;
+      }
+    | undefined;
+
   for (const config of transitions) {
-    if (matchPath(from, config.from) && matchPath(to, config.to)) {
-      return config.transition;
+    const fromMatch = getPathMatch(from, config.from);
+    if (!fromMatch.matched) continue;
+
+    const toMatch = getPathMatch(to, config.to);
+    if (!toMatch.matched) continue;
+
+    const specificity = fromMatch.specificity + toMatch.specificity;
+    if (!best || specificity > best.specificity) {
+      best = { transition: config.transition, specificity };
     }
   }
 
-  // Then try wildcard matches if no exact match found
-  for (const config of transitions) {
-    if (
-      (config.from === "*" || matchPath(from, config.from)) &&
-      (config.to === "*" || matchPath(to, config.to))
-    ) {
-      return config.transition;
-    }
-  }
-
-  return null;
+  return best?.transition ?? null;
 }

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -45,6 +45,7 @@ pnpm add @ssgoi/react
 ```tsx
 import { Ssgoi } from "@ssgoi/react";
 import { fade } from "@ssgoi/react/view-transitions";
+import { SsgoiTransitionBoundary } from "./ssgoi-transition-boundary";
 
 const config = {
   transitions: [fade({ paths: ["/", "/about"] })],
@@ -52,20 +53,25 @@ const config = {
 
 export default function App() {
   return (
-    <Ssgoi config={config}>
-      {/* relative + z-0 are required (see "Layout Requirements" below) */}
-      <div className="relative z-0">{/* Your app */}</div>
-    </Ssgoi>
+    <div className="relative z-0 min-h-dvh bg-white">
+      {/* Layout shell above: positioned ancestor + stacking context for the OUT clone. */}
+      <Ssgoi config={config}>
+        {/* Routed content marker. Layout positioning belongs to the outer wrapper. */}
+        <SsgoiTransitionBoundary className="min-h-full bg-white">
+          {/* Your app */}
+        </SsgoiTransitionBoundary>
+      </Ssgoi>
+    </div>
   );
 }
 ```
 
-### 2. Mark your pages
+### 2. Keep pages unmarked
 
 ```tsx
 export default function HomePage() {
   return (
-    <main data-ssgoi-transition="/">
+    <main>
       <h1>Welcome</h1>
       {/* Page content */}
     </main>
@@ -73,13 +79,59 @@ export default function HomePage() {
 }
 ```
 
+Create one router-specific `SsgoiTransitionBoundary` utility in your layout.
+It reads the current pathname internally, sets the transition boundary key, and
+uses that pathname as a logical page id matched by config such as
+`/products/*`. Use `/products/**` when the parent path itself should match too.
+
+Next.js implementation:
+
+```tsx
+"use client";
+
+import { type ElementType, type ReactNode } from "react";
+import { usePathname } from "next/navigation";
+
+export function SsgoiTransitionBoundary({
+  children,
+  as,
+  className,
+}: {
+  children: ReactNode;
+  as?: ElementType;
+  className?: string;
+}) {
+  const pathname = usePathname();
+  const Component = as ?? "div";
+
+  return (
+    <Component
+      key={pathname}
+      data-ssgoi-transition={pathname}
+      className={className}
+    >
+      {children}
+    </Component>
+  );
+}
+```
+
+React Router and TanStack Router use the same component body with their own
+pathname hook.
+
 **That's it!** Your configured pages now transition smoothly with a fade effect.
 
 ## Layout Requirements
 
-The element wrapping `<Ssgoi>` needs `position: relative` and `z-index: 0` (`relative z-0` in Tailwind).
+The outer element wrapping the SSGOI provider / `<Ssgoi>` needs
+`position: relative` and `z-index: 0` (`relative z-0` in Tailwind).
 
-When a page leaves, SSGOI clones it back into the DOM with `position: absolute` so it can animate out while the new page animates in. Without a positioned, stacking-context ancestor the clone jumps to the wrong place or falls behind the background. Add `overflow-x-clip` too if you use horizontal transitions (`slide`, `drill`).
+When a page leaves, SSGOI clones it back into the DOM with `position: absolute`
+so it can animate out while the new page animates in. Without a positioned,
+stacking-context ancestor the clone jumps to the wrong place or falls behind the
+background. Add `overflow-x-clip` too if you use horizontal transitions
+(`slide`, `drill`). Keep these layout classes on the outer wrapper, not on the
+route boundary marker.
 
 ## Advanced Transitions
 
@@ -233,9 +285,13 @@ function List() {
 ## Next.js App Router Example
 
 ```tsx
-// app/layout.tsx
+// app/ssgoi-provider.tsx
+"use client";
+
+import { type ReactNode } from "react";
 import { Ssgoi } from "@ssgoi/react";
 import { drill, fade } from "@ssgoi/react/view-transitions";
+import { SsgoiTransitionBoundary } from "./ssgoi-transition-boundary";
 
 const config = {
   transitions: [
@@ -244,17 +300,27 @@ const config = {
   ],
 };
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export function SsgoiProvider({ children }: { children: ReactNode }) {
+  return (
+    <Ssgoi config={config}>
+      <SsgoiTransitionBoundary className="min-h-full bg-white">
+        {children}
+      </SsgoiTransitionBoundary>
+    </Ssgoi>
+  );
+}
+
+// app/layout.tsx
+import { type ReactNode } from "react";
+import { SsgoiProvider } from "./ssgoi-provider";
+
+export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html>
       <body>
-        <Ssgoi config={config}>
-          <div className="relative z-0 min-h-screen">{children}</div>
-        </Ssgoi>
+        <main className="relative z-0 min-h-screen bg-white">
+          <SsgoiProvider>{children}</SsgoiProvider>
+        </main>
       </body>
     </html>
   );
@@ -264,7 +330,7 @@ export default function RootLayout({
 ```tsx
 // app/page.tsx
 export default function Page() {
-  return <main data-ssgoi-transition="/">{/* Your page content */}</main>;
+  return <main>{/* Your page content */}</main>;
 }
 ```
 
@@ -280,13 +346,16 @@ The provider component that manages transition context.
 <Ssgoi config={ssgoiConfig}>{children}</Ssgoi>
 ```
 
-#### `data-ssgoi-transition`
+#### Route boundary
 
-Attribute for pages that should transition. Set it on the page boundary element
-inside `<Ssgoi>`.
+Use one route boundary utility inside `<Ssgoi>`. It sets
+`data-ssgoi-transition` from the current pathname internally, so individual page
+components do not need transition markers.
 
 ```tsx
-<main data-ssgoi-transition="/page-id">{children}</main>
+<SsgoiTransitionBoundary className="min-h-full bg-white">
+  {children}
+</SsgoiTransitionBoundary>
 ```
 
 ### Hooks

--- a/templates/nextjs/README.md
+++ b/templates/nextjs/README.md
@@ -1,36 +1,67 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# SSGOI + Next.js Template
+
+This template demonstrates SSGOI page transitions with the Next.js App Router.
 
 ## Getting Started
 
-First, run the development server:
-
 ```bash
-npm run dev
-# or
-yarn dev
-# or
+pnpm install
 pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open http://localhost:3000 to view the demo.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Features
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+- **Drill Transition**: Posts list-to-detail navigation
+- **Slide Transition**: Product category tabs with nested `Ssgoi`
+- **Zoom Expand Transition**: Gallery grid-to-detail shared image animation
+- **Zoom Static Transition**: Profile feed-to-detail shared image animation
+- **Scroll Preservation**: Keeps scroll state where configured
 
-## Learn More
+## Integration
 
-To learn more about Next.js, take a look at the following resources:
+The main provider lives in `src/components/demo-layout.tsx`:
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+```tsx
+import { Ssgoi } from "@ssgoi/react";
+import { drill, zoom } from "@ssgoi/react/view-transitions";
+import { SsgoiTransitionBoundary } from "./ssgoi-transition-boundary";
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+const config = {
+  preserveScroll: { exclude: ["/posts/*"] },
+  transitions: [
+    drill({ enter: "/posts/*", exit: "/posts" }),
+    zoom({ paths: ["/pinterest", "/pinterest/*"], type: "expand" }),
+    zoom({ paths: ["/profile", "/profile/*"], type: "static" }),
+  ],
+};
 
-## Deploy on Vercel
+export default function DemoLayout({ children }) {
+  return (
+    <Ssgoi config={config}>
+      <SsgoiTransitionBoundary className="min-h-full bg-[#121212]">
+        {children}
+      </SsgoiTransitionBoundary>
+    </Ssgoi>
+  );
+}
+```
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+Page components do not set `data-ssgoi-transition` themselves. Dynamic routes
+stay as real pathnames and are matched by wildcard patterns in config. Use
+`/posts/*` for descendants and `/posts/**` when the parent path should match
+too.
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+```tsx
+export default function PostsPage() {
+  return <main>{/* Page content */}</main>;
+}
+```
+
+## Build
+
+```bash
+pnpm lint
+pnpm build
+```

--- a/templates/nextjs/src/app/products/all/page.tsx
+++ b/templates/nextjs/src/app/products/all/page.tsx
@@ -2,5 +2,5 @@ import ProductGrid from "@/components/products/product-grid";
 import { products } from "@/components/products/mock-data";
 
 export default function AllProductsPage() {
-  return <ProductGrid products={products} category="all" />;
+  return <ProductGrid products={products} />;
 }

--- a/templates/nextjs/src/app/products/beauty/page.tsx
+++ b/templates/nextjs/src/app/products/beauty/page.tsx
@@ -3,5 +3,5 @@ import { products } from "@/components/products/mock-data";
 
 export default function BeautyPage() {
   const filtered = products.filter((p) => p.category === "Beauty");
-  return <ProductGrid products={filtered} category="beauty" />;
+  return <ProductGrid products={filtered} />;
 }

--- a/templates/nextjs/src/app/products/electronics/page.tsx
+++ b/templates/nextjs/src/app/products/electronics/page.tsx
@@ -3,5 +3,5 @@ import { products } from "@/components/products/mock-data";
 
 export default function ElectronicsPage() {
   const filtered = products.filter((p) => p.category === "Electronics");
-  return <ProductGrid products={filtered} category="electronics" />;
+  return <ProductGrid products={filtered} />;
 }

--- a/templates/nextjs/src/app/products/fashion/page.tsx
+++ b/templates/nextjs/src/app/products/fashion/page.tsx
@@ -3,5 +3,5 @@ import { products } from "@/components/products/mock-data";
 
 export default function FashionPage() {
   const filtered = products.filter((p) => p.category === "Fashion");
-  return <ProductGrid products={filtered} category="fashion" />;
+  return <ProductGrid products={filtered} />;
 }

--- a/templates/nextjs/src/app/products/home/page.tsx
+++ b/templates/nextjs/src/app/products/home/page.tsx
@@ -3,5 +3,5 @@ import { products } from "@/components/products/mock-data";
 
 export default function HomeProductsPage() {
   const filtered = products.filter((p) => p.category === "Home");
-  return <ProductGrid products={filtered} category="home" />;
+  return <ProductGrid products={filtered} />;
 }

--- a/templates/nextjs/src/app/products/layout.tsx
+++ b/templates/nextjs/src/app/products/layout.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Ssgoi } from "@ssgoi/react";
 import { slide } from "@ssgoi/react/view-transitions";
+import { SsgoiTransitionBoundary } from "@/components/ssgoi-transition-boundary";
 const categories = [
   {
     id: "all",
@@ -49,10 +50,7 @@ export default function ProductsLayout({
     [],
   );
   return (
-    <div
-      data-ssgoi-transition="/products"
-      className="min-h-screen bg-[#121212] flex flex-col"
-    >
+    <div className="min-h-screen bg-[#121212] flex flex-col">
       {/* Header - Fixed */}
       <div className="px-4 pt-6 pb-3 flex-shrink-0">
         <h1 className="text-sm font-medium text-white mb-1">Shop</h1>
@@ -78,7 +76,11 @@ export default function ProductsLayout({
 
       {/* Tab Content - Slide transitions here */}
       <div className="flex-1 overflow-hidden relative">
-        <Ssgoi config={config}>{children}</Ssgoi>
+        <Ssgoi config={config}>
+          <SsgoiTransitionBoundary className="min-h-full bg-[#121212]">
+            {children}
+          </SsgoiTransitionBoundary>
+        </Ssgoi>
       </div>
     </div>
   );

--- a/templates/nextjs/src/components/demo-layout.tsx
+++ b/templates/nextjs/src/components/demo-layout.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { Ssgoi } from "@ssgoi/react";
 import { drill, zoom } from "@ssgoi/react/view-transitions";
+import { SsgoiTransitionBoundary } from "./ssgoi-transition-boundary";
 
 interface DemoLayoutProps {
   children: React.ReactNode;
@@ -46,7 +47,11 @@ export default function DemoLayout({ children }: DemoLayoutProps) {
           id="demo-content"
           className="flex-1 w-full overflow-y-scroll overflow-x-hidden relative z-0 bg-[#121212] scrollbar-hide"
         >
-          <Ssgoi config={config}>{children}</Ssgoi>
+          <Ssgoi config={config}>
+            <SsgoiTransitionBoundary className="min-h-full bg-[#121212]">
+              {children}
+            </SsgoiTransitionBoundary>
+          </Ssgoi>
         </main>
 
         {/* Bottom Navigation */}

--- a/templates/nextjs/src/components/pinterest/detail.tsx
+++ b/templates/nextjs/src/components/pinterest/detail.tsx
@@ -10,7 +10,7 @@ export default function PinterestDetail({ pinId }: PinterestDetailProps) {
   const item = getPinterestItem(pinId);
   if (!item) {
     return (
-      <div data-ssgoi-transition={`/pinterest/${pinId}`}>
+      <div>
         <div className="min-h-screen bg-[#121212] px-4 py-8">
           <p className="text-gray-400">Pin not found</p>
         </div>
@@ -18,7 +18,7 @@ export default function PinterestDetail({ pinId }: PinterestDetailProps) {
     );
   }
   return (
-    <div data-ssgoi-transition={`/pinterest/${pinId}`}>
+    <div>
       <div className="min-h-screen bg-[#121212]">
         {/* Back button */}
         <div className="px-4 py-4">

--- a/templates/nextjs/src/components/pinterest/index.tsx
+++ b/templates/nextjs/src/components/pinterest/index.tsx
@@ -8,7 +8,7 @@ export default function PinterestDemo() {
   const leftColumnItems = pinterestItems.filter((_, index) => index % 2 === 0);
   const rightColumnItems = pinterestItems.filter((_, index) => index % 2 === 1);
   return (
-    <div data-ssgoi-transition="/pinterest">
+    <div>
       <div className="min-h-screen bg-[#121212] px-4 py-6">
         {/* Header */}
         <div className="mb-6">

--- a/templates/nextjs/src/components/posts/detail.tsx
+++ b/templates/nextjs/src/components/posts/detail.tsx
@@ -13,7 +13,7 @@ export default function PostDetail({ postId }: PostDetailProps) {
   const relatedPosts = getRelatedPosts(postId, 3);
   if (!post) {
     return (
-      <div data-ssgoi-transition={`/posts/${postId}`}>
+      <div>
         <div className="min-h-screen bg-[#121212] px-4 py-8">
           <p className="text-gray-400">Post not found</p>
         </div>
@@ -74,7 +74,7 @@ export default function PostDetail({ postId }: PostDetailProps) {
     hr: () => <hr className="border-white/5 my-6" />,
   };
   return (
-    <div data-ssgoi-transition={`/posts/${postId}`}>
+    <div>
       <div className="min-h-screen bg-[#121212]">
         {/* Back button */}
         <div className="px-4 py-4">

--- a/templates/nextjs/src/components/posts/index.tsx
+++ b/templates/nextjs/src/components/posts/index.tsx
@@ -6,7 +6,7 @@ import { getAllPosts } from "./mock-data";
 export default function PostsDemo() {
   const posts = getAllPosts();
   return (
-    <div data-ssgoi-transition="/posts">
+    <div>
       <div className="min-h-full bg-[#121212] px-4 py-6">
         {/* Header */}
         <div className="mb-6">

--- a/templates/nextjs/src/components/products/product-grid.tsx
+++ b/templates/nextjs/src/components/products/product-grid.tsx
@@ -4,11 +4,10 @@ import React from "react";
 import { Product } from "./mock-data";
 interface ProductGridProps {
   products: Product[];
-  category: string;
 }
-export default function ProductGrid({ products, category }: ProductGridProps) {
+export default function ProductGrid({ products }: ProductGridProps) {
   return (
-    <div data-ssgoi-transition={`/products/${category}`}>
+    <div>
       <div className="px-4 pb-6 h-full overflow-y-auto">
         {products.length === 0 ? (
           <div className="text-center py-12">

--- a/templates/nextjs/src/components/profile/feed-detail.tsx
+++ b/templates/nextjs/src/components/profile/feed-detail.tsx
@@ -23,7 +23,7 @@ export default function FeedDetail({ postId }: FeedDetailProps) {
   }, [router]);
   if (!post) {
     return (
-      <div data-ssgoi-transition={`/profile/${postId}`}>
+      <div>
         <div className="bg-[#121212] px-4 py-8">
           <p className="text-gray-400">Post not found</p>
         </div>
@@ -31,7 +31,7 @@ export default function FeedDetail({ postId }: FeedDetailProps) {
     );
   }
   return (
-    <div data-ssgoi-transition={`/profile/${postId}`} className="">
+    <div className="">
       <div className="bg-[#121212] min-h-[760px]">
         {/* Content */}
         <div>

--- a/templates/nextjs/src/components/profile/index.tsx
+++ b/templates/nextjs/src/components/profile/index.tsx
@@ -5,7 +5,7 @@ import { profile } from "./mock-data";
 import { Feed } from "./feed";
 export default function ProfileDemo() {
   return (
-    <div data-ssgoi-transition="/profile">
+    <div>
       <div className="bg-[#121212]">
         {/* Profile Header */}
         <div className="relative">

--- a/templates/nextjs/src/components/ssgoi-transition-boundary.tsx
+++ b/templates/nextjs/src/components/ssgoi-transition-boundary.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { type ElementType, type ReactNode } from "react";
+import { usePathname } from "next/navigation";
+
+export function SsgoiTransitionBoundary({
+  children,
+  as,
+  className,
+}: {
+  children: ReactNode;
+  as?: ElementType;
+  className?: string;
+}) {
+  const pathname = usePathname();
+  const Component = as ?? "div";
+
+  return (
+    <Component
+      key={pathname}
+      data-ssgoi-transition={pathname}
+      className={className}
+    >
+      {children}
+    </Component>
+  );
+}

--- a/templates/nuxt/README.md
+++ b/templates/nuxt/README.md
@@ -65,6 +65,22 @@ nuxt/
 └── public/demo/              # Static demo images
 ```
 
+## Route Boundaries
+
+Nuxt pages mark their own transition boundary with `data-ssgoi-transition`.
+Use a stable logical id that matches your config; it does not have to be the
+actual route pathname.
+Do not use a single slot-based layout boundary here; the outgoing slot can
+render the incoming page content.
+
+```vue
+<template>
+  <div data-ssgoi-transition="/posts">
+    <!-- page content -->
+  </div>
+</template>
+```
+
 ## Transitions
 
 ### Drill Transition (Posts)

--- a/templates/react-router/README.md
+++ b/templates/react-router/README.md
@@ -26,6 +26,7 @@ The main provider lives in `app/components/demo-layout.tsx`:
 ```tsx
 import { Ssgoi } from "@ssgoi/react";
 import { drill, zoom } from "@ssgoi/react/view-transitions";
+import { SsgoiTransitionBoundary } from "./ssgoi-transition-boundary";
 
 const config = {
   preserveScroll: { exclude: ["/posts/*"] },
@@ -37,13 +38,24 @@ const config = {
 };
 ```
 
-Each routed page has a stable `data-ssgoi-transition` route id.
+The demo layout wraps routed content once with a small boundary utility.
 
 ```tsx
-export default function PostsPage() {
-  return <main data-ssgoi-transition="/posts">{/* page */}</main>;
+export default function DemoLayout({ children }) {
+  return (
+    <Ssgoi config={config}>
+      <SsgoiTransitionBoundary className="min-h-full bg-[#121212]">
+        {children}
+      </SsgoiTransitionBoundary>
+    </Ssgoi>
+  );
 }
 ```
+
+Page components do not set `data-ssgoi-transition` themselves. Dynamic routes
+stay as real pathnames and are matched by wildcard patterns in config. Use
+`/posts/*` for descendants and `/posts/**` when the parent path should match
+too.
 
 ## Build
 

--- a/templates/react-router/app/components/demo-layout.tsx
+++ b/templates/react-router/app/components/demo-layout.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from "react";
 import { Link, useLocation } from "react-router";
 import { Ssgoi } from "@ssgoi/react";
 import { drill, zoom } from "@ssgoi/react/view-transitions";
+import { SsgoiTransitionBoundary } from "./ssgoi-transition-boundary";
 
 interface DemoLayoutProps {
   children: React.ReactNode;
@@ -44,7 +45,11 @@ export default function DemoLayout({ children }: DemoLayoutProps) {
           id="demo-content"
           className="flex-1 w-full overflow-y-scroll overflow-x-hidden relative z-0 bg-[#121212] scrollbar-hide"
         >
-          <Ssgoi config={config}>{children}</Ssgoi>
+          <Ssgoi config={config}>
+            <SsgoiTransitionBoundary className="min-h-full bg-[#121212]">
+              {children}
+            </SsgoiTransitionBoundary>
+          </Ssgoi>
         </main>
 
         {/* Bottom Navigation */}

--- a/templates/react-router/app/components/pinterest/detail.tsx
+++ b/templates/react-router/app/components/pinterest/detail.tsx
@@ -8,7 +8,7 @@ export default function PinterestDetail({ pinId }: PinterestDetailProps) {
   const item = getPinterestItem(pinId);
   if (!item) {
     return (
-      <div data-ssgoi-transition={`/pinterest/${pinId}`}>
+      <div>
         <div className="min-h-screen bg-[#121212] px-4 py-8">
           <p className="text-gray-400">Pin not found</p>
         </div>
@@ -16,7 +16,7 @@ export default function PinterestDetail({ pinId }: PinterestDetailProps) {
     );
   }
   return (
-    <div data-ssgoi-transition={`/pinterest/${pinId}`}>
+    <div>
       <div className="min-h-screen bg-[#121212]">
         {/* Back button */}
         <div className="px-4 py-4">

--- a/templates/react-router/app/components/pinterest/index.tsx
+++ b/templates/react-router/app/components/pinterest/index.tsx
@@ -7,7 +7,7 @@ export default function PinterestDemo() {
   const leftColumnItems = pinterestItems.filter((_, index) => index % 2 === 0);
   const rightColumnItems = pinterestItems.filter((_, index) => index % 2 === 1);
   return (
-    <div data-ssgoi-transition="/pinterest">
+    <div>
       <div className="min-h-screen bg-[#121212] px-4 py-6">
         {/* Header */}
         <div className="mb-6">

--- a/templates/react-router/app/components/posts/detail.tsx
+++ b/templates/react-router/app/components/posts/detail.tsx
@@ -9,7 +9,7 @@ export default function PostDetail({ postId }: PostDetailProps) {
   const relatedPosts = getRelatedPosts(postId, 3);
   if (!post) {
     return (
-      <div data-ssgoi-transition={`/posts/${postId}`}>
+      <div>
         <div className="min-h-screen bg-[#121212] px-4 py-8">
           <p className="text-gray-400">Post not found</p>
         </div>
@@ -17,7 +17,7 @@ export default function PostDetail({ postId }: PostDetailProps) {
     );
   }
   return (
-    <div data-ssgoi-transition={`/posts/${postId}`}>
+    <div>
       <div className="min-h-screen bg-[#121212]">
         {/* Back button */}
         <div className="px-4 py-4">

--- a/templates/react-router/app/components/posts/index.tsx
+++ b/templates/react-router/app/components/posts/index.tsx
@@ -4,7 +4,7 @@ import { getAllPosts } from "./mock-data";
 export default function PostsDemo() {
   const posts = getAllPosts();
   return (
-    <div data-ssgoi-transition="/posts">
+    <div>
       <div className="min-h-full bg-[#121212] px-4 py-6">
         {/* Header */}
         <div className="mb-6">

--- a/templates/react-router/app/components/products/product-grid.tsx
+++ b/templates/react-router/app/components/products/product-grid.tsx
@@ -2,11 +2,10 @@ import React from "react";
 import type { Product } from "./mock-data";
 interface ProductGridProps {
   products: Product[];
-  category: string;
 }
-export default function ProductGrid({ products, category }: ProductGridProps) {
+export default function ProductGrid({ products }: ProductGridProps) {
   return (
-    <div data-ssgoi-transition={`/products/${category}`}>
+    <div>
       <div className="px-4 pb-6 h-full overflow-y-auto">
         {products.length === 0 ? (
           <div className="text-center py-12">

--- a/templates/react-router/app/components/profile/feed-detail.tsx
+++ b/templates/react-router/app/components/profile/feed-detail.tsx
@@ -20,7 +20,7 @@ export default function FeedDetail({ postId }: FeedDetailProps) {
   }, [navigate]);
   if (!post) {
     return (
-      <div data-ssgoi-transition={`/profile/${postId}`}>
+      <div>
         <div className="bg-[#121212] px-4 py-8">
           <p className="text-gray-400">Post not found</p>
         </div>
@@ -28,7 +28,7 @@ export default function FeedDetail({ postId }: FeedDetailProps) {
     );
   }
   return (
-    <div data-ssgoi-transition={`/profile/${postId}`} className="">
+    <div className="">
       <div className="bg-[#121212] min-h-[760px]">
         {/* Content */}
         <div>

--- a/templates/react-router/app/components/profile/index.tsx
+++ b/templates/react-router/app/components/profile/index.tsx
@@ -3,7 +3,7 @@ import { profile } from "./mock-data";
 import { Feed } from "./feed";
 export default function ProfileDemo() {
   return (
-    <div data-ssgoi-transition="/profile">
+    <div>
       <div className="bg-[#121212]">
         {/* Profile Header */}
         <div className="relative">

--- a/templates/react-router/app/components/ssgoi-transition-boundary.tsx
+++ b/templates/react-router/app/components/ssgoi-transition-boundary.tsx
@@ -1,0 +1,25 @@
+import { type ElementType, type ReactNode } from "react";
+import { useLocation } from "react-router";
+
+export function SsgoiTransitionBoundary({
+  children,
+  as,
+  className,
+}: {
+  children: ReactNode;
+  as?: ElementType;
+  className?: string;
+}) {
+  const { pathname } = useLocation();
+  const Component = as ?? "div";
+
+  return (
+    <Component
+      key={pathname}
+      data-ssgoi-transition={pathname}
+      className={className}
+    >
+      {children}
+    </Component>
+  );
+}

--- a/templates/react-router/app/routes/products_.all.tsx
+++ b/templates/react-router/app/routes/products_.all.tsx
@@ -2,5 +2,5 @@ import ProductGrid from "../components/products/product-grid";
 import { products } from "../components/products/mock-data";
 
 export default function ProductsAllRoute() {
-  return <ProductGrid products={products} category="all" />;
+  return <ProductGrid products={products} />;
 }

--- a/templates/react-router/app/routes/products_.beauty.tsx
+++ b/templates/react-router/app/routes/products_.beauty.tsx
@@ -3,5 +3,5 @@ import { products } from "../components/products/mock-data";
 
 export default function ProductsBeautyRoute() {
   const beautyProducts = products.filter((p) => p.category === "Beauty");
-  return <ProductGrid products={beautyProducts} category="beauty" />;
+  return <ProductGrid products={beautyProducts} />;
 }

--- a/templates/react-router/app/routes/products_.electronics.tsx
+++ b/templates/react-router/app/routes/products_.electronics.tsx
@@ -3,7 +3,7 @@ import { products } from "../components/products/mock-data";
 
 export default function ProductsElectronicsRoute() {
   const electronicsProducts = products.filter(
-    (p) => p.category === "Electronics"
+    (p) => p.category === "Electronics",
   );
-  return <ProductGrid products={electronicsProducts} category="electronics" />;
+  return <ProductGrid products={electronicsProducts} />;
 }

--- a/templates/react-router/app/routes/products_.fashion.tsx
+++ b/templates/react-router/app/routes/products_.fashion.tsx
@@ -3,5 +3,5 @@ import { products } from "../components/products/mock-data";
 
 export default function ProductsFashionRoute() {
   const fashionProducts = products.filter((p) => p.category === "Fashion");
-  return <ProductGrid products={fashionProducts} category="fashion" />;
+  return <ProductGrid products={fashionProducts} />;
 }

--- a/templates/react-router/app/routes/products_.home.tsx
+++ b/templates/react-router/app/routes/products_.home.tsx
@@ -3,5 +3,5 @@ import { products } from "../components/products/mock-data";
 
 export default function ProductsHomeRoute() {
   const homeProducts = products.filter((p) => p.category === "Home");
-  return <ProductGrid products={homeProducts} category="home" />;
+  return <ProductGrid products={homeProducts} />;
 }

--- a/templates/react-router/app/routes/products_.layout.tsx
+++ b/templates/react-router/app/routes/products_.layout.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from "react";
 import { Link, Outlet, useLocation } from "react-router";
 import { Ssgoi } from "@ssgoi/react";
 import { slide } from "@ssgoi/react/view-transitions";
+import { SsgoiTransitionBoundary } from "../components/ssgoi-transition-boundary";
 const categories = [
   {
     id: "all",
@@ -43,10 +44,7 @@ export default function ProductsLayout() {
     [],
   );
   return (
-    <div
-      data-ssgoi-transition="/products"
-      className="min-h-screen bg-[#121212] flex flex-col"
-    >
+    <div className="min-h-screen bg-[#121212] flex flex-col">
       {/* Header - Fixed */}
       <div className="px-4 pt-6 pb-3 flex-shrink-0">
         <h1 className="text-sm font-medium text-white mb-1">Shop</h1>
@@ -73,7 +71,9 @@ export default function ProductsLayout() {
       {/* Tab Content - Slide transitions here */}
       <div className="flex-1 overflow-hidden relative">
         <Ssgoi config={config}>
-          <Outlet />
+          <SsgoiTransitionBoundary className="min-h-full bg-[#121212]">
+            <Outlet />
+          </SsgoiTransitionBoundary>
         </Ssgoi>
       </div>
     </div>

--- a/templates/sveltekit/README.md
+++ b/templates/sveltekit/README.md
@@ -54,6 +54,20 @@ src/
     └── profile/                    # Profile demo
 ```
 
+## Route Boundaries
+
+SvelteKit pages mark their own transition boundary with `data-ssgoi-transition`.
+Use a stable logical id that matches your config; it does not have to be the
+actual route pathname.
+Do not use a single slot-based layout boundary here; the outgoing slot can
+render the incoming page content.
+
+```svelte
+<div data-ssgoi-transition="/posts">
+  <!-- page content -->
+</div>
+```
+
 ## Transitions
 
 ### Drill Transition (Posts)

--- a/templates/tanstack-router/README.md
+++ b/templates/tanstack-router/README.md
@@ -64,14 +64,11 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
 ### 2. SSGOI Configuration (demo-layout.tsx)
 
 ```tsx
-import { useRouterState } from "@tanstack/react-router";
 import { Ssgoi } from "@ssgoi/react";
 import { drill, zoom } from "@ssgoi/react/view-transitions";
+import { SsgoiTransitionBoundary } from "../components/ssgoi-transition-boundary";
 
 export default function DemoLayout({ children }) {
-  const location = useRouterState({ select: (s) => s.location });
-  const pathname = location.pathname;
-
   const config = useMemo(
     () => ({
       transitions: [
@@ -83,17 +80,26 @@ export default function DemoLayout({ children }) {
     [],
   );
 
-  return <Ssgoi config={config}>{children}</Ssgoi>;
+  return (
+    <Ssgoi config={config}>
+      <SsgoiTransitionBoundary className="min-h-full bg-[#121212]">
+        {children}
+      </SsgoiTransitionBoundary>
+    </Ssgoi>
+  );
 }
 ```
 
 ### 3. Page Components
 
-Each page must set a unique `data-ssgoi-transition` route id:
+Page components do not set `data-ssgoi-transition` themselves. Dynamic routes
+stay as real pathnames and are matched by wildcard patterns in config. Use
+`/posts/*` for descendants and `/posts/**` when the parent path should match
+too.
 
 ```tsx
 export default function PostsPage() {
-  return <main data-ssgoi-transition="/posts">{/* Page content */}</main>;
+  return <main>{/* Page content */}</main>;
 }
 ```
 

--- a/templates/tanstack-router/app/components/demo-layout.tsx
+++ b/templates/tanstack-router/app/components/demo-layout.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from "react";
 import { Link, useRouterState } from "@tanstack/react-router";
 import { Ssgoi } from "@ssgoi/react";
 import { drill, zoom } from "@ssgoi/react/view-transitions";
+import { SsgoiTransitionBoundary } from "./ssgoi-transition-boundary";
 
 interface DemoLayoutProps {
   children: React.ReactNode;
@@ -44,7 +45,11 @@ export default function DemoLayout({ children }: DemoLayoutProps) {
           id="demo-content"
           className="flex-1 w-full overflow-y-scroll overflow-x-hidden relative z-0 bg-[#121212] scrollbar-hide"
         >
-          <Ssgoi config={config}>{children}</Ssgoi>
+          <Ssgoi config={config}>
+            <SsgoiTransitionBoundary className="min-h-full bg-[#121212]">
+              {children}
+            </SsgoiTransitionBoundary>
+          </Ssgoi>
         </main>
 
         {/* Bottom Navigation */}

--- a/templates/tanstack-router/app/components/pinterest/detail.tsx
+++ b/templates/tanstack-router/app/components/pinterest/detail.tsx
@@ -8,7 +8,7 @@ export default function PinterestDetail({ pinId }: PinterestDetailProps) {
   const item = getPinterestItem(pinId);
   if (!item) {
     return (
-      <div data-ssgoi-transition={`/pinterest/${pinId}`}>
+      <div>
         <div className="min-h-screen bg-[#121212] px-4 py-8">
           <p className="text-gray-400">Pin not found</p>
         </div>
@@ -16,7 +16,7 @@ export default function PinterestDetail({ pinId }: PinterestDetailProps) {
     );
   }
   return (
-    <div data-ssgoi-transition={`/pinterest/${pinId}`}>
+    <div>
       <div className="min-h-screen bg-[#121212]">
         {/* Back button */}
         <div className="px-4 py-4">

--- a/templates/tanstack-router/app/components/pinterest/index.tsx
+++ b/templates/tanstack-router/app/components/pinterest/index.tsx
@@ -7,7 +7,7 @@ export default function PinterestDemo() {
   const leftColumnItems = pinterestItems.filter((_, index) => index % 2 === 0);
   const rightColumnItems = pinterestItems.filter((_, index) => index % 2 === 1);
   return (
-    <div data-ssgoi-transition="/pinterest">
+    <div>
       <div className="min-h-screen bg-[#121212] px-4 py-6">
         {/* Header */}
         <div className="mb-6">

--- a/templates/tanstack-router/app/components/posts/detail.tsx
+++ b/templates/tanstack-router/app/components/posts/detail.tsx
@@ -9,7 +9,7 @@ export default function PostDetail({ postId }: PostDetailProps) {
   const relatedPosts = getRelatedPosts(postId, 3);
   if (!post) {
     return (
-      <div data-ssgoi-transition={`/posts/${postId}`}>
+      <div>
         <div className="min-h-screen bg-[#121212] px-4 py-8">
           <p className="text-gray-400">Post not found</p>
         </div>
@@ -17,7 +17,7 @@ export default function PostDetail({ postId }: PostDetailProps) {
     );
   }
   return (
-    <div data-ssgoi-transition={`/posts/${postId}`}>
+    <div>
       <div className="min-h-screen bg-[#121212]">
         {/* Back button */}
         <div className="px-4 py-4">

--- a/templates/tanstack-router/app/components/posts/index.tsx
+++ b/templates/tanstack-router/app/components/posts/index.tsx
@@ -4,7 +4,7 @@ import { getAllPosts } from "./mock-data";
 export default function PostsDemo() {
   const posts = getAllPosts();
   return (
-    <div data-ssgoi-transition="/posts">
+    <div>
       <div className="min-h-full bg-[#121212] px-4 py-6">
         {/* Header */}
         <div className="mb-6">

--- a/templates/tanstack-router/app/components/products/product-grid.tsx
+++ b/templates/tanstack-router/app/components/products/product-grid.tsx
@@ -2,11 +2,10 @@ import React from "react";
 import type { Product } from "./mock-data";
 interface ProductGridProps {
   products: Product[];
-  category: string;
 }
-export default function ProductGrid({ products, category }: ProductGridProps) {
+export default function ProductGrid({ products }: ProductGridProps) {
   return (
-    <div data-ssgoi-transition={`/products/${category}`}>
+    <div>
       <div className="px-4 pb-6 h-full overflow-y-auto">
         {products.length === 0 ? (
           <div className="text-center py-12">

--- a/templates/tanstack-router/app/components/profile/feed-detail.tsx
+++ b/templates/tanstack-router/app/components/profile/feed-detail.tsx
@@ -22,7 +22,7 @@ export default function FeedDetail({ postId }: FeedDetailProps) {
   }, [navigate]);
   if (!post) {
     return (
-      <div data-ssgoi-transition={`/profile/${postId}`}>
+      <div>
         <div className="bg-[#121212] px-4 py-8">
           <p className="text-gray-400">Post not found</p>
         </div>
@@ -30,7 +30,7 @@ export default function FeedDetail({ postId }: FeedDetailProps) {
     );
   }
   return (
-    <div data-ssgoi-transition={`/profile/${postId}`} className="">
+    <div className="">
       <div className="bg-[#121212] min-h-[760px]">
         {/* Content */}
         <div>

--- a/templates/tanstack-router/app/components/profile/index.tsx
+++ b/templates/tanstack-router/app/components/profile/index.tsx
@@ -3,7 +3,7 @@ import { profile } from "./mock-data";
 import { Feed } from "./feed";
 export default function ProfileDemo() {
   return (
-    <div data-ssgoi-transition="/profile">
+    <div>
       <div className="bg-[#121212]">
         {/* Profile Header */}
         <div className="relative">

--- a/templates/tanstack-router/app/components/ssgoi-transition-boundary.tsx
+++ b/templates/tanstack-router/app/components/ssgoi-transition-boundary.tsx
@@ -1,0 +1,27 @@
+import { type ElementType, type ReactNode } from "react";
+import { useRouterState } from "@tanstack/react-router";
+
+export function SsgoiTransitionBoundary({
+  children,
+  as,
+  className,
+}: {
+  children: ReactNode;
+  as?: ElementType;
+  className?: string;
+}) {
+  const pathname = useRouterState({
+    select: (state) => state.location.pathname,
+  });
+  const Component = as ?? "div";
+
+  return (
+    <Component
+      key={pathname}
+      data-ssgoi-transition={pathname}
+      className={className}
+    >
+      {children}
+    </Component>
+  );
+}

--- a/templates/tanstack-router/app/routes/products.all.tsx
+++ b/templates/tanstack-router/app/routes/products.all.tsx
@@ -3,7 +3,7 @@ import ProductGrid from "../components/products/product-grid";
 import { products } from "../components/products/mock-data";
 
 function ProductsAllRoute() {
-  return <ProductGrid products={products} category="all" />;
+  return <ProductGrid products={products} />;
 }
 
 export const Route = createFileRoute("/products/all")({

--- a/templates/tanstack-router/app/routes/products.beauty.tsx
+++ b/templates/tanstack-router/app/routes/products.beauty.tsx
@@ -4,7 +4,7 @@ import { getProductsByCategory } from "../components/products/mock-data";
 
 function ProductsBeautyRoute() {
   const products = getProductsByCategory("beauty");
-  return <ProductGrid products={products} category="beauty" />;
+  return <ProductGrid products={products} />;
 }
 
 export const Route = createFileRoute("/products/beauty")({

--- a/templates/tanstack-router/app/routes/products.electronics.tsx
+++ b/templates/tanstack-router/app/routes/products.electronics.tsx
@@ -4,7 +4,7 @@ import { getProductsByCategory } from "../components/products/mock-data";
 
 function ProductsElectronicsRoute() {
   const products = getProductsByCategory("electronics");
-  return <ProductGrid products={products} category="electronics" />;
+  return <ProductGrid products={products} />;
 }
 
 export const Route = createFileRoute("/products/electronics")({

--- a/templates/tanstack-router/app/routes/products.fashion.tsx
+++ b/templates/tanstack-router/app/routes/products.fashion.tsx
@@ -4,7 +4,7 @@ import { getProductsByCategory } from "../components/products/mock-data";
 
 function ProductsFashionRoute() {
   const products = getProductsByCategory("fashion");
-  return <ProductGrid products={products} category="fashion" />;
+  return <ProductGrid products={products} />;
 }
 
 export const Route = createFileRoute("/products/fashion")({

--- a/templates/tanstack-router/app/routes/products.home.tsx
+++ b/templates/tanstack-router/app/routes/products.home.tsx
@@ -4,7 +4,7 @@ import { getProductsByCategory } from "../components/products/mock-data";
 
 function ProductsHomeRoute() {
   const products = getProductsByCategory("home");
-  return <ProductGrid products={products} category="home" />;
+  return <ProductGrid products={products} />;
 }
 
 export const Route = createFileRoute("/products/home")({

--- a/templates/tanstack-router/app/routes/products.tsx
+++ b/templates/tanstack-router/app/routes/products.tsx
@@ -7,6 +7,7 @@ import {
 } from "@tanstack/react-router";
 import { Ssgoi } from "@ssgoi/react";
 import { slide } from "@ssgoi/react/view-transitions";
+import { SsgoiTransitionBoundary } from "../components/ssgoi-transition-boundary";
 const categories = [
   {
     id: "all",
@@ -50,10 +51,7 @@ function ProductsLayout() {
     [],
   );
   return (
-    <div
-      data-ssgoi-transition="/products"
-      className="min-h-screen bg-[#121212] flex flex-col"
-    >
+    <div className="min-h-screen bg-[#121212] flex flex-col">
       {/* Header - Fixed */}
       <div className="px-4 pt-6 pb-3 flex-shrink-0">
         <h1 className="text-sm font-medium text-white mb-1">Shop</h1>
@@ -80,7 +78,9 @@ function ProductsLayout() {
       {/* Tab Content - Slide transitions here */}
       <div className="flex-1 overflow-hidden relative">
         <Ssgoi config={config}>
-          <Outlet />
+          <SsgoiTransitionBoundary className="min-h-full bg-[#121212]">
+            <Outlet />
+          </SsgoiTransitionBoundary>
         </Ssgoi>
       </div>
     </div>


### PR DESCRIPTION
* refactor: use pathname transition boundaries

* docs: flesh out install page with the why, non-React examples, and templates

The /docs/install page was sparse compared to llms.txt and the README. Bring the missing depth in, sourced from llms.txt:

- Why the DOM structure: a "Why this shape" callout after step 1 explaining the clone & position:absolute mechanism and what relative / z-0 / overflow-x-clip each do on the layout shell, with links to Layout and How it works.
- Non-React boundaries: real SvelteKit / Nuxt / Angular code examples plus the live-slot rationale for why each page is marked directly instead of via one shared parent boundary.
- Reference templates: per-framework GitHub links right on the install page (previously only on Compatibility), plus the monorepo /templates link.

Also add the live-slot rationale to README's non-React note for parity.



---------