### PR TITLE
feat(core): sheet "blur" tone + Voyage demo (+ scroll fixes for sheet/zoom blur)

### DIFF
--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -275,7 +275,7 @@ Material/Flutter-style shared-axis page swap. **Three types**: `x` (horizontal, 
 
 ### `sheet` — https://ssgoi.dev/llms/sheet.txt
 
-Bottom sheet style. New page slides up from below. **Two types**: `static` (background untouched, default) and `scale` (background scales down behind). Use for **modal-like** flows (FAB → compose, "new item" screens). (Legacy `type: "background-scale"` deprecated → use `"scale"`.)
+Bottom sheet style. New page slides up from below. **Three types**: `static` (background untouched, default), `scale` (background scales down behind), and `blur` (background blurs + recedes behind, a modal pushing the page out of focus). Use for **modal-like** flows (FAB → compose, "new item" screens). (Legacy `type: "background-scale"` deprecated → use `"scale"`.)
 
 ### `hero` — https://ssgoi.dev/llms/hero.txt
 

--- a/apps/docs/public/llms/sheet.txt
+++ b/apps/docs/public/llms/sheet.txt
@@ -8,6 +8,7 @@ Setup guide: https://ssgoi.dev/llms.txt
 
 - **`static`** (default): only the rising sheet moves. Background stays put — looks like the new page covers the old one cleanly.
 - **`scale`**: background scales down slightly behind the rising sheet, giving a stacked, iOS-modal feel.
+- **`blur`**: background blurs and recedes (a subtle scale + dim) behind the rising sheet — a modal pushing the page underneath out of focus.
 
 `enter` is the destination path that slides UP. `exit` is the page underneath — what shows when you go back.
 
@@ -19,7 +20,7 @@ import { sheet } from "@ssgoi/react/view-transitions";
 sheet({
   enter: string;                       // destination (the sheet page)
   exit: string;                        // background (the page underneath)
-  type?: "static" | "scale";           // default: "static"
+  type?: "static" | "scale" | "blur";  // default: "static"
   variant?: "default";                 // reserved — only "default" today
   options?: {};                        // reserved — no fields yet
 }): SsgoiPathTransition[];
@@ -36,6 +37,7 @@ const config = {
   transitions: [
     sheet({ enter: "/compose", exit: "/feed" }),
     sheet({ enter: "/settings/*", exit: "/", type: "scale" }),
+    sheet({ enter: "/story/new", exit: "/story", type: "blur" }),
   ],
 };
 ```

--- a/apps/docs/public/voyage-icon.svg
+++ b/apps/docs/public/voyage-icon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 96 96" fill="none">
+  <rect width="96" height="96" rx="22" fill="#FFF0F0"/>
+  <circle cx="46" cy="50" r="22" stroke="#FF5A5F" stroke-width="3" fill="none"/>
+  <ellipse cx="46" cy="50" rx="9" ry="22" stroke="#FF5A5F" stroke-width="3" fill="none"/>
+  <path d="M25 43 H67 M25 57 H67" stroke="#FF5A5F" stroke-width="3" stroke-linecap="round"/>
+  <path d="M68 22 C68 28 62 30 62 30 C62 30 56 28 56 22 C56 18.7 58.7 16 62 16 C65.3 16 68 18.7 68 22 Z" fill="#FF5A5F"/>
+  <circle cx="62" cy="22" r="2.4" fill="#FFF0F0"/>
+</svg>

--- a/apps/docs/src/app/demo/(mobile)/voyage/compose/page.tsx
+++ b/apps/docs/src/app/demo/(mobile)/voyage/compose/page.tsx
@@ -1,0 +1,5 @@
+import ComposePage from "@/demo/voyage/page/compose";
+
+export default function Page() {
+  return <ComposePage />;
+}

--- a/apps/docs/src/app/demo/(mobile)/voyage/layout.tsx
+++ b/apps/docs/src/app/demo/(mobile)/voyage/layout.tsx
@@ -1,0 +1,3 @@
+import VoyageLayout from "@/demo/voyage/page/layout";
+
+export default VoyageLayout;

--- a/apps/docs/src/app/demo/(mobile)/voyage/page.tsx
+++ b/apps/docs/src/app/demo/(mobile)/voyage/page.tsx
@@ -1,0 +1,5 @@
+import FeedPage from "@/demo/voyage/page/feed";
+
+export default function Page() {
+  return <FeedPage />;
+}

--- a/apps/docs/src/demo/voyage/api/story/actions/find-all.ts
+++ b/apps/docs/src/demo/voyage/api/story/actions/find-all.ts
@@ -1,0 +1,9 @@
+import { createAction } from "@/lib/utils";
+import { data } from "../data";
+import type { StorySimple } from "../types";
+
+async function _findAll(): Promise<StorySimple[]> {
+  return data.all();
+}
+
+export const findAll = createAction(_findAll);

--- a/apps/docs/src/demo/voyage/api/story/data.ts
+++ b/apps/docs/src/demo/voyage/api/story/data.ts
@@ -1,0 +1,116 @@
+import type { StorySimple } from "./types";
+
+const cover = (id: string) =>
+  `https://images.unsplash.com/${id}?auto=format&fit=crop&w=1100&q=80`;
+
+const seed: StorySimple[] = [
+  {
+    id: "s-001",
+    title: "Three slow mornings in the hills above Kyoto",
+    cover: cover("photo-1502082553048-f009c37129b9"),
+    location: "Kyoto, Japan",
+    excerpt:
+      "I came for the temples and stayed for the quiet. Every morning began with fog rolling off the bamboo and a cup of matcha I didn't want to finish.",
+    author: "Mina Seo",
+    authorInitial: "M",
+    authorColor: "bg-rose-500",
+    timeLabel: "2d",
+    readMinutes: 6,
+    likes: 248,
+    saved: false,
+  },
+  {
+    id: "s-002",
+    title: "Chasing the green light over Tromsø",
+    cover: cover("photo-1519681393784-d120267933ba"),
+    location: "Tromsø, Norway",
+    excerpt:
+      "We waited four nights in the cold for the aurora. On the fifth, the whole sky cracked open at once and nobody said a word.",
+    author: "Idris Vale",
+    authorInitial: "I",
+    authorColor: "bg-indigo-500",
+    timeLabel: "4d",
+    readMinutes: 8,
+    likes: 1024,
+    saved: true,
+  },
+  {
+    id: "s-003",
+    title: "A week of long lunches in Tuscany",
+    cover: cover("photo-1500382017468-9049fed747ef"),
+    location: "Val d'Orcia, Italy",
+    excerpt:
+      "No itinerary, just a rented Fiat and a list of trattorias from a friend's grandmother. The hills did the rest.",
+    author: "Carla Pires",
+    authorInitial: "C",
+    authorColor: "bg-amber-500",
+    timeLabel: "1w",
+    readMinutes: 5,
+    likes: 512,
+    saved: false,
+  },
+  {
+    id: "s-004",
+    title: "The trail that almost beat me in Patagonia",
+    cover: cover("photo-1469474968028-56623f02e42e"),
+    location: "Torres del Paine, Chile",
+    excerpt:
+      "Day three, the wind was strong enough to lean on. I have never felt smaller or more awake at the same time.",
+    author: "Theo Brandt",
+    authorInitial: "T",
+    authorColor: "bg-emerald-500",
+    timeLabel: "1w",
+    readMinutes: 11,
+    likes: 776,
+    saved: false,
+  },
+  {
+    id: "s-005",
+    title: "Sunset trams and pastéis in Lisbon",
+    cover: cover("photo-1500530855697-b586d89ba3ee"),
+    location: "Lisbon, Portugal",
+    excerpt:
+      "I got beautifully lost in Alfama every single day. The 28 tram became my unreliable, charming compass.",
+    author: "June Han",
+    authorInitial: "J",
+    authorColor: "bg-sky-500",
+    timeLabel: "2w",
+    readMinutes: 4,
+    likes: 333,
+    saved: true,
+  },
+  {
+    id: "s-006",
+    title: "Glassy water and empty roads on Jeju",
+    cover: cover("photo-1584345015538-213f90f9ccbc"),
+    location: "Jeju, South Korea",
+    excerpt:
+      "Rented a tiny car, circled the island clockwise, and stopped at every coastal café that looked like nobody knew about it.",
+    author: "Noah Park",
+    authorInitial: "N",
+    authorColor: "bg-teal-500",
+    timeLabel: "3w",
+    readMinutes: 7,
+    likes: 198,
+    saved: false,
+  },
+  {
+    id: "s-007",
+    title: "Reflections at the foot of Banff",
+    cover: cover("photo-1501785888041-af3ef285b470"),
+    location: "Banff, Canada",
+    excerpt:
+      "The lake was so still it doubled the mountains. We sat on the dock until our coffee went cold, which felt like the point.",
+    author: "Elsa Moreau",
+    authorInitial: "E",
+    authorColor: "bg-violet-500",
+    timeLabel: "1mo",
+    readMinutes: 6,
+    likes: 905,
+    saved: false,
+  },
+];
+
+export const data = {
+  all: () => seed.map((s) => ({ ...s })),
+};

--- a/apps/docs/src/demo/voyage/api/story/index.ts
+++ b/apps/docs/src/demo/voyage/api/story/index.ts
@@ -1,0 +1,7 @@
+import { resolveActions } from "@/lib/utils";
+
+export * from "./types";
+
+import { findAll } from "./actions/find-all";
+
+export const story = resolveActions({ findAll });

--- a/apps/docs/src/demo/voyage/api/story/types.ts
+++ b/apps/docs/src/demo/voyage/api/story/types.ts
@@ -1,0 +1,23 @@
+export interface StoryAPI {
+  findAll: () => Promise<StorySimple[]>;
+}
+
+export type StorySimple = {
+  id: string;
+  title: string;
+  /** wide cover photo for the feed card */
+  cover: string;
+  /** where the trip happened, e.g. "Kyoto, Japan" */
+  location: string;
+  /** one- or two-line teaser shown under the title */
+  excerpt: string;
+  author: string;
+  authorInitial: string;
+  /** tailwind background-color class for the author avatar circle */
+  authorColor: string;
+  /** pre-formatted timestamp label, e.g. "2d", "1w" */
+  timeLabel: string;
+  readMinutes: number;
+  likes: number;
+  saved: boolean;
+};

--- a/apps/docs/src/demo/voyage/page/compose/compose-bar.tsx
+++ b/apps/docs/src/demo/voyage/page/compose/compose-bar.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { Link } from "@/lib/link";
+import { X } from "lucide-react";
+import { toast } from "sonner";
+
+export function ComposeBar() {
+  return (
+    <div className="flex items-center gap-1 border-b border-neutral-200/80 bg-white px-2 py-2.5">
+      <Link
+        href="/demo/voyage"
+        scroll={false}
+        className="rounded-full p-2 text-neutral-700 active:bg-neutral-100"
+        aria-label="Close"
+      >
+        <X size={22} strokeWidth={2.25} />
+      </Link>
+      <div className="flex-1 px-1 text-[16px] font-semibold text-neutral-900">
+        New story
+      </div>
+      <button
+        type="button"
+        onClick={() => toast("Publishing is mocked in this demo")}
+        className="rounded-full bg-[#FF5A5F] px-4 py-2 text-[14px] font-semibold text-white active:bg-[#e84e53]"
+      >
+        Publish
+      </button>
+    </div>
+  );
+}

--- a/apps/docs/src/demo/voyage/page/compose/compose-form.tsx
+++ b/apps/docs/src/demo/voyage/page/compose/compose-form.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useState } from "react";
+import { ImagePlus, MapPin, X } from "lucide-react";
+import { Input } from "@/lib/components/ui/input";
+import { Textarea } from "@/lib/components/ui/textarea";
+
+const SAMPLE_COVER =
+  "https://images.unsplash.com/photo-1502082553048-f009c37129b9?auto=format&fit=crop&w=1100&q=80";
+
+export function ComposeForm() {
+  const [cover, setCover] = useState<string | null>(null);
+  const [location, setLocation] = useState<string | null>(null);
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+
+  return (
+    <div className="flex flex-col">
+      {/* Cover photo */}
+      <div className="px-5 pt-4">
+        {cover ? (
+          <div className="relative aspect-[16/10] w-full overflow-hidden rounded-2xl bg-neutral-100">
+            <img
+              src={cover}
+              alt="Story cover"
+              className="h-full w-full object-cover"
+            />
+            <button
+              type="button"
+              onClick={() => setCover(null)}
+              className="absolute right-2.5 top-2.5 rounded-full bg-black/55 p-1.5 text-white backdrop-blur active:scale-95"
+              aria-label="Remove cover photo"
+            >
+              <X size={16} strokeWidth={2.5} />
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setCover(SAMPLE_COVER)}
+            className="flex aspect-[16/10] w-full flex-col items-center justify-center gap-2 rounded-2xl border-2 border-dashed border-neutral-300 bg-neutral-50 text-neutral-500 active:bg-neutral-100"
+          >
+            <ImagePlus size={26} strokeWidth={2} />
+            <span className="text-[14px] font-medium">Add a cover photo</span>
+          </button>
+        )}
+      </div>
+
+      {/* Location */}
+      <div className="px-5 pt-4">
+        {location ? (
+          <span className="inline-flex items-center gap-1.5 rounded-full bg-[#FFEFEF] px-3 py-1.5 text-[13px] font-semibold text-[#FF5A5F]">
+            <MapPin size={14} strokeWidth={2.5} />
+            {location}
+            <button
+              type="button"
+              onClick={() => setLocation(null)}
+              className="-mr-1 ml-0.5 rounded-full p-0.5 active:bg-[#FF5A5F]/15"
+              aria-label="Remove location"
+            >
+              <X size={13} strokeWidth={3} />
+            </button>
+          </span>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setLocation("Kyoto, Japan")}
+            className="inline-flex items-center gap-1.5 rounded-full border border-neutral-300 px-3 py-1.5 text-[13px] font-medium text-neutral-600 active:bg-neutral-100"
+          >
+            <MapPin size={14} strokeWidth={2.5} />
+            Add location
+          </button>
+        )}
+      </div>
+
+      {/* Title */}
+      <div className="px-5 pt-4">
+        <Input
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Give your story a title"
+          className="h-12 border-0 px-0 text-[20px] font-bold tracking-tight shadow-none placeholder:font-bold placeholder:text-neutral-300 focus-visible:ring-0"
+        />
+      </div>
+
+      {/* Body */}
+      <div className="px-5 pb-6">
+        <Textarea
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          placeholder="Share what made this trip unforgettable…"
+          rows={12}
+          className="min-h-[260px] resize-none border-0 px-0 text-[15px] leading-relaxed shadow-none placeholder:text-neutral-400 focus-visible:ring-0"
+        />
+      </div>
+    </div>
+  );
+}

