### PR TITLE
fix(core): refine drill and sheet motion

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/core",
-  "version": "6.6.10",
+  "version": "6.6.11",
   "description": "Core animation engine for SSGOI - Native app-like page transitions with spring physics",
   "private": false,
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/core",
-  "version": "6.6.11",
+  "version": "6.6.12",
   "description": "Core animation engine for SSGOI - Native app-like page transitions with spring physics",
   "private": false,
   "type": "module",

--- a/packages/core/src/lib/transitions/drill/provider/crossfade.ts
+++ b/packages/core/src/lib/transitions/drill/provider/crossfade.ts
@@ -8,7 +8,11 @@ import type {
 // Double spring gives an ease-in-out feel; leader 130/20 + 0.7 follower
 // lands the visible motion near ~400ms with a soft tail at both ends.
 const CROSSFADE_PHYSICS: PhysicsOptions = {
-  spring: { stiffness: 200, damping: 20, doubleSpring: 0.7 },
+  spring: {
+    stiffness: 250,
+    damping: 23,
+    doubleSpring: 0.7,
+  },
 };
 
 // Opacity floor — incoming starts at 0.5 (not 0), outgoing settles at 0.5 (not 0).

--- a/packages/core/src/lib/transitions/drill/provider/parallax.ts
+++ b/packages/core/src/lib/transitions/drill/provider/parallax.ts
@@ -6,11 +6,15 @@ import type {
 } from "../types";
 
 // ease-out (Material decelerated): incoming page settles into place.
-// stiffness 230, damping 25 → ratio 0.82 of critical (~30.3), settles gently.
+// Primary spring 270/25 settles gently; double spring 600/50 is near-critical.
 const PARALLAX_PHYSICS: PhysicsOptions = {
   spring: {
-    stiffness: 230,
+    stiffness: 270,
     damping: 25,
+    doubleSpring: {
+      stiffness: 600,
+      damping: 50,
+    },
   },
 };
 

--- a/packages/core/src/lib/transitions/drill/provider/parallax.ts
+++ b/packages/core/src/lib/transitions/drill/provider/parallax.ts
@@ -11,10 +11,6 @@ const PARALLAX_PHYSICS: PhysicsOptions = {
   spring: {
     stiffness: 230,
     damping: 25,
-    doubleSpring: {
-      stiffness: 230,
-      damping: 24,
-    },
   },
 };
 

--- a/packages/core/src/lib/transitions/sheet/provider/static.ts
+++ b/packages/core/src/lib/transitions/sheet/provider/static.ts
@@ -3,12 +3,18 @@ import type { SheetProvider } from "../types";
 
 // ease-out (Material decelerated): sheet rises and lands gracefully (incoming).
 const ENTER_PHYSICS: PhysicsOptions = {
-  spring: { stiffness: 200, damping: 24 },
+  spring: {
+    stiffness: 230,
+    damping: 25,
+  },
 };
 
 // ease-in (Material accelerated): sheet falls away (outgoing).
 const EXIT_PHYSICS: PhysicsOptions = {
-  inertia: { acceleration: 25, resistance: 1.2 },
+  spring: {
+    stiffness: 230,
+    damping: 25,
+  },
 };
 
 export function createStaticProvider(): SheetProvider {


### PR DESCRIPTION
## Summary

- make drill crossfade transitions feel quicker and more responsive
- simplify drill parallax to use a single spring
- align static sheet enter and exit motion with the updated spring tuning

## Release

- bump only `@ssgoi/core` from `6.6.10` to `6.6.11`
- pre-publish `@ssgoi/core@6.6.11` to npm under the `latest` tag
- keep all framework adapter package versions unchanged

## Validation

- `pnpm --filter @ssgoi/core test:run`
- `pnpm --filter @ssgoi/core lint`
- `pnpm --filter @ssgoi/core build`
- `pnpm publish --dry-run --access public --no-git-checks`