### PR TITLE
feat(templates): centralize route transition boundaries

### DIFF
--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -332,15 +332,13 @@ Everything outside the React core above lives in its own plain-text file. Fetch 
 
 ### Other frameworks (setup + route boundary rules)
 
-Do not copy the React keyed-child pattern verbatim across frameworks. Use the matching guide; each router has a different ownership and update lifecycle for projected route content:
+- Svelte / SvelteKit: https://ssgoi.dev/llms/svelte.txt
+- Vue / Nuxt: https://ssgoi.dev/llms/vue.txt
+- Solid / SolidStart: https://ssgoi.dev/llms/solid.txt
+- Angular: https://ssgoi.dev/llms/angular.txt
+- Qwik / Qwik City: https://ssgoi.dev/llms/qwik.txt
 
-- Svelte / SvelteKit — use a staged layout boundary that detaches the old live snippet in `onNavigate` before mounting the new route: https://ssgoi.dev/llms/svelte.txt
-- Vue / Nuxt — use a keyed layout VNode; the old VNode retains its own slot subtree while it unmounts: https://ssgoi.dev/llms/vue.txt
-- Solid / SolidStart — use a keyed `<Show>` boundary inside `<Suspense>` so lazy content resolves before the incoming marker appears: https://ssgoi.dev/llms/solid.txt
-- Angular — keep the transition marker on each routed component's own template: https://ssgoi.dev/llms/angular.txt
-- Qwik / Qwik City — keep page-owned markers; a keyed wrapper around the layout `<Slot />` can pair the incoming id with outgoing content: https://ssgoi.dev/llms/qwik.txt
-
-The `SsgoiConfig` shape, transition catalog, and troubleshooting sections above are shared across all frameworks. Installation, provider wiring, and the exact route-boundary lifecycle are framework-specific.
+The `SsgoiConfig` shape, transition catalog, and troubleshooting sections above are shared across all frameworks. Installation, provider wiring, and route-boundary lifecycle are documented only in the linked framework guides.
 
 ### Deep dive
 

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -332,13 +332,15 @@ Everything outside the React core above lives in its own plain-text file. Fetch 
 
 ### Other frameworks (setup + route boundary rules)
 
-- Svelte / SvelteKit: https://ssgoi.dev/llms/svelte.txt
-- Vue / Nuxt: https://ssgoi.dev/llms/vue.txt
-- Solid / SolidStart: https://ssgoi.dev/llms/solid.txt
-- Angular: https://ssgoi.dev/llms/angular.txt
-- Qwik / Qwik City: https://ssgoi.dev/llms/qwik.txt
+Do not copy the React keyed-child pattern verbatim across frameworks. Use the matching guide; each router has a different ownership and update lifecycle for projected route content:
 
-The `SsgoiConfig` shape, transition catalog, and troubleshooting sections above are shared across all frameworks — only installation and the route boundary marker differ.
+- Svelte / SvelteKit — use a staged layout boundary that detaches the old live snippet in `onNavigate` before mounting the new route: https://ssgoi.dev/llms/svelte.txt
+- Vue / Nuxt — use a keyed layout VNode; the old VNode retains its own slot subtree while it unmounts: https://ssgoi.dev/llms/vue.txt
+- Solid / SolidStart — use a keyed `<Show>` boundary inside `<Suspense>` so lazy content resolves before the incoming marker appears: https://ssgoi.dev/llms/solid.txt
+- Angular — keep the transition marker on each routed component's own template: https://ssgoi.dev/llms/angular.txt
+- Qwik / Qwik City — keep page-owned markers; a keyed wrapper around the layout `<Slot />` can pair the incoming id with outgoing content: https://ssgoi.dev/llms/qwik.txt
+
+The `SsgoiConfig` shape, transition catalog, and troubleshooting sections above are shared across all frameworks. Installation, provider wiring, and the exact route-boundary lifecycle are framework-specific.
 
 ### Deep dive
 

--- a/apps/docs/public/llms/angular.txt
+++ b/apps/docs/public/llms/angular.txt
@@ -8,6 +8,10 @@ Framework-specific setup for `@ssgoi/angular`. The `SsgoiConfig` shape, transiti
 npm install @ssgoi/angular
 ```
 
+The following standalone Angular example is complete and can be copied file by file.
+
+Adapter reference: https://github.com/meursyphus/ssgoi/tree/main/packages/angular
+
 ## Layout setup
 
 Same three rules as every framework (details in llms.txt):
@@ -16,17 +20,132 @@ Same three rules as every framework (details in llms.txt):
 2. Put `relative z-0` (plus `overflow-x-clip` for horizontal transitions) on the outer element that wraps the SSGOI provider.
 3. Mark routed content with `data-ssgoi-transition="..."` directly on each routed page's template.
 
-## Route boundary rule
+## Complete router setup
 
-Each routed component marks its own boundary in its template:
+Provide SSGOI once on the persistent app shell:
 
-```html
-<section data-ssgoi-transition="/home">
-  <h1>Home Page</h1>
-</section>
+```typescript
+// src/app/app.component.ts
+import { Component } from "@angular/core";
+import { RouterOutlet } from "@angular/router";
+import { Ssgoi, type SsgoiConfig } from "@ssgoi/angular";
+import { fade } from "@ssgoi/angular/view-transitions";
+
+@Component({
+  selector: "app-root",
+  standalone: true,
+  imports: [RouterOutlet, Ssgoi],
+  template: `
+    <main ssgoi [config]="config" class="app-shell">
+      <router-outlet />
+    </main>
+  `,
+  styles: [
+    `
+      .app-shell {
+        position: relative;
+        z-index: 0;
+        height: 100dvh;
+        overflow-y: auto;
+        overflow-x: clip;
+      }
+    `,
+  ],
+})
+export class AppComponent {
+  protected readonly config = {
+    transitions: [fade({ paths: ["/home", "/about"] })],
+  } satisfies SsgoiConfig;
+}
 ```
 
-The value can be a hard-coded logical page id; it does not have to be the router's URL. It only needs to match the `from`, `to`, or `paths` values in `SsgoiConfig`. For dynamic routes, match with wildcards in the config (`/post/*`).
+Define the routes:
+
+```typescript
+// src/app/app.routes.ts
+import type { Routes } from "@angular/router";
+
+export const routes: Routes = [
+  { path: "", pathMatch: "full", redirectTo: "home" },
+  {
+    path: "home",
+    loadComponent: () =>
+      import("./home.component").then((module) => module.HomeComponent),
+  },
+  {
+    path: "about",
+    loadComponent: () =>
+      import("./about.component").then((module) => module.AboutComponent),
+  },
+];
+```
+
+Bootstrap the router:
+
+```typescript
+// src/main.ts
+import { bootstrapApplication } from "@angular/platform-browser";
+import { provideRouter } from "@angular/router";
+import { AppComponent } from "./app/app.component";
+import { routes } from "./app/app.routes";
+
+bootstrapApplication(AppComponent, {
+  providers: [provideRouter(routes)],
+}).catch((error) => console.error(error));
+```
+
+## Route boundary rule
+
+Each routed component marks its own outer boundary. Copy these two pages to match the config above:
+
+```typescript
+// src/app/home.component.ts
+import { Component } from "@angular/core";
+import { RouterLink } from "@angular/router";
+
+@Component({
+  selector: "app-home",
+  standalone: true,
+  imports: [RouterLink],
+  template: `
+    <section data-ssgoi-transition="/home">
+      <h1>Home</h1>
+      <a routerLink="/about">About</a>
+    </section>
+  `,
+})
+export class HomeComponent {}
+```
+
+```typescript
+// src/app/about.component.ts
+import { Component } from "@angular/core";
+import { RouterLink } from "@angular/router";
+
+@Component({
+  selector: "app-about",
+  standalone: true,
+  imports: [RouterLink],
+  template: `
+    <section data-ssgoi-transition="/about">
+      <h1>About</h1>
+      <a routerLink="/home">Home</a>
+    </section>
+  `,
+})
+export class AboutComponent {}
+```
+
+Do not import the deprecated `SsgoiTransition` directive. A plain `data-ssgoi-transition` attribute inside the `[ssgoi]` host is the current API.
+
+The value can be a hard-coded logical page id; it does not have to be the router's URL. It only needs to match the `from`, `to`, or `paths` values in `SsgoiConfig`. For a dynamic route, derive the id from `ActivatedRoute` and match it with a config wildcard such as `/post/*`.
+
+## Copy checklist
+
+1. `[ssgoi]` and `[config]` are on one persistent shell outside `<router-outlet>`.
+2. That shell is the positioned ancestor for outgoing clones (`position: relative; z-index: 0`) and clips horizontal overflow when needed.
+3. Every routed component has exactly one outer `data-ssgoi-transition` marker.
+4. Marker values exactly match the config's `paths`, `from`, or `to` values.
 
 ## Shared reference
 