--- a/apps/docs/src/demo/voyage/page/compose/compose-toolbar.tsx
+++ b/apps/docs/src/demo/voyage/page/compose/compose-toolbar.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { Camera, MapPin, Smile, Hash, Heading } from "lucide-react";
+
+const tools = [
+  { icon: Camera, label: "Add photo" },
+  { icon: MapPin, label: "Add location" },
+  { icon: Heading, label: "Heading" },
+  { icon: Hash, label: "Add tag" },
+  { icon: Smile, label: "Add emoji" },
+];
+
+export function ComposeToolbar() {
+  return (
+    <div className="flex items-center gap-1 border-t border-neutral-200/80 bg-white px-3 py-2">
+      {tools.map(({ icon: Icon, label }) => (
+        <button
+          key={label}
+          type="button"
+          className="rounded-full p-2 text-neutral-600 active:bg-neutral-100"
+          aria-label={label}
+        >
+          <Icon size={19} strokeWidth={2} />
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/docs/src/demo/voyage/page/compose/index.tsx
+++ b/apps/docs/src/demo/voyage/page/compose/index.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import { ComposeBar } from "./compose-bar";
+import { ComposeForm } from "./compose-form";
+import { ComposeToolbar } from "./compose-toolbar";
+
+export default function ComposePage() {
+  return (
+    <div className="relative flex min-h-full flex-col bg-white">
+      <ComposeBar />
+      <div className="flex-1 overflow-y-auto">
+        <ComposeForm />
+      </div>
+      <ComposeToolbar />
+    </div>
+  );
+}

--- a/apps/docs/src/demo/voyage/page/feed/bottom-nav.tsx
+++ b/apps/docs/src/demo/voyage/page/feed/bottom-nav.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Compass, Bookmark, Map, User } from "lucide-react";
+
+const items = [
+  { label: "Explore", icon: Compass, active: true },
+  { label: "Saved", icon: Bookmark, active: false },
+  { label: "Trips", icon: Map, active: false },
+  { label: "Profile", icon: User, active: false },
+];
+
+export function BottomNav() {
+  return (
+    <nav className="grid grid-cols-4 border-t border-neutral-200/70 bg-white">
+      {items.map(({ label, icon: Icon, active }) => (
+        <button
+          key={label}
+          type="button"
+          className="flex flex-col items-center gap-1 py-2.5"
+        >
+          <Icon
+            size={22}
+            strokeWidth={active ? 2.5 : 2}
+            className={active ? "text-[#FF5A5F]" : "text-neutral-400"}
+          />
+          <span
+            className={`text-[11px] ${
+              active ? "font-semibold text-neutral-900" : "text-neutral-500"
+            }`}
+          >
+            {label}
+          </span>
+        </button>
+      ))}
+    </nav>
+  );
+}

--- a/apps/docs/src/demo/voyage/page/feed/compose-fab.tsx
+++ b/apps/docs/src/demo/voyage/page/feed/compose-fab.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { Link } from "@/lib/link";
+import { PenLine } from "lucide-react";
+
+export function ComposeFab() {
+  return (
+    <Link
+      href="/demo/voyage/compose"
+      scroll={false}
+      className="flex items-center gap-2 rounded-full bg-[#FF5A5F] px-5 py-3.5 text-[15px] font-semibold text-white shadow-[0_8px_20px_-6px_rgba(255,90,95,0.7)] active:bg-[#e84e53]"
+      aria-label="Write a new story"
+    >
+      <PenLine size={19} strokeWidth={2.5} />
+      <span>New story</span>
+    </Link>
+  );
+}

--- a/apps/docs/src/demo/voyage/page/feed/index.tsx
+++ b/apps/docs/src/demo/voyage/page/feed/index.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect } from "react";
+import { useStory } from "@/demo/voyage/state/story";
+import { TopBar } from "./top-bar";
+import { StoryList } from "./story-list";
+import { ComposeFab } from "./compose-fab";
+
+export default function FeedPage() {
+  const story = useStory((s) => ({ actions: s.actions }));
+  useEffect(() => {
+    story.actions.loadStories();
+  }, [story.actions]);
+
+  // The compose FAB sits outside the scrolled content block so the rising
+  // sheet does not drag it along (same approach as material-mail's inbox).
+  return (
+    <>
+      <div className="flex min-h-full flex-col bg-white">
+        <TopBar />
+        <div className="flex-1 pb-6">
+          <StoryList />
+        </div>
+      </div>
+      <div className="sticky bottom-5 z-20 flex justify-end px-5 pointer-events-none">
+        <div className="pointer-events-auto">
+          <ComposeFab />
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/docs/src/demo/voyage/page/feed/story-card.tsx
+++ b/apps/docs/src/demo/voyage/page/feed/story-card.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { useState } from "react";
+import { Bookmark, Heart, MapPin } from "lucide-react";
+import { toast } from "sonner";
+import type { StorySimple } from "@/demo/voyage/state/story";
+
+export function StoryCard({ story }: { story: StorySimple }) {
+  const [saved, setSaved] = useState(story.saved);
+  const [liked, setLiked] = useState(false);
+
+  return (
+    <article className="relative flex flex-col">
+      {/* The cover is the only <button> over the image. The save control is a
+          sibling overlay (not nested) — nesting <button> in <button> is invalid
+          HTML and trips a hydration error. */}
+      <button
+        type="button"
+        onClick={() => toast("Story detail is mocked in this demo")}
+        className="relative block aspect-[4/5] w-full overflow-hidden rounded-3xl bg-neutral-100 text-left"
+      >
+        <img
+          src={story.cover}
+          alt={story.location}
+          loading="lazy"
+          className="h-full w-full object-cover"
+        />
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-2/5 bg-gradient-to-t from-black/55 to-transparent" />
+        <span className="pointer-events-none absolute bottom-3 left-3 inline-flex items-center gap-1 rounded-full bg-white/90 px-2.5 py-1 text-[12px] font-semibold text-neutral-900 shadow-sm backdrop-blur">
+          <MapPin size={13} strokeWidth={2.5} className="text-[#FF5A5F]" />
+          {story.location}
+        </span>
+      </button>
+      <button
+        type="button"
+        onClick={() => setSaved((v) => !v)}
+        aria-label={saved ? "Remove from saved" : "Save story"}
+        className="absolute right-3 top-3 rounded-full bg-white/90 p-2 text-neutral-900 shadow-sm backdrop-blur active:scale-95"
+      >
+        <Bookmark
+          size={17}
+          strokeWidth={2.25}
+          fill={saved ? "currentColor" : "none"}
+        />
+      </button>
+
+      <div className="px-0.5 pt-3">
+        <h3 className="text-[17px] font-bold leading-snug tracking-tight text-neutral-900">
+          {story.title}
+        </h3>
+        <p className="mt-1.5 line-clamp-2 text-[14px] leading-relaxed text-neutral-600">
+          {story.excerpt}
+        </p>
+
+        <div className="mt-3 flex items-center gap-2.5">
+          <span
+            className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-[13px] font-semibold text-white ${story.authorColor}`}
+          >
+            {story.authorInitial}
+          </span>
+          <div className="min-w-0 flex-1 text-[12.5px] text-neutral-500">
+            <span className="font-semibold text-neutral-800">
+              {story.author}
+            </span>
+            <span className="px-1 text-neutral-300">·</span>
+            {story.timeLabel}
+            <span className="px-1 text-neutral-300">·</span>
+            {story.readMinutes} min read
+          </div>
+          <button
+            type="button"
+            onClick={() => setLiked((v) => !v)}
+            aria-label={liked ? "Unlike" : "Like"}
+            className="flex shrink-0 items-center gap-1 text-[13px] font-semibold text-neutral-500 active:scale-95"
+          >
+            <Heart
+              size={17}
+              strokeWidth={2.25}
+              className={liked ? "text-[#FF5A5F]" : ""}
+              fill={liked ? "#FF5A5F" : "none"}
+            />
+            {story.likes + (liked ? 1 : 0)}
+          </button>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/apps/docs/src/demo/voyage/page/feed/story-list.tsx
+++ b/apps/docs/src/demo/voyage/page/feed/story-list.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { useStory } from "@/demo/voyage/state/story";
+import { StoryCard } from "./story-card";
+
+export function StoryList() {
+  const story = useStory((s) => ({ stories: s.stories }));
+
+  if (story.stories.isLoading) {
+    return (
+      <div className="flex flex-col gap-7 px-5 pt-3">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="flex flex-col gap-3" aria-hidden>
+            <div className="aspect-[4/5] w-full animate-pulse rounded-3xl bg-neutral-100" />
+            <div className="h-4 w-3/4 animate-pulse rounded bg-neutral-100" />
+            <div className="h-3 w-1/2 animate-pulse rounded bg-neutral-100" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-7 px-5 pt-3">
+      {story.stories.data.map((s) => (
+        <StoryCard key={s.id} story={s} />
+      ))}
+    </div>
+  );
+}

--- a/apps/docs/src/demo/voyage/page/feed/top-bar.tsx
+++ b/apps/docs/src/demo/voyage/page/feed/top-bar.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { Bell, Globe2 } from "lucide-react";
+
+export function TopBar() {
+  return (
+    <div className="sticky top-0 z-10 flex items-center justify-between bg-white/95 px-5 pt-5 pb-3 backdrop-blur-sm">
+      <div className="flex items-center gap-2">
+        <span className="flex h-8 w-8 items-center justify-center rounded-xl bg-[#FF5A5F] text-white">
+          <Globe2 size={18} strokeWidth={2.5} />
+        </span>
+        <span className="text-[22px] font-extrabold tracking-tight text-neutral-900">
+          Voyage
+        </span>
+      </div>
+      <div className="flex items-center gap-1.5">
+        <button
+          type="button"
+          className="rounded-full p-2 text-neutral-700 active:bg-neutral-100"
+          aria-label="Notifications"
+        >
+          <Bell size={20} strokeWidth={2.25} />
+        </button>
+        <div className="flex h-9 w-9 items-center justify-center rounded-full bg-neutral-900 text-[13px] font-semibold text-white">
+          You
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/docs/src/demo/voyage/page/layout/client.tsx
+++ b/apps/docs/src/demo/voyage/page/layout/client.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { usePathname } from "next/navigation";
+import { type SsgoiConfig } from "@ssgoi/react";
+import { sheet } from "@ssgoi/react/view-transitions";
+import { MobileShowcaseShell } from "@/lib/components/mobile-showcase-shell";
+import { BottomNav } from "../feed/bottom-nav";
+
+const BASE = "/demo/voyage";
+
+// Voyage showcases the `sheet` "blur" tone: tapping "New story" raises the
+// compose sheet while the feed underneath blurs and recedes — a modal pushing
+// the page out of focus, the way Gmail's compose floats over the inbox.
+const config: SsgoiConfig = {
+  preserveScroll: true,
+  transitions: [
+    ...sheet({
+      type: "blur",
+      enter: `${BASE}/compose`,
+      exit: BASE,
+    }),
+  ],
+};
+
+/**
+ * Bottom nav lives outside the page transition (mirrors material-mail). It only
+ * shows on the feed — the compose sheet covers it from above anyway.
+ */
+function BottomNavSlot() {
+  const pathname = usePathname();
+  if (pathname === BASE) return <BottomNav />;
+  return null;
+}
+
+export function VoyageLayoutClient({ children }: { children: ReactNode }) {
+  return (
+    <MobileShowcaseShell
+      config={config}
+      contentClassName="bg-white"
+      bottomSlot={<BottomNavSlot />}
+    >
+      {children}
+    </MobileShowcaseShell>
+  );
+}

--- a/apps/docs/src/demo/voyage/page/layout/index.tsx
+++ b/apps/docs/src/demo/voyage/page/layout/index.tsx
@@ -1,0 +1,6 @@
+import type { ReactNode } from "react";
+import { VoyageLayoutClient } from "./client";
+
+export default function VoyageLayout({ children }: { children: ReactNode }) {
+  return <VoyageLayoutClient>{children}</VoyageLayoutClient>;
+}

--- a/apps/docs/src/demo/voyage/showcase.ts
+++ b/apps/docs/src/demo/voyage/showcase.ts
@@ -1,0 +1,25 @@
+import type { ShowcaseApp } from "@/page/showcase/types";
+
+export const voyageShowcase: ShowcaseApp = {
+  slug: "voyage",
+  name: "Voyage",
+  tagline: "Travel-story feed with a sheet/blur compose modal",
+  platforms: ["mobile"],
+  category: "Travel",
+  badge: "New",
+  logo: "/voyage-icon.svg",
+  demoOrigin: "/demo/voyage",
+  transitions: ["sheet"],
+  sourcePath: "apps/docs/src/demo/voyage",
+  previewTransition: "sheet",
+  clips: [
+    {
+      title: "Feed → New story",
+      transition: "sheet",
+      enterPath: "/demo/voyage/compose",
+      exitPath: "/demo/voyage",
+      caption:
+        "Sheet blur — the feed blurs and recedes behind the compose sheet",
+    },
+  ],
+};

--- a/apps/docs/src/demo/voyage/state/story/actions/load.ts
+++ b/apps/docs/src/demo/voyage/state/story/actions/load.ts
@@ -1,0 +1,15 @@
+import { action } from "comwit";
+import { story } from "../model";
+import type { StoryActions } from "../types";
+
+export const loadActions = action<Pick<StoryActions, "loadStories">>(
+  ({ state }) => {
+    class LoadActions {
+      private model = state(story);
+      async loadStories() {
+        await this.model.stories.query();
+      }
+    }
+    return new LoadActions();
+  },
+);

--- a/apps/docs/src/demo/voyage/state/story/index.ts
+++ b/apps/docs/src/demo/voyage/state/story/index.ts
@@ -1,0 +1,10 @@
+import { create } from "comwit";
+import { story } from "./model";
+import { loadActions } from "./actions/load";
+import type { StoryState, StoryActions } from "./types";
+
+export * from "./types";
+
+export const useStory = create<StoryState, StoryActions>(story, {
+  actions: [loadActions],
+});

--- a/apps/docs/src/demo/voyage/state/story/model.ts
+++ b/apps/docs/src/demo/voyage/state/story/model.ts
@@ -1,0 +1,11 @@
+import { model, query, keepPreviousData } from "comwit";
+import { story as storyAPI } from "@/demo/voyage/api/story";
+import type { StoryState } from "./types";
+
+export const story = model<StoryState>({
+  stories: query<StoryState["stories"]["data"], void>({
+    initialData: [],
+    queryFn: () => storyAPI.findAll(),
+    placeholderData: keepPreviousData,
+  }),
+});

--- a/apps/docs/src/demo/voyage/state/story/types.ts
+++ b/apps/docs/src/demo/voyage/state/story/types.ts
@@ -1,0 +1,12 @@
+import type { Query } from "comwit";
+import type { StorySimple } from "@/demo/voyage/api/story";
+
+export type StoryState = {
+  stories: Query<StorySimple[], void>;
+};
+
+export type StoryActions = {
+  loadStories(): Promise<void>;
+};
+
+export type { StorySimple };

--- a/apps/docs/src/page/docs/transitions-data.ts
+++ b/apps/docs/src/page/docs/transitions-data.ts
@@ -259,6 +259,17 @@ export const TRANSITION_DOCS: TransitionDoc[] = [
           },
         ],
       },
+      {
+        label: "blur",
+        args: 'type: "blur"',
+        ux: "The background page blurs and recedes behind the rising sheet — a modal pushing the page out of focus.",
+        demos: [
+          {
+            enterPath: "/demo/voyage/compose",
+            exitPath: "/demo/voyage",
+          },
+        ],
+      },
     ],
   },
   {

--- a/apps/docs/src/page/showcase/data.ts
+++ b/apps/docs/src/page/showcase/data.ts
@@ -11,6 +11,7 @@ import { noraHaleShowcase } from "@/demo/nora-hale/showcase";
 import { pinterestShowcase } from "@/demo/pinterest/showcase";
 import { silentRoomShowcase } from "@/demo/silent-room/showcase";
 import { ssgoiDocsShowcase } from "@/demo/ssgoi-docs/showcase";
+import { voyageShowcase } from "@/demo/voyage/showcase";
 import { youtubeMusicWebShowcase } from "@/demo/youtube-music-web/showcase";
 import { yuzuClubShowcase } from "@/demo/yuzu-club/showcase";
 import type { ShowcaseApp, ShowcaseClip } from "./types";
@@ -33,6 +34,7 @@ export const showcases: ShowcaseApp[] = [
   pinterestShowcase,
   gamjaMarketShowcase,
   materialMailShowcase,
+  voyageShowcase,
   //web
   youtubeMusicWebShowcase,
   airbnbPhotoTourShowcase,

--- a/packages/core/src/lib/transitions/sheet/index.ts
+++ b/packages/core/src/lib/transitions/sheet/index.ts
@@ -13,8 +13,10 @@ import type { SheetType as InternalSheetType } from "./types";
  * - `"scale"` — the background scales down slightly behind the rising sheet.
  *   This is the new name for the legacy `"background-scale"` value; the
  *   underlying behavior is unchanged.
+ * - `"blur"` — the background blurs and recedes (subtle scale + dim) behind the
+ *   rising sheet, the way a modal pushes the page underneath out of focus.
  */
-export type SheetType = "static" | "scale";
+export type SheetType = "static" | "scale" | "blur";
 
 /**
  * Legacy public `type` value, kept for source compatibility only.
@@ -30,6 +32,7 @@ export type SheetConfig = DirectionalTransitionPaths &
   (
     | { type?: "static"; variant?: "default"; options?: Record<string, never> }
     | { type: "scale"; variant?: "default"; options?: Record<string, never> }
+    | { type: "blur"; variant?: "default"; options?: Record<string, never> }
     | {
         /**
          * @deprecated Do not use in new code. v6 only supports `{ type, variant, options }`.
@@ -54,6 +57,7 @@ function resolveInternalType(
 ): InternalSheetType {
   if (type === "scale") return "background-scale";
   if (type === "background-scale") return "background-scale";
+  if (type === "blur") return "blur";
   return "static";
 }
 

--- a/packages/core/src/lib/transitions/sheet/provider/blur.test.ts
+++ b/packages/core/src/lib/transitions/sheet/provider/blur.test.ts
@@ -2,46 +2,64 @@ import { describe, expect, it } from "vitest";
 import { createBlurProvider } from "./blur";
 
 describe("sheet blur provider", () => {
-  const { background } = createBlurProvider();
+  const { background, overlay } = createBlurProvider();
 
-  it("declares the filter channels it animates", () => {
-    expect(background.willChange).toContain("filter");
-    expect(background.willChange).toContain("transform");
-    expect(background.willChange).toContain("opacity");
+  it("keeps the blur off the background — it only recedes (scale + dim)", () => {
+    expect(background.willChange).toBe("transform, opacity");
+    expect(background.willChange).not.toContain("filter");
   });
 
-  it("enter ramps from rest to frosted-and-receded", () => {
-    const rest = background.enterStyle(0, 1);
-    expect(rest).toEqual({
+  it("background enter ramps from rest to receded", () => {
+    expect(background.enterStyle(0, 1)).toEqual({
       transform: "scale(1)",
-      filter: "blur(0.00px)",
       opacity: 1,
     });
 
     const peak = background.enterStyle(1, 0);
     expect(peak.transform).toBe("scale(0.92)");
-    expect(peak.filter).toBe("blur(16.00px)");
     expect(peak.opacity).toBeCloseTo(0.6);
   });
 
-  it("exit is the inverse ramp — frosted back to rest", () => {
+  it("background exit is the inverse ramp — receded back to rest", () => {
     const start = background.exitStyle(0);
     expect(start.transform).toBe("scale(0.92)");
-    expect(start.filter).toBe("blur(16.00px)");
     expect(start.opacity).toBeCloseTo(0.6);
 
-    const rest = background.exitStyle(1);
-    expect(rest).toEqual({
+    expect(background.exitStyle(1)).toEqual({
       transform: "scale(1)",
-      filter: "blur(0.00px)",
       opacity: 1,
     });
   });
 
-  it("clamps the blur radius to >= 0 when the spring overshoots", () => {
-    // enter overshoot below 0 and exit overshoot past 1 both push the raw
-    // radius negative — it must clamp, never emit `blur(-Npx)` (invalid CSS).
-    expect(background.enterStyle(-0.1, 1.1).filter).toBe("blur(0.00px)");
-    expect(background.exitStyle(1.1).filter).toBe("blur(0.00px)");
+  it("exposes a backdrop-filter overlay layer that owns the blur", () => {
+    expect(overlay).toBeDefined();
+    expect(overlay?.willChange).toContain("backdrop-filter");
+    // The overlay starts fully transparent so applying it before the first
+    // tick has no visible cost.
+    expect(overlay?.initialStyle.backdropFilter).toBe("blur(0px)");
+    expect(overlay?.initialStyle.pointerEvents).toBe("none");
+  });
+
+  it("overlay frosts in on enter and out on exit", () => {
+    const frost = (s: { backdropFilter?: string | number }) => s.backdropFilter;
+
+    // enter: progress 0 → 1 ramps blur 0 → MAX.
+    expect(frost(overlay!.style("enter", 0))).toBe("blur(0.00px)");
+    expect(frost(overlay!.style("enter", 1))).toBe("blur(16.00px)");
+
+    // exit: progress 0 → 1 ramps blur MAX → 0 (visual is inverted).
+    expect(frost(overlay!.style("exit", 0))).toBe("blur(16.00px)");
+    expect(frost(overlay!.style("exit", 1))).toBe("blur(0.00px)");
+
+    // both vendor keys move together.
+    const peak = overlay!.style("enter", 1);
+    expect(peak.WebkitBackdropFilter).toBe(peak.backdropFilter);
+  });
+
+  it("clamps the overlay blur radius to >= 0 when progress overshoots", () => {
+    // reversed enter (progress < 0) and exit overshoot (progress > 1) both
+    // push the raw radius negative — it must clamp, never emit blur(-Npx).
+    expect(overlay!.style("enter", -0.1).backdropFilter).toBe("blur(0.00px)");
+    expect(overlay!.style("exit", 1.1).backdropFilter).toBe("blur(0.00px)");
   });
 });

--- a/packages/core/src/lib/transitions/sheet/provider/blur.test.ts
+++ b/packages/core/src/lib/transitions/sheet/provider/blur.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { createBlurProvider } from "./blur";
+
+describe("sheet blur provider", () => {
+  const { background } = createBlurProvider();
+
+  it("declares the filter channels it animates", () => {
+    expect(background.willChange).toContain("filter");
+    expect(background.willChange).toContain("transform");
+    expect(background.willChange).toContain("opacity");
+  });
+
+  it("enter ramps from rest to frosted-and-receded", () => {
+    const rest = background.enterStyle(0, 1);
+    expect(rest).toEqual({
+      transform: "scale(1)",
+      filter: "blur(0.00px)",
+      opacity: 1,
+    });
+
+    const peak = background.enterStyle(1, 0);
+    expect(peak.transform).toBe("scale(0.92)");
+    expect(peak.filter).toBe("blur(16.00px)");
+    expect(peak.opacity).toBeCloseTo(0.6);
+  });
+
+  it("exit is the inverse ramp — frosted back to rest", () => {
+    const start = background.exitStyle(0);
+    expect(start.transform).toBe("scale(0.92)");
+    expect(start.filter).toBe("blur(16.00px)");
+    expect(start.opacity).toBeCloseTo(0.6);
+
+    const rest = background.exitStyle(1);
+    expect(rest).toEqual({
+      transform: "scale(1)",
+      filter: "blur(0.00px)",
+      opacity: 1,
+    });
+  });
+
+  it("clamps the blur radius to >= 0 when the spring overshoots", () => {
+    // enter overshoot below 0 and exit overshoot past 1 both push the raw
+    // radius negative — it must clamp, never emit `blur(-Npx)` (invalid CSS).
+    expect(background.enterStyle(-0.1, 1.1).filter).toBe("blur(0.00px)");
+    expect(background.exitStyle(1.1).filter).toBe("blur(0.00px)");
+  });
+});

--- a/packages/core/src/lib/transitions/sheet/provider/blur.ts
+++ b/packages/core/src/lib/transitions/sheet/provider/blur.ts
@@ -1,0 +1,61 @@
+import type { PhysicsOptions } from "@types";
+import type { SheetProvider } from "../types";
+
+// ease-out spring for the rising sheet (mirrors the scale tone's feel).
+const ENTER_PHYSICS: PhysicsOptions = {
+  spring: { stiffness: 200, damping: 24 },
+};
+
+// ease-in inertia for the falling sheet (outgoing).
+const EXIT_PHYSICS: PhysicsOptions = {
+  inertia: { acceleration: 25, resistance: 1.2 },
+};
+
+// The background recedes by this much at peak — kept subtle on purpose. The
+// blur is the primary "step back" cue here, so the scale only needs to hint
+// at depth (the `scale` tone uses a much larger 0.2).
+const SCALE_OFFSET = 0.08;
+
+// Peak gaussian blur (px) applied to the background page when the sheet is
+// fully risen. Matches the zoom `blur` tone's frosted-glass amount.
+const MAX_BLUR_PX = 16;
+
+// The background also dims a touch so the foreground sheet reads as the focus.
+// Floor opacity at peak (never fully transparent — the rising sheet already
+// covers it, and a partial dim looks richer mid-transit than a hard fade).
+const MIN_OPACITY = 0.6;
+
+// Springs/inertia overshoot past the endpoints: exit (t > 1) drives
+// blur(MAX * (1 - t)) negative, and an interrupted/reversed enter (t < 0) drives
+// blur(MAX * t) negative — both invalid CSS. Clamp the radius to >= 0.
+const blur = (px: number) => `blur(${Math.max(0, px).toFixed(2)}px)`;
+
+/**
+ * `blur` sheet tone — the background page blurs and recedes behind the rising
+ * sheet, the way a modal pushes the page underneath out of focus. A small
+ * scale + dim gives the recede some depth without the heavy stacked-card shrink
+ * of the `scale` tone.
+ */
+export function createBlurProvider(): SheetProvider {
+  return {
+    enterPhysics: ENTER_PHYSICS,
+    exitPhysics: EXIT_PHYSICS,
+    background: {
+      willChange: "transform, opacity, filter",
+      // enter: t 0 → 1 as the sheet rises (u = 1 - t). At rest (t = 0) the page
+      // is untouched; at peak it is shrunk, blurred and dimmed.
+      enterStyle: (t) => ({
+        transform: `scale(${1 - SCALE_OFFSET * t})`,
+        filter: blur(MAX_BLUR_PX * t),
+        opacity: 1 - (1 - MIN_OPACITY) * t,
+      }),
+      // exit: t 0 → 1 as the sheet falls away and the page returns to rest. The
+      // visual ramp is the inverse of enter.
+      exitStyle: (t) => ({
+        transform: `scale(${1 - SCALE_OFFSET + SCALE_OFFSET * t})`,
+        filter: blur(MAX_BLUR_PX * (1 - t)),
+        opacity: MIN_OPACITY + (1 - MIN_OPACITY) * t,
+      }),
+    },
+  };
+}

--- a/packages/core/src/lib/transitions/sheet/provider/blur.ts
+++ b/packages/core/src/lib/transitions/sheet/provider/blur.ts
@@ -61,9 +61,12 @@ export function createBlurProvider(): SheetProvider {
     },
     overlay: {
       willChange: "backdrop-filter",
+      // `top` + `height` are set per-transition in transition.ts (they depend on
+      // the live scroll position), so they are intentionally omitted here.
       initialStyle: {
         position: "absolute",
-        inset: "0",
+        left: "0",
+        width: "100%",
         pointerEvents: "none",
         backdropFilter: "blur(0px)",
         WebkitBackdropFilter: "blur(0px)",

--- a/packages/core/src/lib/transitions/sheet/provider/blur.ts
+++ b/packages/core/src/lib/transitions/sheet/provider/blur.ts
@@ -16,8 +16,8 @@ const EXIT_PHYSICS: PhysicsOptions = {
 // at depth (the `scale` tone uses a much larger 0.2).
 const SCALE_OFFSET = 0.08;
 
-// Peak gaussian blur (px) applied to the background page when the sheet is
-// fully risen. Matches the zoom `blur` tone's frosted-glass amount.
+// Peak backdrop blur (px) applied to the overlay layer when the sheet is fully
+// risen. Matches the zoom `blur` tone's frosted-glass amount.
 const MAX_BLUR_PX = 16;
 
 // The background also dims a touch so the foreground sheet reads as the focus.
@@ -25,37 +25,56 @@ const MAX_BLUR_PX = 16;
 // covers it, and a partial dim looks richer mid-transit than a hard fade).
 const MIN_OPACITY = 0.6;
 
-// Springs/inertia overshoot past the endpoints: exit (t > 1) drives
-// blur(MAX * (1 - t)) negative, and an interrupted/reversed enter (t < 0) drives
-// blur(MAX * t) negative — both invalid CSS. Clamp the radius to >= 0.
+// Springs/inertia overshoot past the endpoints (exit t > 1, reversed enter
+// t < 0), which would drive the radius negative — invalid CSS. Clamp to >= 0.
 const blur = (px: number) => `blur(${Math.max(0, px).toFixed(2)}px)`;
 
 /**
  * `blur` sheet tone — the background page blurs and recedes behind the rising
- * sheet, the way a modal pushes the page underneath out of focus. A small
- * scale + dim gives the recede some depth without the heavy stacked-card shrink
- * of the `scale` tone.
+ * sheet, the way a modal pushes the page underneath out of focus.
+ *
+ * The blur lives on a *separate* overlay layer (a `backdrop-filter` between the
+ * background and the sheet) rather than on the background element itself. That
+ * keeps the frost uniform and decoupled from the background's clip + scale —
+ * applying `filter: blur` directly to the clipped/scaled page would hard-cut
+ * the blur halo at the clip edge and ride the scale transform. The background
+ * only carries the recede (a small scale + dim); the overlay owns the blur.
  */
 export function createBlurProvider(): SheetProvider {
   return {
     enterPhysics: ENTER_PHYSICS,
     exitPhysics: EXIT_PHYSICS,
     background: {
-      willChange: "transform, opacity, filter",
-      // enter: t 0 → 1 as the sheet rises (u = 1 - t). At rest (t = 0) the page
-      // is untouched; at peak it is shrunk, blurred and dimmed.
+      willChange: "transform, opacity",
+      // enter: t 0 → 1 as the sheet rises. At rest (t = 0) the page is
+      // untouched; at peak it is shrunk and dimmed.
       enterStyle: (t) => ({
         transform: `scale(${1 - SCALE_OFFSET * t})`,
-        filter: blur(MAX_BLUR_PX * t),
         opacity: 1 - (1 - MIN_OPACITY) * t,
       }),
-      // exit: t 0 → 1 as the sheet falls away and the page returns to rest. The
-      // visual ramp is the inverse of enter.
+      // exit: t 0 → 1 as the sheet falls away and the page returns to rest —
+      // the inverse ramp of enter.
       exitStyle: (t) => ({
         transform: `scale(${1 - SCALE_OFFSET + SCALE_OFFSET * t})`,
-        filter: blur(MAX_BLUR_PX * (1 - t)),
         opacity: MIN_OPACITY + (1 - MIN_OPACITY) * t,
       }),
+    },
+    overlay: {
+      willChange: "backdrop-filter",
+      initialStyle: {
+        position: "absolute",
+        inset: "0",
+        pointerEvents: "none",
+        backdropFilter: "blur(0px)",
+        WebkitBackdropFilter: "blur(0px)",
+      },
+      // enter: 0 → MAX as the sheet rises (progress 0 → 1).
+      // exit: MAX → 0 as it falls (progress 0 → 1, so the visual is inverted).
+      style: (direction, progress) => {
+        const visual = direction === "enter" ? progress : 1 - progress;
+        const b = blur(MAX_BLUR_PX * visual);
+        return { backdropFilter: b, WebkitBackdropFilter: b };
+      },
     },
   };
 }

--- a/packages/core/src/lib/transitions/sheet/provider/index.ts
+++ b/packages/core/src/lib/transitions/sheet/provider/index.ts
@@ -1,8 +1,10 @@
 import { createBackgroundScaleProvider } from "./background-scale";
+import { createBlurProvider } from "./blur";
 import { createStaticProvider } from "./static";
 import type { SheetProvider, SheetType } from "../types";
 
 export const SHEET_PROVIDERS: Record<SheetType, SheetProvider> = {
   static: createStaticProvider(),
   "background-scale": createBackgroundScaleProvider(),
+  blur: createBlurProvider(),
 };

--- a/packages/core/src/lib/transitions/sheet/transition.ts
+++ b/packages/core/src/lib/transitions/sheet/transition.ts
@@ -1,5 +1,5 @@
 import type { TransitionConfig } from "@types";
-import { getViewportRect } from "@utils";
+import { getViewportRect, getOverlayRect } from "@utils";
 import {
   IntegratorProvider,
   MultiAnimation,
@@ -235,6 +235,19 @@ export const sheet = (
       // the created node on settle, so no inline-style cleanup is needed.
       if (overlay && overlayConfig) {
         overlay.style.zIndex = Z_OVERLAY;
+        // The overlay must stay inside positionedParent so it sits between the
+        // background and the sheet in the stacking order. But positionedParent
+        // is the scroll container, and absolute children of a scroll container
+        // translate with the content — a plain inset:0 would ride the scroll
+        // and leave the bottom `scroll.y` px of the viewport unblurred (a
+        // missing strip, seen on exit once the sheet drops past it). The
+        // container is restored to the INCOMING page's scroll
+        // (context.to.scroll.y) for the whole run, so anchor the overlay to
+        // that live viewport slice instead (getOverlayRect backs out both the
+        // scroll and positionedParent's own offset so it covers [0, viewport]).
+        const overlayRect = getOverlayRect(context, "to");
+        overlay.style.top = `${overlayRect.top}px`;
+        overlay.style.height = `${overlayRect.height}px`;
         anims.push(
           new WebAnimation({
             element: overlay,

--- a/packages/core/src/lib/transitions/sheet/transition.ts
+++ b/packages/core/src/lib/transitions/sheet/transition.ts
@@ -183,6 +183,9 @@ export const sheet = (options: SheetOptions = {}): TransitionConfig => {
           backgroundEl.style.transformOrigin = "";
           backgroundEl.style.transform = "";
           backgroundEl.style.opacity = "";
+          // `blur` tone leaves a filter on the background; clear it too so the
+          // reused node is not shown still frosted next time.
+          backgroundEl.style.filter = "";
         },
       });
       releaseFillOnSettle(bgAnim);

--- a/packages/core/src/lib/transitions/sheet/transition.ts
+++ b/packages/core/src/lib/transitions/sheet/transition.ts
@@ -6,7 +6,7 @@ import {
   WebAnimation,
 } from "../../animation";
 import { SHEET_PROVIDERS } from "./provider";
-import { Z_BACKGROUND, Z_FOREGROUND } from "../stacking";
+import { Z_BACKGROUND, Z_FOREGROUND, Z_OVERLAY } from "../stacking";
 import type { SheetOptions, SheetType } from "./types";
 
 export type { SheetOptions, SheetType } from "./types";
@@ -14,17 +14,25 @@ export type { SheetOptions, SheetType } from "./types";
 const DEFAULT_TYPE: SheetType = "static";
 const SHEET_WILL_CHANGE = "transform";
 
-export const sheet = (options: SheetOptions = {}): TransitionConfig => {
+/** Prepare → animation hand-off: the optional backdrop-filter overlay layer. */
+interface SheetExtras {
+  overlay?: HTMLElement;
+}
+
+export const sheet = (
+  options: SheetOptions = {},
+): TransitionConfig<SheetExtras> => {
   const direction = options.direction ?? "enter";
   const provider = SHEET_PROVIDERS[options.type ?? DEFAULT_TYPE];
   const physics =
     direction === "enter" ? provider.enterPhysics : provider.exitPhysics;
   const bg = provider.background;
+  const overlayConfig = provider.overlay;
   // Empty willChange == "don't touch the background at all" (zoom-style static).
   const animatesBackground = bg.willChange !== "";
 
   return {
-    prepare: ({ from, to }) => {
+    prepare: ({ from, to, context, createElement }) => {
       const sheet = direction === "enter" ? to : from;
       const background = direction === "enter" ? from : to;
 
@@ -65,9 +73,23 @@ export const sheet = (options: SheetOptions = {}): TransitionConfig => {
         }
       });
 
-      return {};
+      // Tones that frost the background (currently `blur`) need a separate
+      // backdrop-filter layer between the background and the sheet. Stage it
+      // here and hand it to `animation` via extras. It is deliberately NOT
+      // clipped or scaled — keeping the blur on its own layer is what decouples
+      // it from the background's clip + scale. The dispatcher removes nodes
+      // created via `createElement` on settle, so it needs no teardown.
+      let overlay: HTMLElement | undefined;
+      if (overlayConfig) {
+        overlay = createElement("sheet-overlay");
+        Object.assign(overlay.style, overlayConfig.initialStyle);
+        overlay.style.willChange = overlayConfig.willChange;
+        context.positionedParent.appendChild(overlay);
+      }
+
+      return { overlay };
     },
-    animation: ({ from, to, context }) => {
+    animation: ({ from, to, context, overlay }) => {
       const sheetEl = direction === "enter" ? to : from;
       const backgroundEl = direction === "enter" ? from : to;
       const sheetRect = getViewportRect(
@@ -145,52 +167,84 @@ export const sheet = (options: SheetOptions = {}): TransitionConfig => {
       });
       releaseFillOnSettle(sheetAnim);
 
-      if (!animatesBackground) {
-        // Static: the background sits untouched for the whole duration.
-        return new MultiAnimation([sheetAnim], { mode: "parallel" });
+      const anims: WebAnimation[] = [sheetAnim];
+
+      if (animatesBackground) {
+        // The clip slice below and the `contain: paint` set in prepare both
+        // assume the background's border box equals its full content height —
+        // the clip's `100%` is the element box, and the slice is offset by
+        // `scroll.y` so it lands at the viewport. But prepareOutgoing made the
+        // outgoing page `position: absolute`, under which a page root sized
+        // `height: 100%` (`h-full`) collapses to one viewport. `contain: paint`
+        // would then delete everything the user scrolled past, and the clip's
+        // `100%` would be a viewport — together leaving a white band of height
+        // `scroll.y` below the scrolled-in content. Pin the box to the real
+        // content height so both assumptions hold. Read after re-insertion
+        // (this runs in `animation`, where the node is laid out); guard against
+        // a 0 from an edge-case detached node so we never collapse it.
+        const contentHeight = backgroundEl.scrollHeight;
+        if (contentHeight > 0) {
+          backgroundEl.style.height = `${contentHeight}px`;
+        }
+
+        const bgRect = getViewportRect(
+          context,
+          direction === "enter" ? "from" : "to",
+        );
+        const bgCenterX = bgRect.left + bgRect.width / 2;
+        const bgCenterY = bgRect.top + bgRect.height / 2;
+        backgroundEl.style.clipPath = `inset(${bgRect.top}px 0 calc(100% - ${bgRect.top + bgRect.height}px) 0)`;
+        backgroundEl.style.transformOrigin = `${bgCenterX}px ${bgCenterY}px`;
+
+        const bgStyle =
+          direction === "enter"
+            ? (t: number, u: number) => bg.enterStyle(t, u)
+            : (t: number) => bg.exitStyle(t);
+
+        const bgAnim = new WebAnimation({
+          element: backgroundEl,
+          integrator: IntegratorProvider.from(physics),
+          style: bgStyle,
+          // The background is the reused outgoing (`from`) node on `enter` and
+          // the surviving incoming (`to`) node on `exit` — in both cases its
+          // inline styles must be cleared on settle so the reused node is not
+          // left scaled/faded/clipped the next time it is shown. releaseFill
+          // below drops the WAAPI fill so these resets actually take effect.
+          onComplete: () => {
+            backgroundEl.style.willChange = "auto";
+            backgroundEl.style.backfaceVisibility = "";
+            (
+              backgroundEl.style as CSSStyleDeclaration & { contain: string }
+            ).contain = "";
+            backgroundEl.style.clipPath = "";
+            backgroundEl.style.transformOrigin = "";
+            backgroundEl.style.transform = "";
+            backgroundEl.style.opacity = "";
+            // Release the content-height pin applied above.
+            backgroundEl.style.height = "";
+          },
+        });
+        releaseFillOnSettle(bgAnim);
+        anims.push(bgAnim);
       }
 
-      const bgRect = getViewportRect(
-        context,
-        direction === "enter" ? "from" : "to",
-      );
-      const bgCenterX = bgRect.left + bgRect.width / 2;
-      const bgCenterY = bgRect.top + bgRect.height / 2;
-      backgroundEl.style.clipPath = `inset(${bgRect.top}px 0 calc(100% - ${bgRect.top + bgRect.height}px) 0)`;
-      backgroundEl.style.transformOrigin = `${bgCenterX}px ${bgCenterY}px`;
+      // Blur tone: animate the backdrop-filter on the separate overlay layer.
+      // It sits at Z_OVERLAY — between the background (Z_BACKGROUND) and the
+      // sheet (Z_FOREGROUND) — so it frosts the receding background but never
+      // the sheet. Unclipped and unscaled by design. The dispatcher removes
+      // the created node on settle, so no inline-style cleanup is needed.
+      if (overlay && overlayConfig) {
+        overlay.style.zIndex = Z_OVERLAY;
+        anims.push(
+          new WebAnimation({
+            element: overlay,
+            integrator: IntegratorProvider.from(physics),
+            style: (t) => overlayConfig.style(direction, t),
+          }),
+        );
+      }
 
-      const bgStyle =
-        direction === "enter"
-          ? (t: number, u: number) => bg.enterStyle(t, u)
-          : (t: number) => bg.exitStyle(t);
-
-      const bgAnim = new WebAnimation({
-        element: backgroundEl,
-        integrator: IntegratorProvider.from(physics),
-        style: bgStyle,
-        // The background is the reused outgoing (`from`) node on `enter` and the
-        // surviving incoming (`to`) node on `exit` — in both cases its inline
-        // styles must be cleared on settle so the reused node is not left
-        // scaled/faded/clipped the next time it is shown. releaseFill below
-        // drops the WAAPI fill so these resets actually take effect.
-        onComplete: () => {
-          backgroundEl.style.willChange = "auto";
-          backgroundEl.style.backfaceVisibility = "";
-          (
-            backgroundEl.style as CSSStyleDeclaration & { contain: string }
-          ).contain = "";
-          backgroundEl.style.clipPath = "";
-          backgroundEl.style.transformOrigin = "";
-          backgroundEl.style.transform = "";
-          backgroundEl.style.opacity = "";
-          // `blur` tone leaves a filter on the background; clear it too so the
-          // reused node is not shown still frosted next time.
-          backgroundEl.style.filter = "";
-        },
-      });
-      releaseFillOnSettle(bgAnim);
-
-      return new MultiAnimation([sheetAnim, bgAnim], { mode: "parallel" });
+      return new MultiAnimation(anims, { mode: "parallel" });
     },
   };
 };

--- a/packages/core/src/lib/transitions/sheet/types.ts
+++ b/packages/core/src/lib/transitions/sheet/types.ts
@@ -10,7 +10,7 @@ import type { PhysicsOptions } from "@types";
  *
  * @internal
  */
-export type SheetType = "static" | "background-scale";
+export type SheetType = "static" | "background-scale" | "blur";
 export type SheetDirection = "enter" | "exit";
 
 export interface SheetOptions {

--- a/packages/core/src/lib/transitions/sheet/types.ts
+++ b/packages/core/src/lib/transitions/sheet/types.ts
@@ -26,8 +26,24 @@ export interface SheetBackgroundConfig {
   exitStyle: (t: number) => SheetStyle;
 }
 
+/**
+ * A separate full-viewport layer that sits *between* the background page and
+ * the foreground sheet (at `Z_OVERLAY`). Used by the `blur` tone to drive a
+ * `backdrop-filter` independently of the background's own clip + scale — the
+ * background recedes (clipped, scaled) while this layer frosts it uniformly,
+ * the way the zoom `blur` tone separates its blur overlay from the tile.
+ */
+export interface SheetOverlayConfig {
+  willChange: string;
+  initialStyle: Record<string, string>;
+  /** `progress` is the raw animation t (0 → 1) for the active direction. */
+  style: (direction: SheetDirection, progress: number) => SheetStyle;
+}
+
 export interface SheetProvider {
   enterPhysics: PhysicsOptions;
   exitPhysics: PhysicsOptions;
   background: SheetBackgroundConfig;
+  /** Only set by tones that need a backdrop-filter layer (currently `blur`). */
+  overlay?: SheetOverlayConfig;
 }

--- a/packages/core/src/lib/transitions/zoom/provider/blur.ts
+++ b/packages/core/src/lib/transitions/zoom/provider/blur.ts
@@ -15,6 +15,7 @@ import {
 } from "../../../animation";
 import { createZoomIn, createZoomOut } from "../zoom-element";
 import { Z_OVERLAY } from "../../stacking";
+import { getOverlayRect } from "@utils";
 
 export const BLUR_PHYSICS: PhysicsOptions = {
   spring: {
@@ -61,9 +62,12 @@ function backgroundIn(): ZoomAnimationConfig {
 
 const overlay: ZoomOverlayConfig = {
   willChange: "backdrop-filter",
+  // `top` + `height` are set per-transition in OverlayStrategy.contribute (they
+  // track the live scroll position), so they are intentionally omitted here.
   initialStyle: {
     position: "absolute",
-    inset: "0",
+    left: "0",
+    width: "100%",
     pointerEvents: "none",
     // z-index is applied in OverlayStrategy.contribute. The overlay always
     // sits at Z_OVERLAY, between the background page (Z_BACKGROUND) and the
@@ -133,6 +137,18 @@ export class OverlayStrategy implements ZoomStrategy {
     // Overlay is fully transparent (blur(0px)) until the first tick fires, so
     // applying the z-index here — after prepare, before paint — has no cost.
     overlayEl.style.zIndex = Z_OVERLAY;
+    // The overlay must stay inside positionedParent to sit between the
+    // background and the tile in the stacking order — but positionedParent is
+    // the scroll container, and absolute children of a scroll container
+    // translate with the content. A plain inset:0 would ride the scroll and
+    // leave the bottom `scroll.y` px of the viewport unblurred (visible on
+    // exit, e.g. zooming back into a scrolled grid). The container is restored
+    // to the incoming page's scroll (context.to.scroll.y) for the whole run, so
+    // anchor the overlay to that live viewport slice instead (getOverlayRect
+    // backs out both the scroll and positionedParent's own offset).
+    const overlayRect = getOverlayRect(ctx.context, "to");
+    overlayEl.style.top = `${overlayRect.top}px`;
+    overlayEl.style.height = `${overlayRect.height}px`;
     return [
       new WebAnimation({
         element: overlayEl,

--- a/packages/core/src/lib/transitions/zoom/transition.ts
+++ b/packages/core/src/lib/transitions/zoom/transition.ts
@@ -379,6 +379,7 @@ export const zoom = (
         resolved,
         input,
         physics,
+        context,
         extras: extras as ZoomExtras,
         onComplete,
       };

--- a/packages/core/src/lib/transitions/zoom/types.ts
+++ b/packages/core/src/lib/transitions/zoom/types.ts
@@ -1,4 +1,4 @@
-import type { PhysicsOptions } from "@types";
+import type { PhysicsOptions, SsgoiTransitionContext } from "@types";
 import type { Animation } from "../../animation";
 
 /* ────────────────────────────────────────────────────────────────────────────
@@ -124,6 +124,11 @@ export interface ZoomContributeCtx {
   input: ZoomAnimationInput;
   physics: PhysicsOptions;
   extras: ZoomExtras;
+  /**
+   * Full transition context — strategies that stage viewport-aligned layers
+   * (the blur overlay) need the live scroll position + scrolling element.
+   */
+  context: SsgoiTransitionContext;
   /**
    * Mutation registry. Strategies push restore callbacks here; the
    * dispatcher fires them on completion. Keeps cleanup local to each

--- a/packages/core/src/lib/utils/get-viewport-rect.ts
+++ b/packages/core/src/lib/utils/get-viewport-rect.ts
@@ -27,3 +27,33 @@ export function getViewportRect(
     height: scrollingElement.clientHeight - offsetTop,
   };
 }
+
+/**
+ * Vertical placement for an absolute backdrop-filter overlay that lives inside
+ * `positionedParent` but must cover the scrolling element's visible viewport
+ * regardless of scroll (the blur tone of sheet / zoom).
+ *
+ * Unlike {@link getViewportRect} — which sizes a page element's own clipped
+ * slice in its own box — the overlay is a separate layer whose absolute
+ * coordinates are relative to `positionedParent`. During a transition the
+ * container is scrolled to the chosen side's position, so an `inset: 0` overlay
+ * would ride that scroll and leave the bottom `scroll.y` px unblurred. To land
+ * the overlay at the live viewport top instead, its content-space `top` backs
+ * out both the scroll (`scroll.y`) and `positionedParent`'s own offset within
+ * the scroller (`offsetTop`); its height is the full viewport (`clientHeight`).
+ */
+export function getOverlayRect(
+  context: SsgoiTransitionContext,
+  side: "from" | "to",
+) {
+  const { scrollingElement, positionedParent } = context;
+  const offsetTop =
+    scrollingElement !== positionedParent &&
+    scrollingElement.contains(positionedParent)
+      ? getRect(scrollingElement, positionedParent).top
+      : 0;
+  return {
+    top: context[side].scroll.y - offsetTop,
+    height: scrollingElement.clientHeight,
+  };
+}

--- a/packages/core/src/lib/utils/index.ts
+++ b/packages/core/src/lib/utils/index.ts
@@ -4,7 +4,7 @@ export { getPositionedParent } from "./get-positioned-parent";
 export { sleep } from "./sleep";
 export { getRect } from "./get-rect";
 export { getClientRect } from "./get-client-rect";
-export { getViewportRect } from "./get-viewport-rect";
+export { getViewportRect, getOverlayRect } from "./get-viewport-rect";
 export { round, floor, ceil, toFixed } from "./number";
 export { withResolvers } from "./with-resolvers";
 export { waitPaint } from "./wait-paint";


### PR DESCRIPTION
## What

Adds a **`blur`** tone to the `sheet` transition, a demo that shows it off, and — because the blur tone surfaced them — fixes two scroll-related defects in the shared overlay/background machinery that also affected the `scale` and `zoom` blur tones.

## 1. `sheet({ type: "blur" })` (core)

A third sheet tone alongside `static` and `scale`. As the sheet rises, the page underneath **blurs and recedes** (a subtle scale + dim) — a modal pushing the page out of focus. It's the sheet analogue of the existing zoom `blur` tone.

```ts
sheet({ type: "blur", enter: "/story/new", exit: "/story" })
```

The blur lives on a **separate full-viewport `backdrop-filter` overlay**, staged between the background (`Z_BACKGROUND`) and the sheet (`Z_FOREGROUND`) — not on the background element itself. Applying `filter: blur` directly to the background hard-cut the halo at its clip edge and rode its `scale` transform; the separate layer keeps the frost uniform and decoupled. The background carries only the recede (scale + dim). `prepare` stages the overlay via `createElement` + `positionedParent` (the dispatcher removes it on settle); `animation` animates its `backdrop-filter`. A `SheetOverlayConfig` was added to the provider contract. Blur radius is clamped `>= 0` against spring/inertia overshoot.

## 2. "Voyage" demo (docs)

A new Airbnb-toned **travel-story** showcase. The home feed is a scroll of full-bleed story cards; tapping **New story** raises a Gmail-style compose sheet (cover photo, location chip, title, body, toolbar) using `sheet({ type: "blur" })`, so the feed blurs and recedes behind it. Mirrors the `material-mail` demo structure (`api → state → page → layout` + thin app routes + `showcase.ts` + registry), with a new icon. Routes: `/demo/voyage`, `/demo/voyage/compose`.

## 3. Scroll fixes (core)

The blur tone made the page-behind clearly visible, which exposed two pre-existing defects in the sheet/zoom scroll handling (both also affected `scale`/zoom blur, just masked):

- **White band when entering from a scrolled page.** `prepareOutgoing` makes the background `position: absolute`, under which an `h-full` (`height:100%`) page root collapses to one viewport. `contain: paint` then deleted everything scrolled past, and the clip's `100%` became a viewport instead of the full page — leaving a white band of height `scroll.y`. Fixed by pinning the background box to its real content height (`scrollHeight`, read after re-insertion) so the clip slice and `contain: paint` span the whole page.
- **Unblurred bottom strip on exit.** The `backdrop-filter` overlay was `inset:0` inside the scroll container, and absolute children of a scroll container translate with the content — so once scrolled by `S` the overlay rode up and left the bottom `S` px unblurred. The overlay must stay in `positionedParent` for correct stacking, so it's now anchored to the live viewport via a new `getOverlayRect()` (backs out both the scroll and `positionedParent`'s own offset). **The same fix is applied to zoom blur**, which had the identical latent bug when zooming back into a scrolled grid.

## 4. Docs

- `transitions-data.ts`: the `blur` variant on the sheet entry (drives the docs transitions catalog).
- `public/llms/sheet.txt` and `public/llms.txt`: the new `blur` type in the LLM-facing docs (behavior, signature `"static" | "scale" | "blur"`, usage).

## Test plan

- `pnpm --filter @ssgoi/core test:run` → 43 passed (incl. the `blur` provider tests).
- `tsc --noEmit` on `apps/docs` → 0 errors; core + docs eslint clean; `core:build` clean.
- Dev server: `/demo/voyage` and `/demo/voyage/compose` return 200; existing `static`/`scale`/zoom-blur demos unchanged (200, no regression).
- The core changes were vetted with adversarial review passes (stacking/backdrop sampling, enter/exit ramp direction, reused-node cleanup, `static`/`scale` no-regression, the scroll-coordinate math, and the `offsetTop` edge case).

> Note: the two scroll fixes are layout-dependent (real `scrollHeight`/clip/`contain`/`backdrop-filter` behavior), so they're verified by reasoning + adversarial review rather than a jsdom unit test — best confirmed visually in the running demo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
