### PR TITLE
fix(core): preserve scroll under the middleware-resolved path

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/core",
-  "version": "6.6.2",
+  "version": "6.6.3",
   "description": "Core animation engine for SSGOI - Native app-like page transitions with spring physics",
   "private": false,
   "type": "module",

--- a/packages/core/src/lib/ssgoi-transition/create-context-manager.test.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-context-manager.test.ts
@@ -373,4 +373,42 @@ describe("createContextManager", () => {
 
     expect(documentElement.scrollTop).toBe(0);
   });
+
+  it("keys scroll off resolvePath so aliased/rewritten routes share one position", () => {
+    const manager = createContextManager({
+      preserveScroll: true,
+      // Mirror a config `middleware` that aliases a mobile-only route to its
+      // canonical id (e.g. `/m-p/[id]` → `/p/[id]`).
+      resolvePath: (path) => path.replace(/^\/m-p\//, "/p/"),
+    });
+    const mobilePost = createFakeElement({ parentElement: body });
+    const away = createFakeElement({ parentElement: body });
+    const canonicalPost = createFakeElement({ parentElement: body });
+
+    // Scroll the page while on the ALIAS path.
+    manager.initializeContext(mobilePost, "/m-p/123");
+    flushAnimationFrames(11);
+    documentElement.scrollTop = 540;
+    emitWindowScroll();
+
+    // Stored under the RESOLVED key — visible through either spelling.
+    expect(manager.getScrollPosition("/m-p/123")).toEqual({ x: 0, y: 540 });
+    expect(manager.getScrollPosition("/p/123")).toEqual({ x: 0, y: 540 });
+
+    // Outgoing offset leaving the alias keeps the prior scroll (no top-snap):
+    // the regression was this resolving to 0 because the lookup key missed.
+    expect(manager.calculateScrollOffset("/m-p/123", "/external")).toEqual({
+      x: 0,
+      y: 540,
+    });
+
+    // Return via the CANONICAL path — scroll restores from the shared key.
+    manager.initializeContext(away, "/external");
+    flushAnimationFrames(2);
+    expect(documentElement.scrollTop).toBe(0);
+
+    manager.initializeContext(canonicalPost, "/p/123");
+    flushAnimationFrames(2);
+    expect(documentElement.scrollTop).toBe(540);
+  });
 });

