### PR TITLE
Release core 6.6.8 with WAAPI startup and timing fixes

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/angular",
-  "version": "6.6.5",
+  "version": "6.6.6",
   "description": "Angular bindings for SSGOI - Native app-like page transitions for Angular applications",
   "private": false,
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/core",
-  "version": "6.6.7",
+  "version": "6.6.8",
   "description": "Core animation engine for SSGOI - Native app-like page transitions with spring physics",
   "private": false,
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/core",
-  "version": "6.6.6",
+  "version": "6.6.7",
   "description": "Core animation engine for SSGOI - Native app-like page transitions with spring physics",
   "private": false,
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/core",
-  "version": "6.6.5",
+  "version": "6.6.6",
   "description": "Core animation engine for SSGOI - Native app-like page transitions with spring physics",
   "private": false,
   "type": "module",

--- a/packages/core/src/lib/animation/web-animation.test.ts
+++ b/packages/core/src/lib/animation/web-animation.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Integrator } from "./integrator";
 import { WebAnimation } from "./web-animation";
 
@@ -38,21 +38,77 @@ function createFakeElement(waapi: globalThis.Animation) {
 
 function createFakeWaapi() {
   const ready = createReady<globalThis.Animation>();
+  const calls: string[] = [];
+  let currentTime: CSSNumberish | null = 0;
+  let running = true;
   const waapi = {
-    currentTime: null as CSSNumberish | null,
+    get currentTime() {
+      return currentTime;
+    },
+    set currentTime(value: CSSNumberish | null) {
+      calls.push("seek");
+      currentTime = value;
+    },
     playbackRate: 1,
     ready: ready.promise,
     onfinish: null,
-    play: vi.fn(),
-    pause: vi.fn(),
+    play: vi.fn(() => {
+      calls.push("play");
+      running = true;
+    }),
+    pause: vi.fn(() => {
+      calls.push("pause");
+      running = false;
+    }),
     cancel: vi.fn(),
   } as unknown as globalThis.Animation;
-  return { waapi, ready };
+  return {
+    waapi,
+    ready,
+    calls,
+    advance(ms: number) {
+      if (running && typeof currentTime === "number") {
+        currentTime += ms * waapi.playbackRate;
+      }
+    },
+  };
+}
+
+function installAnimationFrameHarness() {
+  let now = 0;
+  let nextId = 0;
+  let queue = new Map<number, FrameRequestCallback>();
+
+  vi.stubGlobal(
+    "requestAnimationFrame",
+    vi.fn((callback: FrameRequestCallback) => {
+      const id = nextId++;
+      queue.set(id, callback);
+      return id;
+    }),
+  );
+
+  return {
+    get pending() {
+      return queue.size;
+    },
+    flush() {
+      const callbacks = [...queue.values()];
+      queue = new Map();
+      now += 1000 / 60;
+      for (const callback of callbacks) callback(now);
+    },
+  };
 }
 
 describe("WebAnimation", () => {
-  it("waits for WAAPI readiness before playing and clearing start styles", async () => {
-    const { waapi, ready } = createFakeWaapi();
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("holds at zero through delayed rendering before playback", async () => {
+    const frames = installAnimationFrameHarness();
+    const { waapi, ready, calls, advance } = createFakeWaapi();
     const { element, style } = createFakeElement(waapi);
     const animation = new WebAnimation({
       element,
@@ -62,16 +118,37 @@ describe("WebAnimation", () => {
 
     animation.play();
 
+    expect(calls).toEqual(["seek", "pause"]);
     expect(waapi.pause).toHaveBeenCalledTimes(1);
     expect(waapi.currentTime).toBe(0);
     expect(waapi.play).not.toHaveBeenCalled();
     expect(style.opacity).toBe("0");
 
+    advance(1000);
+    expect(waapi.currentTime).toBe(0);
+
     ready.resolve(waapi);
+    await Promise.resolve();
+
+    expect(frames.pending).toBe(1);
+    frames.flush();
+    expect(frames.pending).toBe(1);
+    advance(1000);
+    expect(waapi.currentTime).toBe(0);
+    expect(waapi.play).not.toHaveBeenCalled();
+    expect(style.opacity).toBe("0");
+
+    frames.flush();
     await Promise.resolve();
 
     expect(style.opacity).toBe("");
     expect(waapi.play).toHaveBeenCalledTimes(1);
+    expect(waapi.currentTime).toBe(0);
+
+    advance(16);
+    const [pose] = animation.getPose();
+    expect(pose?.value).toBeGreaterThan(0.15);
+    expect(pose?.value).toBeLessThan(0.17);
   });
 
   it("samples live pose from WAAPI currentTime", () => {

--- a/packages/core/src/lib/animation/web-animation.ts
+++ b/packages/core/src/lib/animation/web-animation.ts
@@ -34,8 +34,9 @@ interface SimFrame {
  * Lifecycle:
  *   1. `play()` / `reverse()` calls `simulate()` from the current (position,
  *      velocity) toward the target bound, producing a frame list.
- *   2. Frames are converted to WAAPI keyframes; `element.animate(...)` is armed
- *      at 0 ms, waits for the browser's pending setup, then starts.
+ *   2. Frames are converted to WAAPI keyframes; `element.animate(...)` is held
+ *      at 0 ms until the pending pause is acknowledged and the browser has had
+ *      a rendering opportunity, then starts.
  *   3. While playing, `getPose()` interpolates the live position from frames
  *      using WAAPI's `currentTime`, so browser setup latency is not counted as
  *      animation progress.
@@ -253,8 +254,11 @@ export class WebAnimation extends Animation {
       composite: "replace",
     });
     waapi.playbackRate = this.playbackRate;
-    waapi.pause();
+    // Element.animate() auto-plays. Seek while that play is pending, then pause:
+    // setting currentTime after pause would synchronously complete the pending
+    // pause, making `ready` useless as an acknowledgement of the pause request.
     waapi.currentTime = 0;
+    waapi.pause();
 
     this.waapi = waapi;
     this.waitingForStart = true;
@@ -297,6 +301,8 @@ export class WebAnimation extends Animation {
     runId: number,
   ): Promise<void> {
     try {
+      // This acknowledges the pending pause. It does not prove that pixels have
+      // been presented, so keep the animation held through the frame barrier.
       await waapi.ready;
       if (typeof requestAnimationFrame !== "undefined") {
         await waitPaint(this.element);

--- a/packages/core/src/lib/transitions/axis/provider/x/snappy.ts
+++ b/packages/core/src/lib/transitions/axis/provider/x/snappy.ts
@@ -28,7 +28,7 @@ const KAKAO_SLIDE_PX = 8;
 // changing the perceived motion.
 const SNAPPY_PHYSICS: PhysicsOptions = {
   spring: {
-    stiffness: 1000,
+    stiffness: 800,
     damping: 40,
     doubleSpring: 1.2,
     restDelta: 0.1,

--- a/packages/core/src/lib/transitions/drill/provider/parallax.ts
+++ b/packages/core/src/lib/transitions/drill/provider/parallax.ts
@@ -6,9 +6,9 @@ import type {
 } from "../types";
 
 // ease-out (Material decelerated): incoming page settles into place.
-// stiffness 170, damping 22 → ratio 0.86 of critical (~26.1), settles ~310ms.
+// stiffness 160, damping 22 → ratio 0.87 of critical (~25.3), settles gently.
 const PARALLAX_PHYSICS: PhysicsOptions = {
-  spring: { stiffness: 170, damping: 22 },
+  spring: { stiffness: 160, damping: 22 },
 };
 
 function buildParallax(direction: DrillDirection): DrillAnimationConfig {

--- a/packages/core/src/lib/transitions/drill/provider/parallax.ts
+++ b/packages/core/src/lib/transitions/drill/provider/parallax.ts
@@ -6,9 +6,16 @@ import type {
 } from "../types";
 
 // ease-out (Material decelerated): incoming page settles into place.
-// stiffness 160, damping 22 → ratio 0.87 of critical (~25.3), settles gently.
+// stiffness 230, damping 25 → ratio 0.82 of critical (~30.3), settles gently.
 const PARALLAX_PHYSICS: PhysicsOptions = {
-  spring: { stiffness: 160, damping: 22 },
+  spring: {
+    stiffness: 230,
+    damping: 25,
+    doubleSpring: {
+      stiffness: 230,
+      damping: 24,
+    },
+  },
 };
 
 function buildParallax(direction: DrillDirection): DrillAnimationConfig {

--- a/packages/core/src/lib/transitions/sheet/provider/static.ts
+++ b/packages/core/src/lib/transitions/sheet/provider/static.ts
@@ -3,12 +3,12 @@ import type { SheetProvider } from "../types";
 
 // ease-out (Material decelerated): sheet rises and lands gracefully (incoming).
 const ENTER_PHYSICS: PhysicsOptions = {
-  spring: { stiffness: 300, damping: 30 },
+  spring: { stiffness: 200, damping: 24 },
 };
 
 // ease-in (Material accelerated): sheet falls away (outgoing).
 const EXIT_PHYSICS: PhysicsOptions = {
-  inertia: { acceleration: 30, resistance: 1 },
+  inertia: { acceleration: 25, resistance: 1.2 },
 };
 
 export function createStaticProvider(): SheetProvider {

--- a/packages/core/src/lib/transitions/zoom/provider/blur.ts
+++ b/packages/core/src/lib/transitions/zoom/provider/blur.ts
@@ -19,9 +19,12 @@ import { getOverlayRect } from "@utils";
 
 export const BLUR_PHYSICS: PhysicsOptions = {
   spring: {
-    stiffness: 430,
-    damping: 33,
-    doubleSpring: 1,
+    stiffness: 380,
+    damping: 30,
+    doubleSpring: {
+      stiffness: 260,
+      damping: 30,
+    },
   },
 };
 

--- a/packages/core/src/lib/utils/wait-paint.ts
+++ b/packages/core/src/lib/utils/wait-paint.ts
@@ -1,21 +1,20 @@
 /**
- * Waits for the browser to complete a paint cycle.
+ * Waits across two animation frame callbacks.
  *
- * This ensures that any style changes have been applied and the element
- * has been painted to the screen before starting animations.
+ * This gives style changes made before the first callback a rendering
+ * opportunity before code resumes in the second callback. Since rAF callbacks
+ * run before paint and the web platform has no post-presentation callback, this
+ * is a scheduling barrier rather than proof that pixels reached the screen.
  *
- * Currently uses double requestAnimationFrame as a reliable cross-browser
- * approach. In the future, this could be replaced with a native API when
- * available (e.g., a proposed `element.waitForPaint()` or similar).
+ * In the future, this could be replaced with a native presentation API if one
+ * becomes available.
  *
  * @param _element - The element to wait for (reserved for future API usage)
- * @returns A promise that resolves after the paint cycle completes
+ * @returns A promise that resolves from the second animation frame callback
  */
 
 export function waitPaint(_element?: Element): Promise<void> {
-  // TODO: When a native paint-waiting API becomes available (e.g., element.waitForPaint()),
-  // we can use the _element parameter to leverage that API for more accurate timing.
-  // For now, we use double requestAnimationFrame which works reliably across all browsers.
+  // The element parameter is reserved for a future element-scoped presentation API.
   return new Promise((resolve) => {
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {

--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/qwik",
-  "version": "6.6.5",
+  "version": "6.6.6",
   "description": "Qwik bindings for SSGOI - Native app-like page transitions for Qwik and Qwik City applications",
   "private": false,
   "sideEffects": false,

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/react",
-  "version": "6.6.5",
+  "version": "6.6.6",
   "description": "React bindings for SSGOI - Native app-like page transitions for React applications",
   "private": false,
   "type": "module",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/solid",
-  "version": "6.6.5",
+  "version": "6.6.6",
   "description": "Solid.js bindings for SSGOI - Native app-like page transitions for Solid applications",
   "private": false,
   "type": "module",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/svelte",
-  "version": "6.6.5",
+  "version": "6.6.6",
   "description": "Svelte bindings for SSGOI - Native app-like page transitions for Svelte and SvelteKit applications",
   "private": false,
   "main": "./dist/index.js",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/vue",
-  "version": "6.6.5",
+  "version": "6.6.6",
   "description": "Vue bindings for SSGOI - Native app-like page transitions for Vue applications",
   "private": false,
   "type": "module",


### PR DESCRIPTION
## Summary

- Merge the transition timing work from `timing-is-good`, superseding #372.
- Fix the WAAPI startup barrier so a transition remains at `0ms` until the browser acknowledges the pending pause and reaches the rendering barrier.
- Add a deterministic fake-timeline/rAF regression covering two seconds of startup delay without leaked animation progress.
- Release only `@ssgoi/core@6.6.8`; framework adapters remain at 6.6.6 and resolve it through their existing `^6.6.6` dependency.

## WAAPI startup fix

This is a follow-up to #371.

`Element.animate()` returns a play-pending animation. Under the previous call order, `pause()` was followed by `currentTime = 0`. The Web Animations current-time algorithm synchronously completes an existing pending pause, so `animation.ready` was already resolved and did not acknowledge browser/compositor pause processing.

The corrected order is:

```ts
animation.currentTime = 0;
animation.pause();
await animation.ready;
```

Seeking while play-pending fixes the hold time at zero without completing the play request. `pause()` then replaces that pending play with a pending pause, and `ready` resolves after the user agent acknowledges the pause. The animation stays at zero through the frame barrier, so React mount/unmount work that blocks the main thread before startup cannot consume animation progress.

This preserves native WAAPI playback for transform/opacity effects, allowing eligible animations to continue on the compositor after startup. It deliberately does not replace WAAPI with an rAF-driven clock.

References:

- [Web Animations: setting current time](https://www.w3.org/TR/web-animations-1/#setting-the-current-time-of-an-animation)
- [Web Animations: pausing an animation](https://www.w3.org/TR/web-animations-1/#pausing-an-animation-section)
- [Web Animations: waiting for the associated effect](https://www.w3.org/TR/web-animations-1/#waiting-for-the-associated-effect)
- [Chromium animation architecture](https://chromium.googlesource.com/chromium/src/+/HEAD/third_party/blink/renderer/core/animation/README.md)

## Timing changes

- Soften the snappy x-axis and static sheet motion.
- Retune drill parallax with an explicit follower spring.
- Retune zoom blur with a softer lead and decoupled follower spring.

## Release

- Published [`@ssgoi/core@6.6.8`](https://www.npmjs.com/package/@ssgoi/core/v/6.6.8) with the `latest` dist-tag.
- Verified the registry version, dist-tag, shasum, and integrity.
- Did not publish Angular, Qwik, React, Solid, Svelte, or Vue packages.

## Scope

The startup barrier fixes stalls before the first presented transition frame. A main-thread stall after playback begins can still skip visible samples for non-composited effects such as mixed `transform`/`clip-path` animations; preventing that would require an explicit frame-clock/shared-scheduler design and different duration semantics.

## Validation

- `pnpm --filter @ssgoi/core test:run` (46 tests)
- `pnpm --filter @ssgoi/core lint`
- `pnpm --filter @ssgoi/core build`
- `npm pack --dry-run --json`
- `npm view @ssgoi/core@6.6.8 version dist.integrity dist.shasum --json`
- `npm view @ssgoi/core version dist-tags time --json`