--- a/apps/docs/public/llms/qwik.txt
+++ b/apps/docs/public/llms/qwik.txt
@@ -57,6 +57,8 @@ export default component$(() => {
 });
 ```
 
+Do not replace this with a keyed wrapper around the layout `<Slot />`. Qwik City moves projected slot content into the new wrapper before updating the routed subtree, so an incoming transition id can temporarily contain the outgoing page. `usePreventNavigate$` could stage a pre-navigation unmount, but it currently requires Qwik City's experimental `preventNavigate` flag; the stable template deliberately avoids that dependency.
+
 The value can be a hard-coded logical page id; it only needs to match the `from`, `to`, or `paths` values in `SsgoiConfig`. For dynamic routes, match with wildcards in the config (`/post/*`).
 
 ## Troubleshooting checklist

--- a/apps/docs/public/llms/qwik.txt
+++ b/apps/docs/public/llms/qwik.txt
@@ -16,27 +16,31 @@ Qwik uses resumability and serializes component state, while SSGOI transition co
 
 In Qwik City layouts, prefer `useSsgoi(ref, { config$ })` over wrapping the route `<Slot />` in `<Ssgoi>`. Forwarding a Qwik City route slot through another component prevents routed content from being projected into the live DOM.
 
+Copy this root layout as a complete starting point:
+
 ```tsx
+// src/routes/layout.tsx
 import { $, Slot, component$, useSignal } from "@builder.io/qwik";
 import { useSsgoi } from "@ssgoi/qwik";
 import { drill, zoom } from "@ssgoi/qwik/view-transitions";
 
-const config$ = $(() => ({
+const ssgoiConfig$ = $(() => ({
   preserveScroll: { exclude: ["/post/*"] },
   transitions: [
     drill({ enter: "/post/*", exit: "/post" }),
-    zoom({ paths: ["/gallery", "/gallery/*"], type: "expand" }),
+    zoom({ paths: ["/gallery", "/gallery/*"], type: "expand" as const }),
   ],
 }));
 
 export default component$(() => {
   const ssgoiRoot = useSignal<HTMLElement>();
 
-  useSsgoi(ssgoiRoot, { config$ });
+  useSsgoi(ssgoiRoot, { config$: ssgoiConfig$ });
 
   return (
     <main
       ref={ssgoiRoot}
+      data-ssgoi-root=""
       class="relative z-0 h-dvh overflow-y-auto overflow-x-clip"
     >
       <Slot />
@@ -47,12 +51,38 @@ export default component$(() => {
 
 ## Route boundary rule
 
-Each page component marks its own boundary:
+Each page component marks its own boundary. Copy the marker onto the outermost element of every routed page:
 
 ```tsx
+// src/routes/post/index.tsx
+import { component$ } from "@builder.io/qwik";
+
 export default component$(() => {
   return (
-    <section data-ssgoi-transition="/gallery">{/* page content */}</section>
+    <section data-ssgoi-transition="/post">
+      <h1>Posts</h1>
+      {/* page content */}
+    </section>
+  );
+});
+```
+
+Dynamic pages derive the same logical id used by the config:
+
+```tsx
+// src/routes/post/[id]/index.tsx
+import { component$ } from "@builder.io/qwik";
+import { Link, useLocation } from "@builder.io/qwik-city";
+
+export default component$(() => {
+  const location = useLocation();
+  const id = location.params.id;
+
+  return (
+    <article data-ssgoi-transition={`/post/${id}`}>
+      <Link href="/post/">Back</Link>
+      <h1>Post {id}</h1>
+    </article>
   );
 });
 ```
@@ -61,12 +91,74 @@ Do not replace this with a keyed wrapper around the layout `<Slot />`. Qwik City
 
 The value can be a hard-coded logical page id; it only needs to match the `from`, `to`, or `paths` values in `SsgoiConfig`. For dynamic routes, match with wildcards in the config (`/post/*`).
 
+## Nested route transitions
+
+For a persistent parent such as `/products`, the parent layout owns the outer `/products` marker and initializes a second SSGOI observer around its child `<Slot />`. Copy this layout:
+
+```tsx
+// src/routes/products/layout.tsx
+import { $, Slot, component$, useSignal } from "@builder.io/qwik";
+import { Link } from "@builder.io/qwik-city";
+import { useSsgoi } from "@ssgoi/qwik";
+import { slide } from "@ssgoi/qwik/view-transitions";
+
+const paths = [
+  "/products/all",
+  "/products/electronics",
+  "/products/fashion",
+];
+
+const productConfig$ = $(() => ({
+  transitions: [slide({ paths })],
+}));
+
+export default component$(() => {
+  const ssgoiRoot = useSignal<HTMLElement>();
+
+  useSsgoi(ssgoiRoot, { config$: productConfig$ });
+
+  return (
+    <section data-ssgoi-transition="/products" class="min-h-full">
+      <nav>
+        {paths.map((path) => (
+          <Link key={path} href={`${path}/`}>
+            {path.split("/").at(-1)}
+          </Link>
+        ))}
+      </nav>
+
+      <div
+        ref={ssgoiRoot}
+        data-ssgoi-root=""
+        class="relative z-0 overflow-x-clip"
+      >
+        <Slot />
+      </div>
+    </section>
+  );
+});
+```
+
+Each nested page still owns its full-path marker:
+
+```tsx
+// src/routes/products/all/index.tsx
+import { component$ } from "@builder.io/qwik";
+
+export default component$(() => (
+  <div data-ssgoi-transition="/products/all">All products</div>
+));
+```
+
+Repeat that page file for the other configured paths. Keep the logical ids without Qwik City's optional trailing slash, exactly as written in `paths`.
+
 ## Troubleshooting checklist
 
 - The root layout imports `useSsgoi` from `@ssgoi/qwik` and calls it with a signal ref.
 - The config is declared with Qwik `$`, for example `const config$ = $(() => ({ transitions: [...] }))`.
-- Each page component has its own `data-ssgoi-transition` value that matches `paths`, `from`, or `to`.
+- Each page component has its own `data-ssgoi-transition` value that matches `paths`, `from`, or `to` exactly.
 - The SSGOI root element is the scroll/positioning shell (`relative z-0 overflow-x-clip`) and contains the route `<Slot />` directly.
+- There is no keyed transition wrapper around `<Slot />`.
 
 ## Shared reference
 

--- a/apps/docs/public/llms/solid.txt
+++ b/apps/docs/public/llms/solid.txt
@@ -22,6 +22,8 @@ Same three rules as every framework (details in llms.txt):
 
 Solid's keyed `<Show>` gives each pathname its own reactive owner. Disposing the old owner removes the outgoing subtree before the incoming owner mounts:
 
+### 1. Copy the boundary component
+
 ```tsx
 // src/components/ssgoi-transition-boundary.tsx
 import { useLocation } from "@solidjs/router";
@@ -52,29 +54,43 @@ export function SsgoiTransitionBoundary(props: Props) {
 }
 ```
 
-Keep the boundary inside `<Suspense>`. Lazy route content must resolve before SSGOI observes the incoming marker; putting `<Suspense>` inside the boundary can mount an empty incoming wrapper too early.
+### 2. Wrap routed content once
+
+Copy the boundary as-is. Keep it inside `<Suspense>`: lazy route content must resolve before SSGOI observes the incoming marker. Putting `<Suspense>` inside the boundary can mount an empty incoming wrapper too early.
 
 ```tsx
 // src/app.tsx
 import { Router } from "@solidjs/router";
 import { FileRoutes } from "@solidjs/start/router";
 import { Suspense } from "solid-js";
-import { Ssgoi } from "@ssgoi/solid";
-import { zoom } from "@ssgoi/solid/view-transitions";
+import { Ssgoi, type SsgoiConfig } from "@ssgoi/solid";
+import { drill, zoom } from "@ssgoi/solid/view-transitions";
 import { SsgoiTransitionBoundary } from "./components/ssgoi-transition-boundary";
 
 const config = {
-  transitions: [zoom({ paths: ["/gallery", "/gallery/*"], type: "expand" })],
-};
+  preserveScroll: { exclude: ["/posts/*"] },
+  transitions: [
+    drill({ enter: "/posts/*", exit: "/posts" }),
+    zoom({ paths: ["/gallery", "/gallery/*"], type: "expand" }),
+  ],
+} satisfies SsgoiConfig;
+
+const getRootTransitionId = (path: string) =>
+  path === "/products" || path.startsWith("/products/")
+    ? "/products"
+    : path;
 
 export default function App() {
   return (
     <Router
       root={(props) => (
-        <main class="relative z-0 min-h-dvh overflow-y-auto overflow-x-clip">
+        <main class="relative z-0 h-dvh overflow-y-auto overflow-x-clip">
           <Ssgoi config={config}>
             <Suspense>
-              <SsgoiTransitionBoundary>
+              <SsgoiTransitionBoundary
+                getId={getRootTransitionId}
+                class="min-h-full"
+              >
                 {props.children}
               </SsgoiTransitionBoundary>
             </Suspense>
@@ -88,7 +104,53 @@ export default function App() {
 }
 ```
 
-The default logical id is `location.pathname`. Pass `getId` when a persistent nested layout needs a stable outer identity. For example, map every `/products/*` URL to `/products` on the outer boundary, and use the default full pathname in a nested products provider.
+If the app has no nested transition provider, omit `getId={getRootTransitionId}` and the helper; the boundary defaults to the full `location.pathname`.
+
+### 3. Optional nested provider
+
+For nested transitions, the outer identity must stay stable while the nested boundary uses the full pathname. With the root setup above, copy this route layout:
+
+```tsx
+// src/routes/products.tsx
+import { A } from "@solidjs/router";
+import { For, type JSX } from "solid-js";
+import { Ssgoi, type SsgoiConfig } from "@ssgoi/solid";
+import { slide } from "@ssgoi/solid/view-transitions";
+import { SsgoiTransitionBoundary } from "../components/ssgoi-transition-boundary";
+
+const paths = [
+  "/products/all",
+  "/products/electronics",
+  "/products/fashion",
+];
+
+const config = {
+  transitions: [slide({ paths })],
+} satisfies SsgoiConfig;
+
+export default function ProductsLayout(props: { children?: JSX.Element }) {
+  return (
+    <section class="min-h-full">
+      <nav>
+        <For each={paths}>
+          {(path) => <A href={path}>{path.split("/").at(-1)}</A>}
+        </For>
+      </nav>
+
+      <div class="relative z-0 overflow-x-clip">
+        <Ssgoi config={config}>
+          {/* No getId here: nested tabs need their full pathname. */}
+          <SsgoiTransitionBoundary class="min-h-full">
+            {props.children}
+          </SsgoiTransitionBoundary>
+        </Ssgoi>
+      </div>
+    </section>
+  );
+}
+```
+
+Create child routes such as `src/routes/products/all.tsx`. Routed page components render ordinary content and must not add another `data-ssgoi-transition` marker; the boundary owns it.
 
 For plain Solid without Solid Router, put `data-ssgoi-transition` directly on the routed page boundary. Its value only needs to match the config; match dynamic descendants with wildcards such as `/post/*`.
 

--- a/apps/docs/public/llms/solid.txt
+++ b/apps/docs/public/llms/solid.txt
@@ -16,16 +16,52 @@ Same three rules as every framework (details in llms.txt):
 
 1. Pick the scroll element whose position SSGOI should preserve.
 2. Put `relative z-0` (plus `overflow-x-clip` for horizontal transitions) on the outer element that wraps `<Ssgoi>`.
-3. Mark routed content with `data-ssgoi-transition="..."` directly on each routed page.
+3. Mark routed content with `data-ssgoi-transition="..."`. SolidStart can do this once with a keyed layout boundary.
 
-## SolidStart example
+## SolidStart route boundary
+
+Solid's keyed `<Show>` gives each pathname its own reactive owner. Disposing the old owner removes the outgoing subtree before the incoming owner mounts:
+
+```tsx
+// src/components/ssgoi-transition-boundary.tsx
+import { useLocation } from "@solidjs/router";
+import { Show, splitProps, type JSX } from "solid-js";
+
+type Props = JSX.HTMLAttributes<HTMLDivElement> & {
+  children?: JSX.Element;
+  getId?: (pathname: string) => string;
+};
+
+const pathnameId = (pathname: string) => pathname;
+
+export function SsgoiTransitionBoundary(props: Props) {
+  const location = useLocation();
+  const [local, rest] = splitProps(props, ["children", "getId"]);
+  const transitionId = () =>
+    (local.getId ?? pathnameId)(location.pathname);
+
+  return (
+    <Show when={transitionId()} keyed>
+      {(id) => (
+        <div {...rest} data-ssgoi-transition={id}>
+          {local.children}
+        </div>
+      )}
+    </Show>
+  );
+}
+```
+
+Keep the boundary inside `<Suspense>`. Lazy route content must resolve before SSGOI observes the incoming marker; putting `<Suspense>` inside the boundary can mount an empty incoming wrapper too early.
 
 ```tsx
 // src/app.tsx
 import { Router } from "@solidjs/router";
 import { FileRoutes } from "@solidjs/start/router";
+import { Suspense } from "solid-js";
 import { Ssgoi } from "@ssgoi/solid";
 import { zoom } from "@ssgoi/solid/view-transitions";
+import { SsgoiTransitionBoundary } from "./components/ssgoi-transition-boundary";
 
 const config = {
   transitions: [zoom({ paths: ["/gallery", "/gallery/*"], type: "expand" })],
@@ -36,7 +72,13 @@ export default function App() {
     <Router
       root={(props) => (
         <main class="relative z-0 min-h-dvh overflow-y-auto overflow-x-clip">
-          <Ssgoi config={config}>{props.children}</Ssgoi>
+          <Ssgoi config={config}>
+            <Suspense>
+              <SsgoiTransitionBoundary>
+                {props.children}
+              </SsgoiTransitionBoundary>
+            </Suspense>
+          </Ssgoi>
         </main>
       )}
     >
@@ -44,14 +86,11 @@ export default function App() {
     </Router>
   );
 }
-
-// src/routes/gallery/index.tsx
-export default function Gallery() {
-  return <section data-ssgoi-transition="/gallery">{/* content */}</section>;
-}
 ```
 
-The `data-ssgoi-transition` value can be a hard-coded logical page id; it only needs to match the `from`, `to`, or `paths` values in `SsgoiConfig`. For dynamic routes, match with wildcards in the config (`/post/*`).
+The default logical id is `location.pathname`. Pass `getId` when a persistent nested layout needs a stable outer identity. For example, map every `/products/*` URL to `/products` on the outer boundary, and use the default full pathname in a nested products provider.
+
+For plain Solid without Solid Router, put `data-ssgoi-transition` directly on the routed page boundary. Its value only needs to match the config; match dynamic descendants with wildcards such as `/post/*`.
 
 ## Shared reference
 

--- a/apps/docs/public/llms/svelte.txt
+++ b/apps/docs/public/llms/svelte.txt
@@ -18,19 +18,101 @@ Same three rules as every framework (details in llms.txt):
 2. Put `relative z-0` (plus `overflow-x-clip` for horizontal transitions) on the outer element that wraps the SSGOI provider.
 3. Mark routed content with `data-ssgoi-transition="..."`.
 
-## Route boundary rule (SvelteKit-specific)
+## SvelteKit route boundary
 
-Set `data-ssgoi-transition` **directly on each routed page's boundary element** — do NOT wrap the layout slot in a single shared boundary.
+SvelteKit can mark routed content once in a layout, but a plain `{#key $page.url.pathname}` wrapper is not sufficient. Layout snippets are live: SvelteKit can update the old wrapper's `children` to the incoming route before removing it.
 
-SvelteKit slot content is live: during navigation the outgoing page wrapper can render the incoming page's children, so a layout-level boundary pairs the wrong subtrees. Each page marks itself:
+Use a small SvelteKit-specific boundary that detaches the old route synchronously in `onNavigate`, before SvelteKit updates the live snippet, and mounts the new route in the callback SvelteKit runs after the route DOM has updated:
 
 ```svelte
-<main data-ssgoi-transition="/gallery">
-  <!-- page content -->
+<!-- src/lib/ssgoi-transition-boundary.svelte -->
+<script lang="ts">
+  import { onNavigate } from "$app/navigation";
+  import { page } from "$app/stores";
+  import { flushSync, onDestroy, type Snippet } from "svelte";
+
+  interface Props {
+    children: Snippet;
+    as?: keyof HTMLElementTagNameMap;
+    class?: string;
+    getId?: (url: URL) => string;
+    [key: string]: unknown;
+  }
+
+  const pathnameId = (url: URL) => url.pathname;
+
+  let {
+    children,
+    as = "div",
+    class: className,
+    getId = pathnameId,
+    ...rest
+  }: Props = $props();
+
+  let currentId = $state(getId($page.url));
+  let mounted = $state(true);
+  let alive = true;
+
+  onDestroy(() => {
+    alive = false;
+  });
+
+  onNavigate((navigation) => {
+    if (!alive || !navigation.to) return;
+
+    const nextId = getId(navigation.to.url);
+    if (nextId === currentId) return;
+
+    flushSync(() => {
+      mounted = false;
+    });
+
+    return () => {
+      if (!alive) return;
+
+      flushSync(() => {
+        currentId = nextId;
+        mounted = true;
+      });
+    };
+  });
+</script>
+
+{#if mounted}
+  <svelte:element
+    this={as}
+    data-ssgoi-transition={currentId}
+    class={className}
+    {...rest}
+  >
+    {@render children()}
+  </svelte:element>
+{/if}
+```
+
+Use it inside the provider in a persistent layout:
+
+```svelte
+<script lang="ts">
+  import { Ssgoi } from "@ssgoi/svelte";
+  import SsgoiTransitionBoundary from "$lib/ssgoi-transition-boundary.svelte";
+
+  let { children } = $props();
+</script>
+
+<!-- Positioning and overflow classes belong on this outer layout shell. -->
+<main class="relative z-0 overflow-x-clip overflow-y-auto">
+  <Ssgoi {config}>
+    <SsgoiTransitionBoundary class="min-h-full">
+      {@render children()}
+    </SsgoiTransitionBoundary>
+  </Ssgoi>
 </main>
 ```
 
-The value can be a hard-coded logical page id; it does not have to be the framework's route pathname. It only needs to match the `from`, `to`, or `paths` values in `SsgoiConfig`. For dynamic routes, match with wildcards in the config (`/post/*`).
+The default logical id is `url.pathname`. Pass `getId` when a persistent nested layout needs a stable outer identity. For example, map every `/products/*` URL to `/products` on the outer boundary, and use the default full pathname in a nested products provider.
+
+For plain Svelte without SvelteKit navigation hooks, put `data-ssgoi-transition` directly on the routed page boundary. Its value only needs to match the `from`, `to`, or `paths` values in `SsgoiConfig`; match dynamic descendants with config wildcards such as `/post/*`.
 
 ## Shared reference
 

--- a/apps/docs/public/llms/svelte.txt
+++ b/apps/docs/public/llms/svelte.txt
@@ -22,10 +22,12 @@ Same three rules as every framework (details in llms.txt):
 
 SvelteKit can mark routed content once in a layout, but a plain `{#key $page.url.pathname}` wrapper is not sufficient. Layout snippets are live: SvelteKit can update the old wrapper's `children` to the incoming route before removing it.
 
+### 1. Copy the boundary component
+
 Use a small SvelteKit-specific boundary that detaches the old route synchronously in `onNavigate`, before SvelteKit updates the live snippet, and mounts the new route in the callback SvelteKit runs after the route DOM has updated:
 
 ```svelte
-<!-- src/lib/ssgoi-transition-boundary.svelte -->
+<!-- src/lib/components/ssgoi-transition-boundary.svelte -->
 <script lang="ts">
   import { onNavigate } from "$app/navigation";
   import { page } from "$app/stores";
@@ -63,10 +65,14 @@ Use a small SvelteKit-specific boundary that detaches the old route synchronousl
     const nextId = getId(navigation.to.url);
     if (nextId === currentId) return;
 
+    // Detach the old route before SvelteKit updates its live `children`
+    // snippet. SSGOI can then retain the real outgoing DOM for its animation.
     flushSync(() => {
       mounted = false;
     });
 
+    // SvelteKit calls this after the route DOM has updated. Rendering the
+    // snippet now produces only the incoming route under its own boundary.
     return () => {
       if (!alive) return;
 
@@ -90,27 +96,94 @@ Use a small SvelteKit-specific boundary that detaches the old route synchronousl
 {/if}
 ```
 
-Use it inside the provider in a persistent layout:
+### 2. Wrap routed content once
+
+Copy the component above as-is, then use it inside the provider in a persistent root layout. This example is complete: it includes imports, a typed config, the required scroll/positioning shell, and a stable id for an optional nested `/products` layout.
 
 ```svelte
+<!-- src/routes/+layout.svelte -->
 <script lang="ts">
-  import { Ssgoi } from "@ssgoi/svelte";
-  import SsgoiTransitionBoundary from "$lib/ssgoi-transition-boundary.svelte";
+  import "../app.css";
+  import { Ssgoi, type SsgoiConfig } from "@ssgoi/svelte";
+  import { drill, zoom } from "@ssgoi/svelte/view-transitions";
+  import type { Snippet } from "svelte";
+  import SsgoiTransitionBoundary from "$lib/components/ssgoi-transition-boundary.svelte";
 
-  let { children } = $props();
+  let { children }: { children: Snippet } = $props();
+
+  const config = {
+    preserveScroll: { exclude: ["/posts/*"] },
+    transitions: [
+      drill({ enter: "/posts/*", exit: "/posts" }),
+      zoom({ paths: ["/gallery", "/gallery/*"], type: "expand" }),
+    ],
+  } satisfies SsgoiConfig;
+
+  const getRootTransitionId = (url: URL) =>
+    url.pathname === "/products" || url.pathname.startsWith("/products/")
+      ? "/products"
+      : url.pathname;
 </script>
 
-<!-- Positioning and overflow classes belong on this outer layout shell. -->
-<main class="relative z-0 overflow-x-clip overflow-y-auto">
+<!-- This is the scroll element and the positioned ancestor for OUT clones. -->
+<main class="relative z-0 h-dvh overflow-y-auto overflow-x-clip">
   <Ssgoi {config}>
-    <SsgoiTransitionBoundary class="min-h-full">
+    <SsgoiTransitionBoundary
+      getId={getRootTransitionId}
+      class="min-h-full"
+    >
       {@render children()}
     </SsgoiTransitionBoundary>
   </Ssgoi>
 </main>
 ```
 
-The default logical id is `url.pathname`. Pass `getId` when a persistent nested layout needs a stable outer identity. For example, map every `/products/*` URL to `/products` on the outer boundary, and use the default full pathname in a nested products provider.
+If the app has no nested transition provider, omit `getId={getRootTransitionId}` and the helper; the boundary defaults to the full `url.pathname`.
+
+### 3. Optional nested provider
+
+For nested transitions, the outer identity must stay stable while the nested boundary uses the full pathname. With the root layout above, copy this nested layout:
+
+```svelte
+<!-- src/routes/products/+layout.svelte -->
+<script lang="ts">
+  import { Ssgoi, type SsgoiConfig } from "@ssgoi/svelte";
+  import { slide } from "@ssgoi/svelte/view-transitions";
+  import type { Snippet } from "svelte";
+  import SsgoiTransitionBoundary from "$lib/components/ssgoi-transition-boundary.svelte";
+
+  let { children }: { children: Snippet } = $props();
+
+  const paths = [
+    "/products/all",
+    "/products/electronics",
+    "/products/fashion",
+  ];
+
+  const config = {
+    transitions: [slide({ paths })],
+  } satisfies SsgoiConfig;
+</script>
+
+<section class="min-h-full">
+  <nav>
+    <a href="/products/all">All</a>
+    <a href="/products/electronics">Tech</a>
+    <a href="/products/fashion">Fashion</a>
+  </nav>
+
+  <div class="relative z-0 overflow-x-clip">
+    <Ssgoi {config}>
+      <!-- No getId here: nested tabs need their full pathname. -->
+      <SsgoiTransitionBoundary class="min-h-full">
+        {@render children()}
+      </SsgoiTransitionBoundary>
+    </Ssgoi>
+  </div>
+</section>
+```
+
+Routed `+page.svelte` files now render ordinary page content and must not add another `data-ssgoi-transition` marker. The boundary owns that marker.
 
 For plain Svelte without SvelteKit navigation hooks, put `data-ssgoi-transition` directly on the routed page boundary. Its value only needs to match the `from`, `to`, or `paths` values in `SsgoiConfig`; match dynamic descendants with config wildcards such as `/post/*`.
 

--- a/apps/docs/public/llms/vue.txt
+++ b/apps/docs/public/llms/vue.txt
@@ -18,21 +18,58 @@ Same three rules as every framework (details in llms.txt):
 2. Put `relative z-0` (plus `overflow-x-clip` for horizontal transitions) on the outer element that wraps the SSGOI provider.
 3. Mark routed content with `data-ssgoi-transition="..."`.
 
-## Route boundary rule (Nuxt/Vue-specific)
+## Nuxt/Vue route boundary
 
-Set `data-ssgoi-transition` **directly on each routed page's boundary element** — do NOT wrap the layout slot in a single shared boundary.
+Nuxt can mark routed content once in a persistent layout. A keyed Vue VNode retains its own slot subtree, so unmounting the old key gives SSGOI the outgoing page while the new key receives the incoming route.
 
-Nuxt slot content is live: during navigation the outgoing page wrapper can render the incoming page's children, so a layout-level boundary pairs the wrong subtrees. Each page marks itself:
+Create a small router-specific boundary:
 
 ```vue
+<!-- components/ssgoi-transition-boundary.vue -->
 <template>
-  <main data-ssgoi-transition="/gallery">
-    <!-- page content -->
-  </main>
+  <component
+    :is="as"
+    :key="transitionId"
+    :data-ssgoi-transition="transitionId"
+  >
+    <slot />
+  </component>
 </template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { useRoute } from "vue-router";
+
+interface Props {
+  as?: keyof HTMLElementTagNameMap;
+  getId?: (pathname: string) => string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  as: "div",
+  getId: (pathname: string) => pathname,
+});
+
+const route = useRoute();
+const transitionId = computed(() => props.getId(route.path));
+</script>
 ```
 
-The value can be a hard-coded logical page id; it does not have to be the framework's route pathname. It only needs to match the `from`, `to`, or `paths` values in `SsgoiConfig`. For dynamic routes, match with wildcards in the config (`/post/*`).
+Use it inside the provider in a persistent layout:
+
+```vue
+<main class="relative z-0 overflow-x-clip overflow-y-auto">
+  <Ssgoi :config="config">
+    <SsgoiTransitionBoundary class="min-h-full">
+      <slot />
+    </SsgoiTransitionBoundary>
+  </Ssgoi>
+</main>
+```
+
+The default logical id is `route.path`. Pass `getId` when a persistent nested layout needs a stable outer identity. For example, map every `/products/*` URL to `/products` on the outer boundary, and use the default full path in a nested products provider.
+
+For plain Vue without Vue Router, put `data-ssgoi-transition` directly on the routed page boundary. Its value only needs to match the `from`, `to`, or `paths` values in `SsgoiConfig`; match dynamic descendants with config wildcards such as `/post/*`.
 
 ## Shared reference
 

--- a/apps/docs/public/llms/vue.txt
+++ b/apps/docs/public/llms/vue.txt
@@ -22,6 +22,8 @@ Same three rules as every framework (details in llms.txt):
 
 Nuxt can mark routed content once in a persistent layout. A keyed Vue VNode retains its own slot subtree, so unmounting the old key gives SSGOI the outgoing page while the new key receives the incoming route.
 
+### 1. Copy the boundary component
+
 Create a small router-specific boundary:
 
 ```vue
@@ -55,19 +57,91 @@ const transitionId = computed(() => props.getId(route.path));
 </script>
 ```
 
-Use it inside the provider in a persistent layout:
+### 2. Wrap routed content once
+
+Copy the component above as-is, then use it in `app.vue`. This example includes all imports, a typed config, the required scroll/positioning shell, and a stable id for an optional nested `/products` layout:
 
 ```vue
-<main class="relative z-0 overflow-x-clip overflow-y-auto">
-  <Ssgoi :config="config">
-    <SsgoiTransitionBoundary class="min-h-full">
-      <slot />
-    </SsgoiTransitionBoundary>
-  </Ssgoi>
-</main>
+<!-- app.vue -->
+<template>
+  <!-- This is the scroll element and the positioned ancestor for OUT clones. -->
+  <main class="relative z-0 h-dvh overflow-y-auto overflow-x-clip">
+    <Ssgoi :config="config">
+      <SsgoiTransitionBoundary
+        :get-id="getRootTransitionId"
+        class="min-h-full"
+      >
+        <NuxtPage />
+      </SsgoiTransitionBoundary>
+    </Ssgoi>
+  </main>
+</template>
+
+<script setup lang="ts">
+import { Ssgoi } from "@ssgoi/vue";
+import type { SsgoiConfig } from "@ssgoi/vue";
+import { drill, zoom } from "@ssgoi/vue/view-transitions";
+
+const config = {
+  preserveScroll: { exclude: ["/posts/*"] },
+  transitions: [
+    drill({ enter: "/posts/*", exit: "/posts" }),
+    zoom({ paths: ["/gallery", "/gallery/*"], type: "expand" }),
+  ],
+} satisfies SsgoiConfig;
+
+const getRootTransitionId = (path: string) =>
+  path === "/products" || path.startsWith("/products/")
+    ? "/products"
+    : path;
+</script>
 ```
 
-The default logical id is `route.path`. Pass `getId` when a persistent nested layout needs a stable outer identity. For example, map every `/products/*` URL to `/products` on the outer boundary, and use the default full path in a nested products provider.
+If the app has no nested transition provider, omit `:get-id="getRootTransitionId"` and the helper; the boundary defaults to the full `route.path`.
+
+### 3. Optional nested provider
+
+For nested transitions, the outer identity must stay stable while the nested boundary uses the full pathname. With the root setup above, copy this Nuxt parent page:
+
+```vue
+<!-- pages/products.vue -->
+<template>
+  <section class="min-h-full">
+    <nav>
+      <NuxtLink v-for="path in paths" :key="path" :to="path">
+        {{ path.split("/").at(-1) }}
+      </NuxtLink>
+    </nav>
+
+    <div class="relative z-0 overflow-x-clip">
+      <Ssgoi :config="config">
+        <!-- No get-id here: nested tabs need their full pathname. -->
+        <SsgoiTransitionBoundary class="min-h-full">
+          <NuxtPage />
+        </SsgoiTransitionBoundary>
+      </Ssgoi>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { Ssgoi } from "@ssgoi/vue";
+import type { SsgoiConfig } from "@ssgoi/vue";
+import { slide } from "@ssgoi/vue/view-transitions";
+
+const paths = [
+  "/products/all",
+  "/products/electronics",
+  "/products/fashion",
+];
+
+const config = {
+  transitions: [slide({ paths })],
+} satisfies SsgoiConfig;
+</script>
+```
+
+Create the child pages at `pages/products/all.vue`, `pages/products/electronics.vue`, and `pages/products/fashion.vue`. They render ordinary page content and must not add another `data-ssgoi-transition` marker; the boundary owns it.
 
 For plain Vue without Vue Router, put `data-ssgoi-transition` directly on the routed page boundary. Its value only needs to match the `from`, `to`, or `paths` values in `SsgoiConfig`; match dynamic descendants with config wildcards such as `/post/*`.
 

--- a/templates/nuxt/README.md
+++ b/templates/nuxt/README.md
@@ -50,6 +50,7 @@ nuxt/
 │   ├── pincard.vue           # Pinterest card
 │   ├── postcard.vue          # Profile post card
 │   ├── profilefeed.vue       # Profile feed grid
+│   ├── ssgoi-transition-boundary.vue # Keyed route boundary
 │   └── products/             # Product components
 ├── composables/               # Vue composables
 │   ├── use-posts.ts          # Posts data
@@ -67,19 +68,22 @@ nuxt/
 
 ## Route Boundaries
 
-Nuxt pages mark their own transition boundary with `data-ssgoi-transition`.
-Use a stable logical id that matches your config; it does not have to be the
-actual route pathname.
-Do not use a single slot-based layout boundary here; the outgoing slot can
-render the incoming page content.
+`SsgoiTransitionBoundary` lets a persistent layout own the transition marker,
+so individual page components do not set `data-ssgoi-transition`. Its keyed
+Vue VNode keeps the outgoing slot subtree separate from the incoming route.
 
 ```vue
-<template>
-  <div data-ssgoi-transition="/posts">
-    <!-- page content -->
-  </div>
-</template>
+<Ssgoi :config="config">
+  <SsgoiTransitionBoundary>
+    <slot />
+  </SsgoiTransitionBoundary>
+</Ssgoi>
 ```
+
+The default id is `route.path`. Pass `getId` when a persistent nested layout
+needs one outer identity. This template maps every `/products/*` route to the
+outer `/products` boundary and uses the full path in the nested products
+provider.
 
 ## Transitions
 

--- a/templates/nuxt/components/demo-layout.vue
+++ b/templates/nuxt/components/demo-layout.vue
@@ -8,7 +8,12 @@
         class="flex-1 w-full overflow-y-scroll overflow-x-hidden relative z-0 bg-[#121212] scrollbar-hide"
       >
         <Ssgoi :config="config">
-          <slot />
+          <SsgoiTransitionBoundary
+            :get-id="getRootTransitionId"
+            class="min-h-full bg-[#121212]"
+          >
+            <slot />
+          </SsgoiTransitionBoundary>
         </Ssgoi>
       </main>
 
@@ -105,6 +110,11 @@ import { drill, zoom } from '@ssgoi/vue/view-transitions';
 
 const route = useRoute();
 const pathname = computed(() => route.path);
+
+const getRootTransitionId = (path: string) =>
+  path === '/products' || path.startsWith('/products/')
+    ? '/products'
+    : path;
 
 const config: SsgoiConfig = {
   preserveScroll: { exclude: ['/posts/*'] },

--- a/templates/nuxt/components/products/product-grid.vue
+++ b/templates/nuxt/components/products/product-grid.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :data-ssgoi-transition="`/products/${category}`">
+  <div>
     <div class="px-4 pb-6 h-full overflow-y-auto">
       <div v-if="products.length === 0" class="text-center py-12">
         <p class="text-neutral-500 text-sm">No products in this category</p>
@@ -20,6 +20,5 @@ import type { Product } from "~/composables/use-products";
 
 defineProps<{
   products: Product[];
-  category: string;
 }>();
 </script>

--- a/templates/nuxt/components/ssgoi-transition-boundary.vue
+++ b/templates/nuxt/components/ssgoi-transition-boundary.vue
@@ -1,0 +1,23 @@
+<template>
+  <component :is="as" :key="transitionId" :data-ssgoi-transition="transitionId">
+    <slot />
+  </component>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { useRoute } from "vue-router";
+
+interface Props {
+  as?: keyof HTMLElementTagNameMap;
+  getId?: (pathname: string) => string;
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  as: "div",
+  getId: (pathname: string) => pathname,
+});
+
+const route = useRoute();
+const transitionId = computed(() => props.getId(route.path));
+</script>

--- a/templates/nuxt/pages/pinterest/[id].vue
+++ b/templates/nuxt/pages/pinterest/[id].vue
@@ -1,5 +1,5 @@
 <template>
-  <div :data-ssgoi-transition="`/pinterest/${id}`">
+  <div>
     <div v-if="!item" class="min-h-screen bg-[#121212] px-4 py-8">
       <p class="text-gray-400">Pin not found</p>
     </div>

--- a/templates/nuxt/pages/pinterest/index.vue
+++ b/templates/nuxt/pages/pinterest/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div data-ssgoi-transition="/pinterest">
+  <div>
     <div class="min-h-screen bg-[#121212] px-4 py-6">
       <!-- Header -->
       <div class="mb-6">

--- a/templates/nuxt/pages/posts/[id].vue
+++ b/templates/nuxt/pages/posts/[id].vue
@@ -1,5 +1,5 @@
 <template>
-  <div :data-ssgoi-transition="`/posts/${id}`">
+  <div>
     <div v-if="!post" class="min-h-screen bg-[#121212] px-4 py-8">
       <p class="text-gray-400">Post not found</p>
     </div>

--- a/templates/nuxt/pages/posts/index.vue
+++ b/templates/nuxt/pages/posts/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div data-ssgoi-transition="/posts">
+  <div>
     <div class="min-h-full bg-[#121212] px-4 py-6">
       <!-- Header -->
       <div class="mb-6">

--- a/templates/nuxt/pages/products.vue
+++ b/templates/nuxt/pages/products.vue
@@ -1,8 +1,5 @@
 <template>
-  <div
-    data-ssgoi-transition="/products"
-    class="min-h-screen bg-[#121212] flex flex-col"
-  >
+  <div class="min-h-screen bg-[#121212] flex flex-col">
     <!-- Header - Fixed -->
     <div class="px-4 pt-6 pb-3 flex-shrink-0">
       <h1 class="text-sm font-medium text-white mb-1">Shop</h1>
@@ -31,7 +28,9 @@
     <!-- Tab Content - Slide transitions here -->
     <div class="flex-1 overflow-hidden relative">
       <Ssgoi :config="config">
-        <NuxtPage />
+        <SsgoiTransitionBoundary class="min-h-full bg-[#121212]">
+          <NuxtPage />
+        </SsgoiTransitionBoundary>
       </Ssgoi>
     </div>
   </div>

--- a/templates/nuxt/pages/products/all.vue
+++ b/templates/nuxt/pages/products/all.vue
@@ -1,5 +1,5 @@
 <template>
-  <ProductsProductGrid :products="products" category="all" />
+  <ProductsProductGrid :products="products" />
 </template>
 
 <script setup lang="ts">

--- a/templates/nuxt/pages/products/beauty.vue
+++ b/templates/nuxt/pages/products/beauty.vue
@@ -1,5 +1,5 @@
 <template>
-  <ProductsProductGrid :products="products" category="beauty" />
+  <ProductsProductGrid :products="products" />
 </template>
 
 <script setup lang="ts">

--- a/templates/nuxt/pages/products/electronics.vue
+++ b/templates/nuxt/pages/products/electronics.vue
@@ -1,5 +1,5 @@
 <template>
-  <ProductsProductGrid :products="products" category="electronics" />
+  <ProductsProductGrid :products="products" />
 </template>
 
 <script setup lang="ts">

--- a/templates/nuxt/pages/products/fashion.vue
+++ b/templates/nuxt/pages/products/fashion.vue
@@ -1,5 +1,5 @@
 <template>
-  <ProductsProductGrid :products="products" category="fashion" />
+  <ProductsProductGrid :products="products" />
 </template>
 
 <script setup lang="ts">

--- a/templates/nuxt/pages/products/home.vue
+++ b/templates/nuxt/pages/products/home.vue
@@ -1,5 +1,5 @@
 <template>
-  <ProductsProductGrid :products="products" category="home" />
+  <ProductsProductGrid :products="products" />
 </template>
 
 <script setup lang="ts">

--- a/templates/nuxt/pages/profile/[id].vue
+++ b/templates/nuxt/pages/profile/[id].vue
@@ -1,5 +1,5 @@
 <template>
-  <div :data-ssgoi-transition="`/profile/${id}`">
+  <div>
     <div v-if="!post" class="bg-[#121212] px-4 py-8">
       <p class="text-gray-400">Post not found</p>
     </div>

--- a/templates/nuxt/pages/profile/index.vue
+++ b/templates/nuxt/pages/profile/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div data-ssgoi-transition="/profile">
+  <div>
     <div class="bg-[#121212]">
       <!-- Profile Header -->
       <div class="relative">

--- a/templates/qwik/README.md
+++ b/templates/qwik/README.md
@@ -7,4 +7,13 @@ pnpm install
 pnpm dev
 ```
 
-Qwik pages mark their own transition boundary with `data-ssgoi-transition`, matching the SvelteKit and Nuxt template pattern. The root layout calls `useSsgoi(ref, { config$ })` directly because Qwik serializes component state and SSGOI configs contain transition functions.
+Qwik pages mark their own transition boundary with `data-ssgoi-transition`.
+The root layout calls `useSsgoi(ref, { config$ })` directly because Qwik
+serializes component state and SSGOI configs contain transition functions.
+
+Keep the marker on each Qwik City page. A keyed wrapper around the layout
+`<Slot />` is not a safe route boundary: Qwik moves the projected slot into the
+new wrapper before updating its routed content, so the incoming id can briefly
+contain the outgoing page. The navigation interception API that could stage the
+unmount is currently experimental, so this template deliberately keeps the
+page-owned boundary pattern.

--- a/templates/solidstart/README.md
+++ b/templates/solidstart/README.md
@@ -7,4 +7,21 @@ pnpm install
 pnpm dev
 ```
 
-SolidStart pages mark their own transition boundary with `data-ssgoi-transition`, matching the SvelteKit, Nuxt, and Qwik template pattern. The root app wraps file routes once with `<Ssgoi>`, while every route page provides the stable transition id that the config matches.
+SolidStart routes are wrapped once with `SsgoiTransitionBoundary`, so individual
+page components do not set `data-ssgoi-transition`. The boundary uses Solid's
+keyed `<Show>` to dispose the outgoing route owner before mounting the incoming
+one.
+
+Keep the boundary inside `<Suspense>` so lazy route content is ready before
+SSGOI observes the incoming marker:
+
+```tsx
+<Ssgoi config={config}>
+  <Suspense>
+    <SsgoiTransitionBoundary>{props.children}</SsgoiTransitionBoundary>
+  </Suspense>
+</Ssgoi>
+```
+
+Nested providers use the same component. The outer boundary maps
+`/products/*` to `/products`, while the nested boundary uses the full pathname.

--- a/templates/solidstart/src/app.tsx
+++ b/templates/solidstart/src/app.tsx
@@ -3,6 +3,7 @@ import { FileRoutes } from "@solidjs/start/router";
 import { Suspense, type JSX } from "solid-js";
 import { Ssgoi, type SsgoiConfig } from "@ssgoi/solid";
 import { drill, zoom } from "@ssgoi/solid/view-transitions";
+import { SsgoiTransitionBoundary } from "./components/ssgoi-transition-boundary";
 import "./app.css";
 
 const ssgoiConfig = {
@@ -23,15 +24,12 @@ const ssgoiConfig = {
   ],
 } satisfies SsgoiConfig;
 
+const getRootTransitionId = (path: string) =>
+  path === "/products" || path.startsWith("/products/") ? "/products" : path;
+
 export default function App() {
   return (
-    <Router
-      root={(props) => (
-        <AppFrame>
-          <Suspense>{props.children}</Suspense>
-        </AppFrame>
-      )}
-    >
+    <Router root={(props) => <AppFrame>{props.children}</AppFrame>}>
       <FileRoutes />
     </Router>
   );
@@ -52,7 +50,16 @@ function AppFrame(props: { children?: JSX.Element }) {
               data-ssgoi-root=""
               class="flex-1 min-h-0 w-full overflow-y-scroll overflow-x-clip relative z-0 bg-[#121212] scrollbar-hide"
             >
-              <Ssgoi config={ssgoiConfig}>{props.children}</Ssgoi>
+              <Ssgoi config={ssgoiConfig}>
+                <Suspense>
+                  <SsgoiTransitionBoundary
+                    getId={getRootTransitionId}
+                    class="min-h-full bg-[#121212]"
+                  >
+                    {props.children}
+                  </SsgoiTransitionBoundary>
+                </Suspense>
+              </Ssgoi>
             </main>
 
             <nav class="flex justify-around items-center bg-[#121212] border-t border-white/5 py-2 flex-shrink-0">

--- a/templates/solidstart/src/components/pinterest.tsx
+++ b/templates/solidstart/src/components/pinterest.tsx
@@ -11,10 +11,7 @@ export function PinterestPage() {
   const rightColumnItems = pinterestItems.filter((_, index) => index % 2 === 1);
 
   return (
-    <div
-      data-ssgoi-transition="/pinterest"
-      class="min-h-screen bg-[#121212] px-4 py-6"
-    >
+    <div class="min-h-screen bg-[#121212] px-4 py-6">
       <div class="mb-6">
         <h1 class="text-sm font-medium text-white mb-1">Gallery</h1>
         <p class="text-xs text-neutral-500">
@@ -41,19 +38,13 @@ export function PinterestDetailPage(props: { pinId: string }) {
     <Show
       when={item()}
       fallback={
-        <div
-          data-ssgoi-transition={`/pinterest/${props.pinId}`}
-          class="min-h-screen bg-[#121212] px-4 py-8"
-        >
+        <div class="min-h-screen bg-[#121212] px-4 py-8">
           <p class="text-gray-400">Pin not found</p>
         </div>
       }
     >
       {(item) => (
-        <div
-          data-ssgoi-transition={`/pinterest/${item().id}`}
-          class="min-h-screen bg-[#121212]"
-        >
+        <div class="min-h-screen bg-[#121212]">
           <div class="px-4 py-4">
             <A
               href="/pinterest"

--- a/templates/solidstart/src/components/posts.tsx
+++ b/templates/solidstart/src/components/posts.tsx
@@ -11,7 +11,7 @@ export function PostsPage() {
   const posts = getAllPosts();
 
   return (
-    <div data-ssgoi-transition="/posts" class="min-h-full bg-[#121212]">
+    <div class="min-h-full bg-[#121212]">
       <div class="px-4 py-6">
         <div class="mb-6">
           <h1 class="text-sm font-medium text-white mb-1">Latest Posts</h1>
@@ -84,19 +84,13 @@ export function PostDetailPage(props: { postId: string }) {
     <Show
       when={post()}
       fallback={
-        <div
-          data-ssgoi-transition={`/posts/${props.postId}`}
-          class="min-h-full bg-[#121212] px-4 py-8"
-        >
+        <div class="min-h-full bg-[#121212] px-4 py-8">
           <p class="text-gray-400">Post not found</p>
         </div>
       }
     >
       {(post) => (
-        <div
-          data-ssgoi-transition={`/posts/${post().id}`}
-          class="min-h-screen bg-[#121212]"
-        >
+        <div class="min-h-screen bg-[#121212]">
           <div class="px-4 py-4">
             <A
               href="/posts"

--- a/templates/solidstart/src/components/products.tsx
+++ b/templates/solidstart/src/components/products.tsx
@@ -3,10 +3,9 @@ import { getProductsByCategory, type Product } from "../data/products";
 
 export function ProductGrid(props: { category: string }) {
   const products = () => getProductsByCategory(props.category);
-  const transitionId = () => `/products/${props.category}`;
 
   return (
-    <div data-ssgoi-transition={transitionId()}>
+    <div>
       <div class="px-4 pb-6 h-full overflow-y-auto">
         <Show
           when={products().length > 0}

--- a/templates/solidstart/src/components/profile.tsx
+++ b/templates/solidstart/src/components/profile.tsx
@@ -4,7 +4,7 @@ import { getPost, profile, posts, type Post } from "../data/profile";
 
 export function ProfilePage() {
   return (
-    <div data-ssgoi-transition="/profile" class="bg-[#121212]">
+    <div class="bg-[#121212]">
       <div class="relative">
         <div class="h-24 relative">
           <img
@@ -91,19 +91,13 @@ export function ProfileDetailPage(props: { postId: string }) {
     <Show
       when={post()}
       fallback={
-        <div
-          data-ssgoi-transition={`/profile/${props.postId}`}
-          class="bg-[#121212] px-4 py-8"
-        >
+        <div class="bg-[#121212] px-4 py-8">
           <p class="text-gray-400">Post not found</p>
         </div>
       }
     >
       {(post) => (
-        <div
-          data-ssgoi-transition={`/profile/${post().id}`}
-          class="bg-[#121212] min-h-[760px]"
-        >
+        <div class="bg-[#121212] min-h-[760px]">
           <div class="relative">
             <img
               src={post().coverImage.url}

--- a/templates/solidstart/src/components/ssgoi-transition-boundary.tsx
+++ b/templates/solidstart/src/components/ssgoi-transition-boundary.tsx
@@ -1,0 +1,25 @@
+import { useLocation } from "@solidjs/router";
+import { Show, splitProps, type JSX } from "solid-js";
+
+type Props = JSX.HTMLAttributes<HTMLDivElement> & {
+  children?: JSX.Element;
+  getId?: (pathname: string) => string;
+};
+
+const pathnameId = (pathname: string) => pathname;
+
+export function SsgoiTransitionBoundary(props: Props) {
+  const location = useLocation();
+  const [local, rest] = splitProps(props, ["children", "getId"]);
+  const transitionId = () => (local.getId ?? pathnameId)(location.pathname);
+
+  return (
+    <Show when={transitionId()} keyed>
+      {(id) => (
+        <div {...rest} data-ssgoi-transition={id}>
+          {local.children}
+        </div>
+      )}
+    </Show>
+  );
+}

--- a/templates/solidstart/src/routes/products.tsx
+++ b/templates/solidstart/src/routes/products.tsx
@@ -2,6 +2,7 @@ import { A, useLocation } from "@solidjs/router";
 import { For, type JSX } from "solid-js";
 import { Ssgoi, type SsgoiConfig } from "@ssgoi/solid";
 import { slide } from "@ssgoi/solid/view-transitions";
+import { SsgoiTransitionBoundary } from "../components/ssgoi-transition-boundary";
 
 const categories = [
   { id: "all", label: "All", path: "/products/all" },
@@ -19,10 +20,7 @@ export default function ProductsLayout(props: { children?: JSX.Element }) {
   const location = useLocation();
 
   return (
-    <div
-      data-ssgoi-transition="/products"
-      class="min-h-screen bg-[#121212] flex flex-col"
-    >
+    <div class="min-h-screen bg-[#121212] flex flex-col">
       <div class="px-4 pt-6 pb-3 flex-shrink-0">
         <h1 class="text-sm font-medium text-white mb-1">Shop</h1>
         <p class="text-xs text-neutral-500">Discover our curated collection</p>
@@ -50,7 +48,11 @@ export default function ProductsLayout(props: { children?: JSX.Element }) {
       </div>
 
       <div class="flex-1 overflow-hidden relative">
-        <Ssgoi config={productConfig}>{props.children}</Ssgoi>
+        <Ssgoi config={productConfig}>
+          <SsgoiTransitionBoundary class="min-h-full bg-[#121212]">
+            {props.children}
+          </SsgoiTransitionBoundary>
+        </Ssgoi>
       </div>
     </div>
   );

--- a/templates/sveltekit/README.md
+++ b/templates/sveltekit/README.md
@@ -39,6 +39,7 @@ src/
 │   ├── components/
 │   │   ├── demo-layout.svelte      # Main layout with Ssgoi provider and navigation
 │   │   ├── demo-wrapper.svelte     # iPhone frame wrapper
+│   │   ├── ssgoi-transition-boundary.svelte # SvelteKit route boundary
 │   │   └── product-grid.svelte     # Product grid component
 │   └── data/
 │       ├── posts.ts                # Posts mock data
@@ -56,17 +57,24 @@ src/
 
 ## Route Boundaries
 
-SvelteKit pages mark their own transition boundary with `data-ssgoi-transition`.
-Use a stable logical id that matches your config; it does not have to be the
-actual route pathname.
-Do not use a single slot-based layout boundary here; the outgoing slot can
-render the incoming page content.
+`SsgoiTransitionBoundary` lets the layout own the transition marker, so page
+components do not need to set `data-ssgoi-transition` themselves. It detaches
+the outgoing boundary in SvelteKit's `onNavigate` hook before the live layout
+snippet is updated, then mounts the incoming boundary after the route DOM has
+updated.
 
 ```svelte
-<div data-ssgoi-transition="/posts">
-  <!-- page content -->
-</div>
+<Ssgoi {config}>
+  <SsgoiTransitionBoundary>
+    {@render children()}
+  </SsgoiTransitionBoundary>
+</Ssgoi>
 ```
+
+By default the boundary uses `url.pathname`. Pass `getId` when a persistent
+nested layout should keep one logical id. The outer demo boundary maps every
+`/products/*` URL to `/products`, while the nested products boundary uses the
+full pathname for tab transitions.
 
 ## Transitions
 

--- a/templates/sveltekit/src/lib/components/demo-layout.svelte
+++ b/templates/sveltekit/src/lib/components/demo-layout.svelte
@@ -3,6 +3,7 @@
 	import { drill, zoom } from '@ssgoi/svelte/view-transitions';
 	import { page } from '$app/stores';
 	import NavItem from './nav-item.svelte';
+	import SsgoiTransitionBoundary from './ssgoi-transition-boundary.svelte';
 
 	let { children } = $props();
 
@@ -26,6 +27,10 @@
 			})
 		]
 	};
+
+	function getRootTransitionId(url: URL) {
+		return url.pathname === '/products' || url.pathname.startsWith('/products/') ? '/products' : url.pathname;
+	}
 </script>
 
 <div class="h-full bg-[#121212] flex z-0">
@@ -37,7 +42,9 @@
 			class="flex-1 w-full overflow-y-scroll overflow-x-hidden relative z-0 bg-[#121212] scrollbar-hide"
 		>
 			<Ssgoi {config}>
-				{@render children()}
+				<SsgoiTransitionBoundary getId={getRootTransitionId} class="min-h-full bg-[#121212]">
+					{@render children()}
+				</SsgoiTransitionBoundary>
 			</Ssgoi>
 		</main>
 

--- a/templates/sveltekit/src/lib/components/product-grid.svelte
+++ b/templates/sveltekit/src/lib/components/product-grid.svelte
@@ -3,13 +3,12 @@
 
   interface Props {
     products: Product[];
-    category: string;
   }
 
-  let { products, category }: Props = $props();
+  let { products }: Props = $props();
 </script>
 
-<div data-ssgoi-transition="/products/{category}">
+<div>
   <div class="px-4 pb-6 h-full overflow-y-auto">
     {#if products.length === 0}
       <div class="text-center py-12">

--- a/templates/sveltekit/src/lib/components/ssgoi-transition-boundary.svelte
+++ b/templates/sveltekit/src/lib/components/ssgoi-transition-boundary.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+  import { onNavigate } from "$app/navigation";
+  import { page } from "$app/stores";
+  import { flushSync, onDestroy, type Snippet } from "svelte";
+
+  interface Props {
+    children: Snippet;
+    as?: keyof HTMLElementTagNameMap;
+    class?: string;
+    getId?: (url: URL) => string;
+    [key: string]: unknown;
+  }
+
+  const pathnameId = (url: URL) => url.pathname;
+
+  let {
+    children,
+    as = "div",
+    class: className,
+    getId = pathnameId,
+    ...rest
+  }: Props = $props();
+
+  let currentId = $state(getId($page.url));
+  let mounted = $state(true);
+  let alive = true;
+
+  onDestroy(() => {
+    alive = false;
+  });
+
+  onNavigate((navigation) => {
+    if (!alive || !navigation.to) return;
+
+    const nextId = getId(navigation.to.url);
+
+    if (nextId === currentId) return;
+
+    // Detach the old route before SvelteKit updates its live `children`
+    // snippet. SSGOI can then retain the real outgoing DOM for its animation.
+    flushSync(() => {
+      mounted = false;
+    });
+
+    // SvelteKit calls this after the route DOM has updated. Rendering the
+    // snippet now produces only the incoming route under its own boundary.
+    return () => {
+      if (!alive) return;
+
+      flushSync(() => {
+        currentId = nextId;
+        mounted = true;
+      });
+    };
+  });
+</script>
+
+{#if mounted}
+  <svelte:element
+    this={as}
+    data-ssgoi-transition={currentId}
+    class={className}
+    {...rest}
+  >
+    {@render children()}
+  </svelte:element>
+{/if}

--- a/templates/sveltekit/src/routes/pinterest/+page.svelte
+++ b/templates/sveltekit/src/routes/pinterest/+page.svelte
@@ -6,7 +6,7 @@
   const rightColumnItems = pinterestItems.filter((_, index) => index % 2 === 1);
 </script>
 
-<div data-ssgoi-transition="/pinterest">
+<div>
   <div class="min-h-screen bg-[#121212] px-4 py-6">
     <!-- Header -->
     <div class="mb-6">

--- a/templates/sveltekit/src/routes/pinterest/[id]/+page.svelte
+++ b/templates/sveltekit/src/routes/pinterest/[id]/+page.svelte
@@ -8,13 +8,13 @@
 </script>
 
 {#if !item}
-  <div data-ssgoi-transition="/pinterest/{pinId}">
+  <div>
     <div class="min-h-screen bg-[#121212] px-4 py-8">
       <p class="text-gray-400">Pin not found</p>
     </div>
   </div>
 {:else}
-  <div data-ssgoi-transition="/pinterest/{pinId}">
+  <div>
     <div class="min-h-screen bg-[#121212]">
       <!-- Back button -->
       <div class="px-4 py-4">

--- a/templates/sveltekit/src/routes/posts/+page.svelte
+++ b/templates/sveltekit/src/routes/posts/+page.svelte
@@ -4,7 +4,7 @@
   const posts = getAllPosts();
 </script>
 
-<div data-ssgoi-transition="/posts">
+<div>
   <div class="min-h-full bg-[#121212] px-4 py-6">
     <!-- Header -->
     <div class="mb-6">

--- a/templates/sveltekit/src/routes/posts/[id]/+page.svelte
+++ b/templates/sveltekit/src/routes/posts/[id]/+page.svelte
@@ -40,13 +40,13 @@
 </script>
 
 {#if !post}
-  <div data-ssgoi-transition="/posts/{postId}">
+  <div>
     <div class="min-h-screen bg-[#121212] px-4 py-8">
       <p class="text-gray-400">Post not found</p>
     </div>
   </div>
 {:else}
-  <div data-ssgoi-transition="/posts/{postId}">
+  <div>
     <div class="min-h-screen bg-[#121212]">
       <!-- Back button -->
       <div class="px-4 py-4">

--- a/templates/sveltekit/src/routes/products/+layout.svelte
+++ b/templates/sveltekit/src/routes/products/+layout.svelte
@@ -2,6 +2,7 @@
   import { Ssgoi } from "@ssgoi/svelte";
   import { slide } from "@ssgoi/svelte/view-transitions";
   import { page } from "$app/stores";
+  import SsgoiTransitionBoundary from "$lib/components/ssgoi-transition-boundary.svelte";
 
   let { children } = $props();
 
@@ -20,10 +21,7 @@
   };
 </script>
 
-<div
-  data-ssgoi-transition="/products"
-  class="min-h-screen bg-[#121212] flex flex-col"
->
+<div class="min-h-screen bg-[#121212] flex flex-col">
   <!-- Header - Fixed -->
   <div class="px-4 pt-6 pb-3 shrink-0">
     <h1 class="text-sm font-medium text-white mb-1">Shop</h1>
@@ -50,7 +48,9 @@
   <!-- Tab Content - Slide transitions here -->
   <div class="flex-1 overflow-hidden relative">
     <Ssgoi {config}>
-      {@render children()}
+      <SsgoiTransitionBoundary class="min-h-full bg-[#121212]">
+        {@render children()}
+      </SsgoiTransitionBoundary>
     </Ssgoi>
   </div>
 </div>

--- a/templates/sveltekit/src/routes/products/all/+page.svelte
+++ b/templates/sveltekit/src/routes/products/all/+page.svelte
@@ -5,4 +5,4 @@
 	const products = getProductsByCategory('all');
 </script>
 
-<ProductGrid {products} category="all" />
+<ProductGrid {products} />

--- a/templates/sveltekit/src/routes/products/beauty/+page.svelte
+++ b/templates/sveltekit/src/routes/products/beauty/+page.svelte
@@ -5,4 +5,4 @@
 	const products = getProductsByCategory('beauty');
 </script>
 
-<ProductGrid {products} category="beauty" />
+<ProductGrid {products} />

--- a/templates/sveltekit/src/routes/products/electronics/+page.svelte
+++ b/templates/sveltekit/src/routes/products/electronics/+page.svelte
@@ -5,4 +5,4 @@
 	const products = getProductsByCategory('electronics');
 </script>
 
-<ProductGrid {products} category="electronics" />
+<ProductGrid {products} />

--- a/templates/sveltekit/src/routes/products/fashion/+page.svelte
+++ b/templates/sveltekit/src/routes/products/fashion/+page.svelte
@@ -5,4 +5,4 @@
 	const products = getProductsByCategory('fashion');
 </script>
 
-<ProductGrid {products} category="fashion" />
+<ProductGrid {products} />

--- a/templates/sveltekit/src/routes/products/home/+page.svelte
+++ b/templates/sveltekit/src/routes/products/home/+page.svelte
@@ -5,4 +5,4 @@
 	const products = getProductsByCategory('home');
 </script>
 
-<ProductGrid {products} category="home" />
+<ProductGrid {products} />

--- a/templates/sveltekit/src/routes/profile/+page.svelte
+++ b/templates/sveltekit/src/routes/profile/+page.svelte
@@ -2,7 +2,7 @@
   import { profile, posts } from "$lib/data/profile";
 </script>
 
-<div data-ssgoi-transition="/profile">
+<div>
   <div class="bg-[#121212]">
     <!-- Profile Header -->
     <div class="relative">

--- a/templates/sveltekit/src/routes/profile/[id]/+page.svelte
+++ b/templates/sveltekit/src/routes/profile/[id]/+page.svelte
@@ -8,13 +8,13 @@
 </script>
 
 {#if !post}
-  <div data-ssgoi-transition="/profile/{postId}">
+  <div>
     <div class="min-h-screen bg-[#121212] px-4 py-8">
       <p class="text-gray-400">Post not found</p>
     </div>
   </div>
 {:else}
-  <div data-ssgoi-transition="/profile/{postId}">
+  <div>
     <div class="min-h-screen bg-[#121212]">
       <!-- Back button -->
       <div class="px-4 py-4">


### PR DESCRIPTION
## Summary

- add a SvelteKit route boundary that detaches the outgoing subtree in `onNavigate` before the live layout snippet updates, then mounts the incoming subtree after the route DOM commit
- add reusable keyed route boundaries for Nuxt/Vue and SolidStart so individual pages no longer need `data-ssgoi-transition`
- preserve nested product layouts by mapping `/products/*` to a stable outer `/products` identity while nested providers use the full pathname
- document why Qwik City keeps page-owned markers: a keyed layout wrapper moves projected `<Slot />` content under the incoming id before the routed subtree updates, and the interception API needed to stage the unmount is still experimental
- keep the main `llms.txt` framework section as a link-only index
- expand the linked SvelteKit, Nuxt/Vue, SolidStart, Qwik City, and Angular guides into copy-ready, file-by-file setup instructions with complete imports, configs, root wiring, route boundaries, and nested examples
- update template READMEs to match the verified patterns
- leave React templates and React-specific guidance unchanged

## Framework-specific behavior

| Framework | Boundary strategy |
| --- | --- |
| SvelteKit | `onNavigate` + `flushSync` staged unmount/remount |
| Nuxt/Vue | keyed Vue VNode around the routed slot |
| SolidStart | keyed `<Show>` owner inside `<Suspense>` |
| Angular | keep page-owned markers |
| Qwik City | keep page-owned markers; layout-slot boundary is unsafe |

## Validation

- `pnpm --filter ssgoi-sveltekit-template check`
- `pnpm --filter ssgoi-sveltekit-template build`
- `pnpm --filter ssgoi-nuxt-template build`
- `pnpm --filter ssgoi-solidstart-template typecheck`
- `pnpm --filter ssgoi-solidstart-template build`
- parsed every new framework-guide code fence with Prettier's Markdown embedded-language parser
- `git diff --check`
- browser-tested list/detail drill transitions, shared zoom transitions, rapid SvelteKit navigation, and nested product tab transitions
- verified removed boundaries retained the outgoing page text, incoming boundaries contained the new page and shared-element keys, and the outer `/products` node stayed mounted during nested tab navigation
- experimentally verified that Qwik's keyed layout-slot approach mispairs the route id and subtree, then fully reverted the Qwik source experiment
