### PR TITLE
Release v6.6.6 with softer core transition timing

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/angular",
-  "version": "6.6.5",
+  "version": "6.6.6",
   "description": "Angular bindings for SSGOI - Native app-like page transitions for Angular applications",
   "private": false,
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/core",
-  "version": "6.6.6",
+  "version": "6.6.7",
   "description": "Core animation engine for SSGOI - Native app-like page transitions with spring physics",
   "private": false,
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/core",
-  "version": "6.6.5",
+  "version": "6.6.6",
   "description": "Core animation engine for SSGOI - Native app-like page transitions with spring physics",
   "private": false,
   "type": "module",

--- a/packages/core/src/lib/transitions/axis/provider/x/snappy.ts
+++ b/packages/core/src/lib/transitions/axis/provider/x/snappy.ts
@@ -28,7 +28,7 @@ const KAKAO_SLIDE_PX = 8;
 // changing the perceived motion.
 const SNAPPY_PHYSICS: PhysicsOptions = {
   spring: {
-    stiffness: 1000,
+    stiffness: 800,
     damping: 40,
     doubleSpring: 1.2,
     restDelta: 0.1,

--- a/packages/core/src/lib/transitions/drill/provider/parallax.ts
+++ b/packages/core/src/lib/transitions/drill/provider/parallax.ts
@@ -6,9 +6,9 @@ import type {
 } from "../types";
 
 // ease-out (Material decelerated): incoming page settles into place.
-// stiffness 170, damping 22 → ratio 0.86 of critical (~26.1), settles ~310ms.
+// stiffness 160, damping 22 → ratio 0.87 of critical (~25.3), settles gently.
 const PARALLAX_PHYSICS: PhysicsOptions = {
-  spring: { stiffness: 170, damping: 22 },
+  spring: { stiffness: 160, damping: 22 },
 };
 
 function buildParallax(direction: DrillDirection): DrillAnimationConfig {

--- a/packages/core/src/lib/transitions/drill/provider/parallax.ts
+++ b/packages/core/src/lib/transitions/drill/provider/parallax.ts
@@ -6,9 +6,16 @@ import type {
 } from "../types";
 
 // ease-out (Material decelerated): incoming page settles into place.
-// stiffness 160, damping 22 → ratio 0.87 of critical (~25.3), settles gently.
+// stiffness 230, damping 25 → ratio 0.82 of critical (~30.3), settles gently.
 const PARALLAX_PHYSICS: PhysicsOptions = {
-  spring: { stiffness: 160, damping: 22 },
+  spring: {
+    stiffness: 230,
+    damping: 25,
+    doubleSpring: {
+      stiffness: 230,
+      damping: 24,
+    },
+  },
 };
 
 function buildParallax(direction: DrillDirection): DrillAnimationConfig {

--- a/packages/core/src/lib/transitions/sheet/provider/static.ts
+++ b/packages/core/src/lib/transitions/sheet/provider/static.ts
@@ -3,12 +3,12 @@ import type { SheetProvider } from "../types";
 
 // ease-out (Material decelerated): sheet rises and lands gracefully (incoming).
 const ENTER_PHYSICS: PhysicsOptions = {
-  spring: { stiffness: 300, damping: 30 },
+  spring: { stiffness: 200, damping: 24 },
 };
 
 // ease-in (Material accelerated): sheet falls away (outgoing).
 const EXIT_PHYSICS: PhysicsOptions = {
-  inertia: { acceleration: 30, resistance: 1 },
+  inertia: { acceleration: 25, resistance: 1.2 },
 };
 
 export function createStaticProvider(): SheetProvider {

--- a/packages/core/src/lib/transitions/zoom/provider/blur.ts
+++ b/packages/core/src/lib/transitions/zoom/provider/blur.ts
@@ -19,9 +19,12 @@ import { getOverlayRect } from "@utils";
 
 export const BLUR_PHYSICS: PhysicsOptions = {
   spring: {
-    stiffness: 430,
-    damping: 33,
-    doubleSpring: 1,
+    stiffness: 380,
+    damping: 30,
+    doubleSpring: {
+      stiffness: 260,
+      damping: 30,
+    },
   },
 };
 

--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/qwik",
-  "version": "6.6.5",
+  "version": "6.6.6",
   "description": "Qwik bindings for SSGOI - Native app-like page transitions for Qwik and Qwik City applications",
   "private": false,
   "sideEffects": false,

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/react",
-  "version": "6.6.5",
+  "version": "6.6.6",
   "description": "React bindings for SSGOI - Native app-like page transitions for React applications",
   "private": false,
   "type": "module",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/solid",
-  "version": "6.6.5",
+  "version": "6.6.6",
   "description": "Solid.js bindings for SSGOI - Native app-like page transitions for Solid applications",
   "private": false,
   "type": "module",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/svelte",
-  "version": "6.6.5",
+  "version": "6.6.6",
   "description": "Svelte bindings for SSGOI - Native app-like page transitions for Svelte and SvelteKit applications",
   "private": false,
   "main": "./dist/index.js",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/vue",
-  "version": "6.6.5",
+  "version": "6.6.6",
   "description": "Vue bindings for SSGOI - Native app-like page transitions for Vue applications",
   "private": false,
   "type": "module",


### PR DESCRIPTION
## Summary
- Tune snappy x-axis and parallax spring stiffness for gentler settling
- Soften static sheet enter and exit physics
- Bump all publishable @ssgoi/* packages from 6.6.5 to 6.6.6 in lockstep

## Release
- Published @ssgoi/core@6.6.6
- Published @ssgoi/angular@6.6.6
- Published @ssgoi/qwik@6.6.6
- Published @ssgoi/react@6.6.6
- Published @ssgoi/solid@6.6.6
- Published @ssgoi/svelte@6.6.6
- Published @ssgoi/vue@6.6.6

## Validation
- pnpm --filter @ssgoi/core lint
- pnpm release patch
- npm view @ssgoi/* version confirms 6.6.6