### PR TITLE
fix(core): prevent body-scroll collapse before outgoing remount

### DIFF
--- a/packages/core/src/lib/ssgoi-transition/create-context-manager.test.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-context-manager.test.ts
@@ -130,6 +130,7 @@ describe("createContextManager", () => {
     vi.stubGlobal("document", {
       body,
       documentElement,
+      addEventListener: vi.fn(),
     } as unknown as Document);
     vi.stubGlobal("ResizeObserver", undefined);
   });

--- a/packages/core/src/lib/ssgoi-transition/create-context-manager.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-context-manager.ts
@@ -2,6 +2,10 @@ import type { PreserveScrollOption, PreserveScrollFn } from "@types";
 import { getScrollingElement } from "@utils";
 import { getPositionedParent } from "@utils";
 import { matchPath } from "./find-matching-transition";
+import {
+  installDocumentScrollGuard,
+  releaseDocumentScrollGuard,
+} from "./document-scroll-guard";
 
 const MOBILE_BREAKPOINT_PX = 768;
 const RESTORE_MAX_RETRIES = 10;
@@ -164,9 +168,18 @@ export function createContextManager(options: ContextManagerOptions = {}) {
         Math.abs(scrollContainer.scrollTop - target.y) < 1 &&
         Math.abs(scrollContainer.scrollLeft - target.x) < 1;
 
-      if (!targetReached && retryCount < RESTORE_MAX_RETRIES) {
+      if (targetReached) {
+        if (scrollContainer === document.documentElement) {
+          releaseDocumentScrollGuard(document);
+        }
+      } else if (retryCount < RESTORE_MAX_RETRIES) {
         retryCount++;
         requestAnimationFrame(tryRestore);
+      } else if (scrollContainer === document.documentElement) {
+        // Do not leave a stale floor behind when an async page never grows
+        // enough to make the saved target reachable. The guard also owns a
+        // safety timeout, but releasing here keeps the normal path prompt.
+        releaseDocumentScrollGuard(document);
       }
     };
 
@@ -201,6 +214,9 @@ export function createContextManager(options: ContextManagerOptions = {}) {
       target.addEventListener("scroll", scrollListener, {
         passive: true,
       });
+      if (scrollContainer === document.documentElement) {
+        installDocumentScrollGuard(document);
+      }
     }
 
     currentPath = path;

--- a/packages/core/src/lib/ssgoi-transition/create-ssgoi-transition-context.test.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-ssgoi-transition-context.test.ts
@@ -1,0 +1,255 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Animation } from "../animation/animation";
+import type { HostAnimation } from "../animation/host-animation";
+import { createSggoiTransitionContext } from "./create-ssgoi-transition-context";
+
+type RemovalAnchor = { parent: Node; nextSibling: Node | null };
+
+const testState = vi.hoisted(() => ({
+  unmountCallbacks: new Map<
+    object,
+    (anchor?: { parent: Node; nextSibling: Node | null }) => void
+  >(),
+  positionedParent: null as Node | null,
+  scrollingElement: null as HTMLElement | null,
+}));
+
+vi.mock("./create-context-manager", () => ({
+  createContextManager: () => ({
+    initializeContext: vi.fn(),
+    calculateScrollOffset: (from?: string, to?: string) => ({
+      x: 0,
+      y: (from === "/feed" ? 3600 : 0) - (to === "/feed" ? 3600 : 0),
+    }),
+    evictScrollPosition: vi.fn(),
+    shouldPreserve: () => true,
+    getScrollContainer: () => testState.scrollingElement,
+    getPositionedParentElement: () => testState.positionedParent,
+    getScrollPosition: (path?: string) => ({
+      x: 0,
+      y: path === "/feed" ? 3600 : 0,
+    }),
+    getIsMobile: () => true,
+  }),
+}));
+
+vi.mock("./create-swipe-back-detector", () => ({
+  createSwipeBackDetector: () => ({
+    initialize: vi.fn(),
+    destroy: vi.fn(),
+    isSwipeBack: () => false,
+    onPageEnter: vi.fn(),
+  }),
+}));
+
+vi.mock("./unmount-observer", () => ({
+  watchUnmount: (
+    element: object,
+    callback: (anchor?: RemovalAnchor) => void,
+  ) => {
+    testState.unmountCallbacks.set(element, callback);
+    return () => testState.unmountCallbacks.delete(element);
+  },
+}));
+
+vi.mock("./visibility-observer", () => ({
+  watchVisibility: () => ({
+    isHidden: false,
+    setDisplay: vi.fn(),
+    sync: vi.fn(),
+    stop: vi.fn(),
+  }),
+}));
+
+class FakeStyle {
+  cssText = "";
+  display = "";
+  left = "";
+  opacity = "";
+  position = "";
+  top = "";
+  width = "";
+
+  getPropertyPriority(): string {
+    return "";
+  }
+
+  getPropertyValue(name: string): string {
+    return (this as unknown as Record<string, string>)[name] ?? "";
+  }
+
+  removeProperty(name: string): string {
+    const values = this as unknown as Record<string, string>;
+    const previous = values[name] ?? "";
+    values[name] = "";
+    return previous;
+  }
+
+  setProperty(name: string, value: string): void {
+    (this as unknown as Record<string, string>)[name] = value;
+  }
+}
+
+class FakeElement {
+  readonly attributes = new Map<string, string>();
+  readonly style = new FakeStyle() as unknown as CSSStyleDeclaration;
+  parentNode: FakeParent | null = null;
+  nextSibling: FakeElement | null = null;
+
+  get parentElement(): HTMLElement | null {
+    return this.parentNode as unknown as HTMLElement | null;
+  }
+
+  get nextElementSibling(): HTMLElement | null {
+    return this.nextSibling as unknown as HTMLElement | null;
+  }
+
+  getAttribute(name: string): string | null {
+    return this.attributes.get(name) ?? null;
+  }
+
+  setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+  }
+}
+
+class FakeParent {
+  readonly children: FakeElement[] = [];
+  trackedOutgoing: FakeElement | null = null;
+  readonly order: string[] = [];
+
+  appendChild(element: FakeElement): FakeElement {
+    this.detach(element);
+    this.children.push(element);
+    this.syncLinks();
+    if (element === this.trackedOutgoing) this.order.push("insert");
+    return element;
+  }
+
+  contains(node: Node | null): boolean {
+    return this.children.includes(node as unknown as FakeElement);
+  }
+
+  insertBefore(element: FakeElement, sibling: Node): FakeElement {
+    this.detach(element);
+    const index = this.children.indexOf(sibling as unknown as FakeElement);
+    this.children.splice(index < 0 ? this.children.length : index, 0, element);
+    this.syncLinks();
+    if (element === this.trackedOutgoing) this.order.push("insert");
+    return element;
+  }
+
+  removeChild(element: FakeElement): FakeElement {
+    this.detach(element);
+    this.syncLinks();
+    return element;
+  }
+
+  private detach(element: FakeElement): void {
+    const index = this.children.indexOf(element);
+    if (index >= 0) this.children.splice(index, 1);
+    element.parentNode = null;
+    element.nextSibling = null;
+  }
+
+  private syncLinks(): void {
+    for (let index = 0; index < this.children.length; index += 1) {
+      const element = this.children[index]!;
+      element.parentNode = this;
+      element.nextSibling = this.children[index + 1] ?? null;
+    }
+  }
+}
+
+async function flushMicrotasks(count = 12): Promise<void> {
+  for (let index = 0; index < count; index += 1) {
+    await Promise.resolve();
+  }
+}
+
+describe("createSggoiTransitionContext", () => {
+  beforeEach(() => {
+    testState.unmountCallbacks.clear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("reinserts the styled outgoing page without waiting for async prepare extras", async () => {
+    const parent = new FakeParent();
+    const scrollingElement = new FakeElement();
+    const outgoing = new FakeElement();
+    const incoming = new FakeElement();
+    parent.appendChild(outgoing);
+    parent.trackedOutgoing = outgoing;
+    testState.positionedParent = parent as unknown as Node;
+    testState.scrollingElement = scrollingElement as unknown as HTMLElement;
+
+    vi.stubGlobal("document", {
+      body: parent,
+      documentElement: scrollingElement,
+      createElement: () => new FakeElement(),
+    });
+    vi.stubGlobal("getComputedStyle", () => ({ display: "block" }));
+
+    let resolveExtras!: (value: object) => void;
+    const extras = new Promise<object>((resolve) => {
+      resolveExtras = resolve;
+    });
+    const animation = {} as Animation;
+    const animationFactory = vi.fn(() => animation);
+    const host = { attach: vi.fn() } as unknown as HostAnimation;
+
+    const context = createSggoiTransitionContext(
+      {
+        preserveScroll: true,
+        transitions: [
+          {
+            from: "/feed",
+            to: "/detail",
+            transition: {
+              prepare: ({ from }) => {
+                from.then((element) => {
+                  element.style.opacity = "1";
+                  parent.order.push("style");
+                });
+                return extras;
+              },
+              animation: animationFactory,
+            },
+          },
+        ],
+      },
+      { host },
+    );
+
+    context.register("/feed", outgoing as unknown as HTMLElement);
+
+    // Mirror a framework route commit: replace the tall, scrolled feed with
+    // the not-yet-laid-out detail page, register IN, then deliver OUT from the
+    // shared MutationObserver.
+    parent.removeChild(outgoing);
+    parent.appendChild(incoming);
+    context.register("/detail", incoming as unknown as HTMLElement);
+    testState.unmountCallbacks.get(outgoing)?.({
+      parent: parent as unknown as Node,
+      nextSibling: null,
+    });
+
+    await flushMicrotasks();
+
+    expect(parent.order).toEqual(["style", "insert"]);
+    expect(parent.children).toContain(outgoing);
+    expect(outgoing.style.position).toBe("absolute");
+    expect(outgoing.style.top).toBe("-3600px");
+    expect(animationFactory).not.toHaveBeenCalled();
+    expect(host.attach).not.toHaveBeenCalled();
+
+    resolveExtras({});
+    await flushMicrotasks();
+
+    expect(animationFactory).toHaveBeenCalledOnce();
+    expect(host.attach).toHaveBeenCalledWith(animation);
+  });
+});

--- a/packages/core/src/lib/ssgoi-transition/create-ssgoi-transition-context.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-ssgoi-transition-context.ts
@@ -344,25 +344,36 @@ export function createSggoiTransitionContext(
       config.prepare ? config.prepare(prepareArgs) : {},
     );
 
-    // Resolve from/to + prepare extras in parallel via promiseAll util.
-    // The entire function returns synchronously; .then fires when ready.
+    // `prepare` schedules its per-side pre-paint styles through the already
+    // resolved from/to promises. Queue the insertion after those callbacks,
+    // but do not make it wait for the (possibly asynchronous) extras result.
+    //
+    // Waiting for all of `prepare` used to leave an unmount-mode page detached
+    // while the incoming page was still empty. With document/body scrolling,
+    // that transient height collapse clamps window.scrollY before the outgoing
+    // page returns, which iOS browsers can expose as a white frame. Keeping the
+    // insertion on its own promise preserves the style-before-insert ordering
+    // without extending the detached interval to the full prepare pipeline.
+    const outgoingReady: Promise<void> =
+      !isHidden && parent
+        ? fromPromise.then(() => {
+            if (nextSibling && parent.contains(nextSibling)) {
+              parent.insertBefore(fromElement, nextSibling);
+            } else {
+              parent.appendChild(fromElement);
+            }
+          })
+        : Promise.resolve();
+
+    // Resolve from/to + prepare extras in parallel via promiseAll util. Include
+    // the independently scheduled insertion so animation creation can never
+    // race ahead of the outgoing node reaching the DOM.
     promiseAll({
       from: fromPromise,
       to: toPromise,
       extras: extrasPromise,
+      outgoingReady,
     }).then(({ from: resolvedFrom, to: resolvedTo, extras }) => {
-      // Now that prepare's microtasks have all run (initial styles, extras
-      // built), drop the outgoing node into place. Order is:
-      //   prepare → out insert → animation create/play
-      // Hidden mode skips insertion: the real node is already in place.
-      if (!isHidden && parent) {
-        if (nextSibling && parent.contains(nextSibling)) {
-          parent.insertBefore(fromElement, nextSibling);
-        } else {
-          parent.appendChild(fromElement);
-        }
-      }
-
       const animation = config.animation({
         from: resolvedFrom,
         to: resolvedTo,

--- a/packages/core/src/lib/ssgoi-transition/document-scroll-guard.test.ts
+++ b/packages/core/src/lib/ssgoi-transition/document-scroll-guard.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  installDocumentScrollGuard,
+  releaseDocumentScrollGuard,
+} from "./document-scroll-guard";
+
+type ClickListener = (event: Event) => void;
+
+function createFakeDocument(options: { scrollTop?: number } = {}) {
+  let clickListener: ClickListener | null = null;
+  const children: FakeGuard[] = [];
+  const scrollingElement = {
+    clientHeight: 844,
+    scrollHeight: 7243,
+    scrollTop: options.scrollTop ?? 3600,
+  };
+
+  class FakeGuard {
+    attributes = new Map<string, string>();
+    isConnected = false;
+    style: Record<string, string> = {};
+
+    remove(): void {
+      const index = children.indexOf(this);
+      if (index >= 0) children.splice(index, 1);
+      this.isConnected = false;
+    }
+
+    setAttribute(name: string, value: string): void {
+      this.attributes.set(name, value);
+    }
+  }
+
+  const document = {
+    URL: "https://example.com/feed",
+    baseURI: "https://example.com/feed",
+    body: {
+      appendChild(guard: FakeGuard) {
+        children.push(guard);
+        guard.isConnected = true;
+        return guard;
+      },
+    },
+    scrollingElement,
+    createElement: () => new FakeGuard(),
+    addEventListener(type: string, listener: ClickListener) {
+      if (type === "click") clickListener = listener;
+    },
+  } as unknown as Document;
+
+  const click = (href: string) => {
+    const anchor = {
+      href,
+      target: "",
+      closest: () => anchor,
+      hasAttribute: () => false,
+    };
+    clickListener?.({
+      target: anchor,
+      button: 0,
+      metaKey: false,
+      ctrlKey: false,
+      shiftKey: false,
+      altKey: false,
+    } as unknown as Event);
+  };
+
+  return { children, click, document, scrollingElement };
+}
+
+describe("document scroll guard", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("holds the current document extent for a link navigation, then releases it", () => {
+    const { children, click, document } = createFakeDocument();
+
+    installDocumentScrollGuard(document);
+    click("https://example.com/detail");
+
+    expect(children).toHaveLength(1);
+    expect(children[0]!.attributes.get("data-ssgoi-scroll-guard")).toBe("");
+    expect(children[0]!.style).toMatchObject({
+      position: "absolute",
+      top: "7242px",
+      visibility: "hidden",
+    });
+
+    releaseDocumentScrollGuard(document);
+    expect(children).toHaveLength(0);
+  });
+
+  it("does not guard a document that is already at the top", () => {
+    const { children, click, document } = createFakeDocument({ scrollTop: 0 });
+
+    installDocumentScrollGuard(document);
+    click("https://example.com/detail");
+
+    expect(children).toHaveLength(0);
+  });
+
+  it("releases the guard if the click does not produce an incoming page", () => {
+    const { children, click, document } = createFakeDocument();
+
+    installDocumentScrollGuard(document);
+    click("https://example.com/detail");
+    expect(children).toHaveLength(1);
+
+    vi.advanceTimersByTime(5000);
+    expect(children).toHaveLength(0);
+  });
+});

--- a/packages/core/src/lib/ssgoi-transition/document-scroll-guard.ts
+++ b/packages/core/src/lib/ssgoi-transition/document-scroll-guard.ts
@@ -1,0 +1,130 @@
+const GUARD_ATTRIBUTE = "data-ssgoi-scroll-guard";
+const SAFETY_TIMEOUT_MS = 5000;
+
+type GuardState = {
+  guard: HTMLElement | null;
+  installed: boolean;
+  timer: ReturnType<typeof setTimeout> | null;
+};
+
+const states = new WeakMap<Document, GuardState>();
+
+function getState(document: Document): GuardState {
+  let state = states.get(document);
+  if (!state) {
+    state = { guard: null, installed: false, timer: null };
+    states.set(document, state);
+  }
+  return state;
+}
+
+function clearSafetyTimer(state: GuardState): void {
+  if (state.timer === null) return;
+  clearTimeout(state.timer);
+  state.timer = null;
+}
+
+function isNavigationClick(event: Event, document: Document): boolean {
+  const mouseEvent = event as MouseEvent;
+  if (
+    mouseEvent.button !== 0 ||
+    mouseEvent.metaKey ||
+    mouseEvent.ctrlKey ||
+    mouseEvent.shiftKey ||
+    mouseEvent.altKey
+  ) {
+    return false;
+  }
+
+  const target = event.target as {
+    closest?: (selector: string) => Element | null;
+  };
+  const anchor = target?.closest?.("a[href]") as HTMLAnchorElement | null;
+  if (!anchor || anchor.hasAttribute("download")) return false;
+  if (anchor.target && anchor.target !== "_self") return false;
+
+  let destination: URL;
+  try {
+    destination = new URL(anchor.href, document.baseURI);
+  } catch {
+    return false;
+  }
+
+  if (destination.protocol !== "http:" && destination.protocol !== "https:") {
+    return false;
+  }
+
+  const current = new URL(document.URL);
+  const sameDocumentHash =
+    destination.origin === current.origin &&
+    destination.pathname === current.pathname &&
+    destination.search === current.search &&
+    Boolean(destination.hash);
+  return !sameDocumentHash;
+}
+
+function holdDocumentScrollExtent(document: Document): void {
+  const body = document.body;
+  const scrollingElement = document.scrollingElement;
+  if (!body || !scrollingElement || scrollingElement.scrollTop <= 0) return;
+
+  const state = getState(document);
+  const scrollHeight = scrollingElement.scrollHeight;
+  if (scrollHeight <= scrollingElement.clientHeight) return;
+
+  let guard = state.guard;
+  if (!guard?.isConnected) {
+    guard = document.createElement("div");
+    guard.setAttribute(GUARD_ATTRIBUTE, "");
+    guard.setAttribute("aria-hidden", "true");
+    state.guard = guard;
+  }
+
+  Object.assign(guard.style, {
+    position: "absolute",
+    top: `${Math.max(0, scrollHeight - 1)}px`,
+    left: "0",
+    width: "1px",
+    height: "1px",
+    pointerEvents: "none",
+    visibility: "hidden",
+  });
+
+  if (!guard.isConnected) body.appendChild(guard);
+
+  clearSafetyTimer(state);
+  state.timer = setTimeout(() => {
+    releaseDocumentScrollGuard(document);
+  }, SAFETY_TIMEOUT_MS);
+}
+
+/**
+ * Preserve the current document scrollable extent across a link-driven route
+ * commit. The outgoing page can be removed before its MutationObserver runs;
+ * without this floor, a body-scrolled document immediately clamps scrollTop
+ * against the not-yet-laid-out incoming page.
+ */
+export function installDocumentScrollGuard(document: Document): void {
+  const state = getState(document);
+  if (state.installed) return;
+  state.installed = true;
+
+  document.addEventListener(
+    "click",
+    (event) => {
+      if (isNavigationClick(event, document)) {
+        holdDocumentScrollExtent(document);
+      }
+    },
+    { capture: true },
+  );
+}
+
+/** Remove the temporary scroll-extent floor after incoming scroll restore. */
+export function releaseDocumentScrollGuard(document: Document): void {
+  const state = states.get(document);
+  if (!state) return;
+  clearSafetyTimer(state);
+  state.guard?.remove();
+  state.guard = null;
+}


### PR DESCRIPTION
## Summary

- hold the document's current scrollable extent across a link-driven route commit, so removing a tall outgoing page cannot clamp `window.scrollY` against an empty/short incoming page
- release that temporary extent guard as soon as the incoming scroll target is reached, with a 5-second safety cleanup when no navigation follows the click
- reinsert the outgoing node after its queued pre-paint styles, without waiting for asynchronous `prepare` extras
- add regression coverage for the body-scroll guard and for style-before-insert ordering while `prepare` remains pending

Fixes #382.

## Root cause

The report initially looked like an iOS Safari compositing/startup issue. The follow-up conditions point somewhere more specific:

- it is visible in both iOS Safari and iOS Chrome, but not on desktop
- `scrollY = 0` does not reproduce it
- entering a feed item after scrolling the document does reproduce it
- the reverse transition does not reproduce it
- the working demos use a bounded scroll container, while the affected site uses document/body scrolling

I instrumented the affected `holaworld.io` route at a 390 x 844 viewport. This does not reproduce the iOS pixel flash in desktop Chromium, but it exposes the DOM/scroll state that iOS can paint:

| Relative time | Operation | `scrollY` | Document height |
| ---: | --- | ---: | ---: |
| 0.0 ms | click from the scrolled feed | 3600 | 7243 |
| 18.7 ms | outgoing page removed | 0 | 844 |
| 18.9 ms | incoming root appended | 0 | 3515 |
| 28.8 ms | outgoing page reinsert starts | 0 | 3515 |
| 29.0 ms | outgoing page reinserted (`position:absolute; top:-3600px`) | 0 | 3643 |

The important transition is synchronous with the outgoing removal: the document collapses from 7243 px to one viewport and clamps `scrollY` from 3600 to 0 before the MutationObserver can restore the outgoing node. There is then roughly a 10 ms commit/observer window with no outgoing layer in the DOM. Desktop browsers normally coalesce that state; iOS's document scrolling/compositing path can expose it as the reported white frame.

CPU speed can make the window easier to see, but it is not the primary trigger: the deterministic discriminator is a non-zero document scroll position. Data loading and WAAPI startup happen later.

## Fix

### 1. Preserve the document extent before the route commit

When SSGOI detects document/body scrolling, it installs one capture-phase link listener. For an unmodified primary link click while the document is scrolled, it appends an invisible, absolutely positioned 1 px guard at the current document bottom. This preserves the old scrollable extent before the router removes the outgoing tree.

The guard is outside the framework root, does not modify application `body` styles, and is removed:

- in the same restoration frame once the incoming scroll target is reachable;
- after restoration retries are exhausted; or
- after 5 seconds if the click does not result in an incoming page.

Repeating the same live-site instrumentation with the guard held `scrollY = 3600` and document height `7243` through outgoing removal, incoming mount, and outgoing reinsertion. The scheduled scroll-restore callback then moved to `scrollY = 0` during the first rendering opportunity, before paint.

Bounded/internal scroll containers do not install this document guard.

### 2. Do not couple outgoing reinsertion to async prepare extras

`prepare` callbacks still get the first microtask, preserving the existing pre-paint style-before-insert guarantee. The outgoing insertion now has its own promise immediately behind those callbacks instead of waiting for `Promise.all(from, to, extras)`. Animation creation still waits for both insertion and extras.

This reduces the post-commit detached interval and prevents a custom asynchronous `prepare` result from extending it.

## Verification

- `pnpm --filter @ssgoi/core test:run` — 14 files, 86 tests passed
- `pnpm --filter @ssgoi/core lint`
- `pnpm --filter @ssgoi/core build`
- `pnpm release:build` — all 7 packages built
- live-site DOM/scroll trace before and with the extent guard

## Validation still needed

This is intentionally a draft because the white pixel frame itself needs validation on a physical iOS device. The structural failure is reproduced and removed in instrumentation, but desktop Chromium and macOS/headless WebKit do not render the reported flash.

The pre-commit guard currently targets link-driven navigation, which covers the reported feed-card path. Fully programmatic navigation without a click still benefits from earlier outgoing reinsertion but does not arm the extent guard; that can be expanded if the same failure is demonstrated on such a path.