--- a/packages/core/src/lib/ssgoi-transition/create-context-manager.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-context-manager.ts
@@ -20,10 +20,24 @@ export type ContextManagerOptions = {
    * @default (isMobile) => isMobile
    */
   preserveScroll?: PreserveScrollOption;
+  /**
+   * Resolves a raw path to the identity used for ALL scroll bookkeeping
+   * (record, restore, offset, evict). Defaults to the path unchanged.
+   *
+   * Wire this to the config `middleware` so a rewritten/aliased route records and
+   * restores its scroll under the SAME key the transition matcher resolves it to.
+   * Without it, scroll is stored under the raw `data-ssgoi-transition` id while the
+   * offset is looked up under the middleware-rewritten id (or vice-versa); the keys
+   * miss each other and the outgoing page snaps to the top mid-transition.
+   */
+  resolvePath?: (path: string) => string;
 };
 
 export function createContextManager(options: ContextManagerOptions = {}) {
-  const { preserveScroll = (isMobile: boolean) => isMobile } = options;
+  const {
+    preserveScroll = (isMobile: boolean) => isMobile,
+    resolvePath = (path: string) => path,
+  } = options;
 
   const resolvePreserve: PreserveScrollFn =
     typeof preserveScroll === "function"
@@ -62,7 +76,11 @@ export function createContextManager(options: ContextManagerOptions = {}) {
     return cachedIsMobile;
   };
 
-  const getScrollPolicy = (path: string): ScrollPolicy => {
+  const getScrollPolicy = (rawPath: string): ScrollPolicy => {
+    // Every scroll-key derivation funnels through here (record, restore, offset,
+    // evict), so resolving the path once at the top normalizes ALL of them to a
+    // single middleware-aware identity — no caller can sneak a raw path past it.
+    const path = resolvePath(rawPath);
     const value = resolvePreserve(detectIsMobile());
 
     if (value === false) {

--- a/packages/core/src/lib/ssgoi-transition/create-ssgoi-transition-context.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-ssgoi-transition-context.ts
@@ -106,6 +106,21 @@ export function createSggoiTransitionContext(
   const swipeDetector = createSwipeBackDetector();
   swipeDetector.initialize();
 
+  // Single-path scroll identity, derived from the SAME `middleware` the matcher
+  // uses, so an aliased/rewritten route records & restores scroll under one key.
+  // `middleware` is a (from,to) pair rewrite; for a lone path we run it as a
+  // self-pair and take `from`. Memoized — the scroll listener calls this per
+  // frame and the path set is tiny (one per route).
+  const resolvedScrollPaths = new Map<string, string>();
+  const resolveScrollPath = (path: string): string => {
+    let resolved = resolvedScrollPaths.get(path);
+    if (resolved === undefined) {
+      resolved = middleware(path, path).from;
+      resolvedScrollPaths.set(path, resolved);
+    }
+    return resolved;
+  };
+
   const {
     initializeContext,
     calculateScrollOffset,
@@ -115,7 +130,7 @@ export function createSggoiTransitionContext(
     getPositionedParentElement,
     getScrollPosition,
     getIsMobile,
-  } = createContextManager({ preserveScroll });
+  } = createContextManager({ preserveScroll, resolvePath: resolveScrollPath });
 
   // Resolve + flatten + process the path-transition list lazily. `isMobile` is
   // only reliable once the scroll container is known (measured on the first IN),
@@ -403,6 +418,14 @@ export function createSggoiTransitionContext(
       // Only the IN side drives the run — by then both sides have arrived.
       if (side !== "in") return;
 
+      // `middleware` rewrites the path pair for matching (e.g. aliasing
+      // `/m-p/[id]` → `/p/[id]`, or collapsing a deep route to a logical id). Use
+      // the transformed pair for `findMatchingTransition`, but hand `runTransition`
+      // the ORIGINAL pair: the context manager already funnels every scroll path
+      // through the same `middleware` (via `resolveScrollPath`), so passing the
+      // originals keeps record/restore on one identity. Passing the pre-transformed
+      // paths here would double-apply the rewrite and could miss the stored scroll,
+      // snapping the outgoing page to the top mid-transition.
       const { from: transformedFrom, to: transformedTo } = middleware(
         pair.from,
         pair.to,
@@ -421,7 +444,7 @@ export function createSggoiTransitionContext(
 
       if (!config || !outSide || !inSide) return;
 
-      runTransition(config, transformedFrom, transformedTo, outSide, inSide);
+      runTransition(config, pair.from, pair.to, outSide, inSide);
     });
   };
 


### PR DESCRIPTION
## Problem

`SsgoiConfig.middleware` rewrites the `(from, to)` path pair and the matcher uses the rewritten pair (`findMatchingTransition`). But scroll positions are **recorded** under each element's raw `data-ssgoi-transition` id (`scrollListener` keys off the path passed to `initializeContext`), while the outgoing scroll offset is **looked up** under the middleware-rewritten path (`runTransition` was called with the *transformed* pair, which feeds `calculateScrollOffset` / `getScrollPosition`).

So the moment `middleware` changes a path — route aliasing (`/m-p/[id]` → `/p/[id]`), collapsing a deep route to a logical id, etc. — the lookup key misses the stored entry. `calculateScrollOffset` returns `{ y: 0 }`, `prepareOutgoing` pins the outgoing page at `top: 0`, and the leaving page snaps to the top mid-transition instead of holding its scroll. With an identity middleware (the default) the keys coincide, so the bug only surfaces once a middleware actually rewrites paths.

## Fix

Key scroll bookkeeping off the **same identity the matcher resolves a path to**:

- `createContextManager` gains a `resolvePath` hook. Every scroll-key derivation already funnels through `getScrollPolicy`, so resolving the path once there normalizes record / restore / offset / evict together.
- `createSggoiTransitionContext` wires `resolvePath` to the config `middleware` (applied to a lone path as a self-pair: `middleware(path, path).from`, memoized) and hands `runTransition` the **original, pre-middleware** paths, since the context manager now owns scroll-path resolution.

Aliased/rewritten routes now record and restore scroll under one key, and the outgoing page keeps its scroll position through the transition.

## Test

Adds a `create-context-manager` test: with a `resolvePath` that aliases `/m-p/[id]` → `/p/[id]`, scroll recorded on the alias is readable/restorable via the canonical path, and the outgoing offset retains the prior scroll.

Default behavior (no middleware / identity middleware) is unchanged; all existing tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)