### PR TITLE
fix(core): scroll restore yields to deliberate scrolls instead of fighting them

### DIFF
--- a/packages/core/src/lib/ssgoi-transition/create-context-manager.test.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-context-manager.test.ts
@@ -374,6 +374,154 @@ describe("createContextManager", () => {
     expect(documentElement.scrollTop).toBe(0);
   });
 
+  it("yields to an app-driven scroll during the restore window", () => {
+    const manager = createContextManager({
+      preserveScroll: true,
+    });
+    const feedPage = createFakeElement({ parentElement: body });
+    const detailPage = createFakeElement({ parentElement: body });
+    const returningFeedPage = createFakeElement({ parentElement: body });
+
+    manager.initializeContext(feedPage, "/feed");
+    flushAnimationFrames(11);
+
+    documentElement.scrollTop = 900;
+    emitWindowScroll();
+
+    manager.initializeContext(detailPage, "/detail");
+    flushAnimationFrames(11);
+
+    // Return while the page is still short: restore clamps and keeps retrying.
+    documentElement.scrollHeight = 760;
+    documentElement.scrollTop = 0;
+    manager.initializeContext(returningFeedPage, "/feed");
+    flushAnimationFrames(2);
+    expect(documentElement.scrollTop).toBe(160);
+
+    // Content arrives AND the page scrolls itself somewhere deliberate
+    // (anchor / useEffect scrollTo). The restore loop must yield, not drag
+    // the container back to the saved 900.
+    documentElement.scrollHeight = 2000;
+    documentElement.scrollTop = 300;
+    flushAnimationFrames(1);
+    expect(documentElement.scrollTop).toBe(300);
+
+    const callsAfterYield = documentElement.scrollTo.mock.calls.length;
+    flushAnimationFrames(10);
+    expect(documentElement.scrollTop).toBe(300);
+    expect(documentElement.scrollTo.mock.calls.length).toBe(callsAfterYield);
+  });
+
+  it("yields to a scroll that lands before the first restore frame", () => {
+    const manager = createContextManager({
+      preserveScroll: true,
+    });
+    const page = createFakeElement({ parentElement: body });
+
+    // Previous page's stale position at init time…
+    documentElement.scrollTop = 320;
+    manager.initializeContext(page, "/feed");
+    // …then the entering page scrolls itself during commit (useLayoutEffect
+    // timing), BEFORE our first frame runs.
+    documentElement.scrollTop = 600;
+
+    flushAnimationFrames(2);
+    expect(documentElement.scrollTop).toBe(600);
+    expect(documentElement.scrollTo).not.toHaveBeenCalled();
+  });
+
+  it("treats a layout clamp as passive, not as an external scroll", () => {
+    const manager = createContextManager({
+      preserveScroll: true,
+    });
+    const page = createFakeElement({ parentElement: body });
+
+    // Stale position from the previous page; the new page's shorter layout
+    // clamps it down before our first frame. That's the browser, not intent —
+    // the fresh page must still arrive at the top.
+    documentElement.scrollTop = 480;
+    manager.initializeContext(page, "/feed");
+    documentElement.scrollHeight = 760;
+    documentElement.scrollTop = 160;
+
+    flushAnimationFrames(2);
+    expect(documentElement.scrollTop).toBe(0);
+  });
+
+  it("re-fights a router top reset even after the target was reached", () => {
+    const manager = createContextManager({
+      preserveScroll: true,
+    });
+    const feedPage = createFakeElement({ parentElement: body });
+    const detailPage = createFakeElement({ parentElement: body });
+    const returningFeedPage = createFakeElement({ parentElement: body });
+
+    manager.initializeContext(feedPage, "/feed");
+    flushAnimationFrames(11);
+
+    documentElement.scrollTop = 480;
+    emitWindowScroll();
+
+    manager.initializeContext(detailPage, "/detail");
+    flushAnimationFrames(11);
+
+    documentElement.scrollTop = 0;
+    manager.initializeContext(returningFeedPage, "/feed");
+    flushAnimationFrames(1);
+    expect(documentElement.scrollTop).toBe(480);
+
+    // A router-side reset (e.g. afterNavigate) lands AFTER we already
+    // restored. A jump to exactly (0,0) is the one movement we re-fight.
+    documentElement.scrollTop = 0;
+    flushAnimationFrames(1);
+    expect(documentElement.scrollTop).toBe(480);
+
+    // Restoration writes are pinned to instant so a page-level
+    // `scroll-behavior: smooth` can't turn them into animations.
+    const lastCall = documentElement.scrollTo.mock.calls.at(-1)![0];
+    expect(lastCall).toMatchObject({ behavior: "instant" });
+  });
+
+  it("cancels a live restore loop when a newer navigation initializes", () => {
+    const manager = createContextManager({
+      preserveScroll: true,
+    });
+    const feedPage = createFakeElement({ parentElement: body });
+    const detailPage = createFakeElement({ parentElement: body });
+    const returningFeedPage = createFakeElement({ parentElement: body });
+    const nextPage = createFakeElement({ parentElement: body });
+
+    manager.initializeContext(feedPage, "/feed");
+    flushAnimationFrames(11);
+
+    documentElement.scrollTop = 900;
+    emitWindowScroll();
+
+    manager.initializeContext(detailPage, "/detail");
+    flushAnimationFrames(11);
+
+    // Return to /feed with the page still short: the loop stays alive
+    // waiting for layout to grow toward the saved 900.
+    documentElement.scrollHeight = 760;
+    documentElement.scrollTop = 0;
+    manager.initializeContext(returningFeedPage, "/feed");
+    flushAnimationFrames(2);
+    expect(documentElement.scrollTop).toBe(160);
+
+    // Navigate again mid-loop. The old loop must die with its generation —
+    // even once 900 becomes reachable, only the new target may be applied.
+    const callsBeforeNext = documentElement.scrollTo.mock.calls.length;
+    manager.initializeContext(nextPage, "/next");
+    documentElement.scrollHeight = 2000;
+    flushAnimationFrames(12);
+
+    const staleWrites = documentElement.scrollTo.mock.calls
+      .slice(callsBeforeNext)
+      .filter(([options]) => (options as ScrollToOptions).top === 900);
+    expect(staleWrites).toHaveLength(0);
+    expect(documentElement.scrollTop).toBe(0);
+  });
+
   it("keys scroll off resolvePath so aliased/rewritten routes share one position", () => {
     const manager = createContextManager({
       preserveScroll: true,

--- a/packages/core/src/lib/ssgoi-transition/create-context-manager.test.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-context-manager.test.ts
@@ -25,6 +25,32 @@ const emitEvent = (listeners: ListenerMap, type: string) => {
   }
 };
 
+class FakeResizeObserver {
+  static instances: FakeResizeObserver[] = [];
+  targets = new Set<HTMLElement>();
+  constructor(private callback: ResizeObserverCallback) {
+    FakeResizeObserver.instances.push(this);
+  }
+  observe(target: HTMLElement) {
+    this.targets.add(target);
+  }
+  unobserve(target: HTMLElement) {
+    this.targets.delete(target);
+  }
+  disconnect() {
+    this.targets.clear();
+  }
+  trigger() {
+    this.callback([], this as unknown as ResizeObserver);
+  }
+}
+
+const triggerResize = (element: HTMLElement) => {
+  for (const instance of FakeResizeObserver.instances) {
+    if (instance.targets.has(element)) instance.trigger();
+  }
+};
+
 const createFakeElement = (
   overrides: Partial<FakeElement> = {},
 ): FakeElement => {
@@ -131,7 +157,8 @@ describe("createContextManager", () => {
       body,
       documentElement,
     } as unknown as Document);
-    vi.stubGlobal("ResizeObserver", undefined);
+    FakeResizeObserver.instances = [];
+    vi.stubGlobal("ResizeObserver", FakeResizeObserver);
   });
 
   afterEach(() => {
@@ -259,7 +286,7 @@ describe("createContextManager", () => {
     expect(documentElement.scrollTop).toBe(480);
   });
 
-  it("retries restore until the saved target becomes reachable", () => {
+  it("re-applies when the entering page's growth makes the target reachable", () => {
     const manager = createContextManager({
       preserveScroll: true,
     });
@@ -285,8 +312,10 @@ describe("createContextManager", () => {
     // Container clamps to maxY=160 until layout grows.
     expect(documentElement.scrollTop).toBe(160);
 
+    // Content arrives (images, async data): the page element resizes, and the
+    // reconciler re-applies the still-unreached target — no frame polling.
     documentElement.scrollHeight = 2000;
-    flushAnimationFrames(1);
+    triggerResize(returningFeedPage);
     expect(documentElement.scrollTop).toBe(900);
   });
 
@@ -399,14 +428,16 @@ describe("createContextManager", () => {
     expect(documentElement.scrollTop).toBe(160);
 
     // Content arrives AND the page scrolls itself somewhere deliberate
-    // (anchor / useEffect scrollTo). The restore loop must yield, not drag
-    // the container back to the saved 900.
+    // (anchor / useEffect scrollTo). The reconciler must yield, not drag the
+    // container back to the saved 900.
     documentElement.scrollHeight = 2000;
     documentElement.scrollTop = 300;
-    flushAnimationFrames(1);
+    emitWindowScroll();
     expect(documentElement.scrollTop).toBe(300);
 
+    // Once yielded, even a later resize of the page must not re-apply.
     const callsAfterYield = documentElement.scrollTo.mock.calls.length;
+    triggerResize(returningFeedPage);
     flushAnimationFrames(10);
     expect(documentElement.scrollTop).toBe(300);
     expect(documentElement.scrollTo.mock.calls.length).toBe(callsAfterYield);
@@ -471,9 +502,10 @@ describe("createContextManager", () => {
     expect(documentElement.scrollTop).toBe(480);
 
     // A router-side reset (e.g. afterNavigate) lands AFTER we already
-    // restored. A jump to exactly (0,0) is the one movement we re-fight.
+    // restored. Its scroll event reaches the reconciler, and a jump to
+    // exactly (0,0) is the one movement that gets re-fought.
     documentElement.scrollTop = 0;
-    flushAnimationFrames(1);
+    emitWindowScroll();
     expect(documentElement.scrollTop).toBe(480);
 
     // Restoration writes are pinned to instant so a page-level
@@ -482,7 +514,7 @@ describe("createContextManager", () => {
     expect(lastCall).toMatchObject({ behavior: "instant" });
   });
 
-  it("cancels a live restore loop when a newer navigation initializes", () => {
+  it("drops a superseded restore session when a newer navigation initializes", () => {
     const manager = createContextManager({
       preserveScroll: true,
     });
@@ -500,19 +532,21 @@ describe("createContextManager", () => {
     manager.initializeContext(detailPage, "/detail");
     flushAnimationFrames(11);
 
-    // Return to /feed with the page still short: the loop stays alive
-    // waiting for layout to grow toward the saved 900.
+    // Return to /feed with the page still short: the session holds a clamped
+    // target, waiting for layout to grow toward the saved 900.
     documentElement.scrollHeight = 760;
     documentElement.scrollTop = 0;
     manager.initializeContext(returningFeedPage, "/feed");
     flushAnimationFrames(2);
     expect(documentElement.scrollTop).toBe(160);
 
-    // Navigate again mid-loop. The old loop must die with its generation —
-    // even once 900 becomes reachable, only the new target may be applied.
+    // Navigate again mid-session. The superseded session's observer must be
+    // disconnected — even once 900 becomes reachable, only the new target may
+    // be applied.
     const callsBeforeNext = documentElement.scrollTo.mock.calls.length;
     manager.initializeContext(nextPage, "/next");
     documentElement.scrollHeight = 2000;
+    triggerResize(returningFeedPage);
     flushAnimationFrames(12);
 
     const staleWrites = documentElement.scrollTo.mock.calls

--- a/packages/core/src/lib/ssgoi-transition/create-context-manager.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-context-manager.ts
@@ -4,7 +4,7 @@ import { getPositionedParent } from "@utils";
 import { matchPath } from "./find-matching-transition";
 
 const MOBILE_BREAKPOINT_PX = 768;
-const RESTORE_MAX_RETRIES = 10;
+const RESTORE_WINDOW_FRAMES = 10;
 const TRANSITION_SETTLE_FRAMES = 10;
 
 type ScrollPosition = { x: number; y: number };
@@ -129,14 +129,24 @@ export function createContextManager(options: ContextManagerOptions = {}) {
   // Restore scroll position for the given path. For non-preserved paths the
   // arrival starts at the top; for shared-key paths without a saved value, leave
   // the current scroll alone because a parent transition context may own it.
-  // Saved targets are re-applied for up to 10 frames or until reached.
+  //
+  // The target (saved value or top) is supervised for RESTORE_WINDOW_FRAMES
+  // frames, but never re-applied blindly. Each frame classifies how the
+  // container moved since OUR last write:
+  //  - unmoved, or merely clamped by the new page's shorter layout: our write
+  //    hasn't stuck / isn't reachable yet — re-apply and wait for layout.
+  //  - moved to (0,0) while we hold a non-top target: a router-style top reset
+  //    (e.g. SvelteKit's `afterNavigate`) — the thing this window exists to
+  //    beat — re-apply.
+  //  - moved anywhere else: a deliberate scroll by the entering page (anchor,
+  //    `useEffect` scrollTo, scroll-to-bottom) or by the user — yield
+  //    immediately and never touch scroll again for this navigation.
+  // The baseline is read synchronously at init, before the first write, so a
+  // scroll landing between commit and our first frame (`useLayoutEffect`
+  // timing) is classified the same way instead of being overwritten.
   const restoreScrollPosition = (path: string) => {
     if (!scrollContainer) return;
 
-    // Resolve the target: saved value if preservation is on AND we have one,
-    // otherwise (0, 0). These cases go through the same retry loop so a
-    // router-side scroll restore (e.g., SvelteKit's `afterNavigate`) running
-    // after our first scrollTo can be overridden within the retry window.
     const policy = getScrollPolicy(path);
     if (
       policy.preserves &&
@@ -151,21 +161,83 @@ export function createContextManager(options: ContextManagerOptions = {}) {
         ? scrollPositions.get(policy.storageKey)!
         : { x: 0, y: 0 };
 
-    let retryCount = 0;
+    // A newer init supersedes this loop — two live loops with different
+    // targets must never fight over one container during rapid navigation.
+    const myGeneration = initGeneration;
+
+    // Last position WE put the container at (seeded with the pre-write
+    // baseline). Re-read after every write because the browser clamps writes
+    // to the scrollable extent.
+    let lastApplied: ScrollPosition = {
+      x: scrollContainer.scrollLeft,
+      y: scrollContainer.scrollTop,
+    };
+    let frame = 0;
+
     const tryRestore = () => {
       if (!scrollContainer) return;
+      if (myGeneration !== initGeneration) return;
+      frame++;
 
-      scrollContainer.scrollTo({
-        top: target.y,
-        left: target.x,
-      });
+      const current: ScrollPosition = {
+        x: scrollContainer.scrollLeft,
+        y: scrollContainer.scrollTop,
+      };
+      // Where lastApplied passively sits after any layout shrink — clamping
+      // moves nobody deliberately, so landing exactly there is not a scroll.
+      const expected: ScrollPosition = {
+        x: Math.min(
+          lastApplied.x,
+          Math.max(
+            0,
+            scrollContainer.scrollWidth - scrollContainer.clientWidth,
+          ),
+        ),
+        y: Math.min(
+          lastApplied.y,
+          Math.max(
+            0,
+            scrollContainer.scrollHeight - scrollContainer.clientHeight,
+          ),
+        ),
+      };
 
-      const targetReached =
-        Math.abs(scrollContainer.scrollTop - target.y) < 1 &&
-        Math.abs(scrollContainer.scrollLeft - target.x) < 1;
+      const movedExternally =
+        Math.abs(current.x - expected.x) >= 1 ||
+        Math.abs(current.y - expected.y) >= 1;
 
-      if (!targetReached && retryCount < RESTORE_MAX_RETRIES) {
-        retryCount++;
+      if (movedExternally) {
+        const movedToTop = current.x < 1 && current.y < 1;
+        const targetIsTop = target.x < 1 && target.y < 1;
+        // Only a top reset while we hold a saved position gets fought; any
+        // other movement is someone's intent — stop competing with it.
+        if (!movedToTop || targetIsTop) return;
+      }
+
+      const atTarget =
+        Math.abs(current.x - target.x) < 1 &&
+        Math.abs(current.y - target.y) < 1;
+
+      if (!atTarget) {
+        // behavior:"instant" pins the write against a page-level
+        // `scroll-behavior: smooth`, which would otherwise turn restoration
+        // into a visible crawl and leave the read-back below mid-animation.
+        scrollContainer.scrollTo({
+          top: target.y,
+          left: target.x,
+          behavior: "instant",
+        });
+      }
+
+      lastApplied = {
+        x: scrollContainer.scrollLeft,
+        y: scrollContainer.scrollTop,
+      };
+
+      // Keep supervising for the full window even after the target is
+      // reached: a late router reset must still be re-fought, and reads
+      // without writes are cheap.
+      if (frame <= RESTORE_WINDOW_FRAMES) {
         requestAnimationFrame(tryRestore);
       }
     };

--- a/packages/core/src/lib/ssgoi-transition/create-context-manager.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-context-manager.ts
@@ -4,7 +4,6 @@ import { getPositionedParent } from "@utils";
 import { matchPath } from "./find-matching-transition";
 
 const MOBILE_BREAKPOINT_PX = 768;
-const RESTORE_WINDOW_FRAMES = 10;
 const TRANSITION_SETTLE_FRAMES = 10;
 
 type ScrollPosition = { x: number; y: number };
@@ -117,37 +116,123 @@ export function createContextManager(options: ContextManagerOptions = {}) {
   // isTransitioning back to false mid-way through a newer transition.
   let initGeneration = 0;
 
-  const scrollListener = () => {
-    if (scrollContainer && currentPath && !isTransitioning) {
-      scrollPositions.set(getScrollPolicy(currentPath).storageKey, {
-        x: scrollContainer.scrollLeft,
-        y: scrollContainer.scrollTop,
-      });
-    }
+  /* ── Scroll restoration ──────────────────────────────────────────────────
+   *
+   * Restoration is a small reconciler, not a polling loop. A session opens at
+   * init with a target (saved value, or top for non-preserved paths) and a
+   * pre-write baseline; `superviseRestore` is then invoked only when something
+   * actually happens:
+   *  - one deferred kick on the next frame (the entering page needs a layout
+   *    before the first write can stick),
+   *  - every scroll event during the transition window (the same listener that
+   *    captures positions outside it),
+   *  - the entering page resizing (ResizeObserver) — growth is what makes a
+   *    clamped target reachable.
+   *
+   * Each invocation classifies how the container moved since OUR last write:
+   *  - unmoved, or merely clamped by a shorter layout: our write hasn't stuck /
+   *    isn't reachable yet — re-apply.
+   *  - moved to (0,0) while we hold a non-top target: a router-style top reset
+   *    (e.g. SvelteKit's `afterNavigate`) — the one movement we fight —
+   *    re-apply.
+   *  - moved anywhere else: a deliberate scroll by the entering page (anchor,
+   *    `useEffect` scrollTo, scroll-to-bottom) or by the user — yield and
+   *    never touch scroll again for this navigation.
+   * The baseline is read synchronously at init, before the first write, so a
+   * scroll landing between commit and the first frame (`useLayoutEffect`
+   * timing) is classified the same way instead of being overwritten.
+   *
+   * The session closes when the settle countdown flips `isTransitioning` off —
+   * one shared window for capture suppression and restoration alike.
+   * ──────────────────────────────────────────────────────────────────────── */
+
+  type RestoreSession = {
+    target: ScrollPosition;
+    // Last position WE put the container at (seeded with the pre-write
+    // baseline). Re-read after every write because the browser clamps writes
+    // to the scrollable extent.
+    lastApplied: ScrollPosition;
+    yielded: boolean;
   };
 
-  // Restore scroll position for the given path. For non-preserved paths the
-  // arrival starts at the top; for shared-key paths without a saved value, leave
-  // the current scroll alone because a parent transition context may own it.
-  //
-  // The target (saved value or top) is supervised for RESTORE_WINDOW_FRAMES
-  // frames, but never re-applied blindly. Each frame classifies how the
-  // container moved since OUR last write:
-  //  - unmoved, or merely clamped by the new page's shorter layout: our write
-  //    hasn't stuck / isn't reachable yet — re-apply and wait for layout.
-  //  - moved to (0,0) while we hold a non-top target: a router-style top reset
-  //    (e.g. SvelteKit's `afterNavigate`) — the thing this window exists to
-  //    beat — re-apply.
-  //  - moved anywhere else: a deliberate scroll by the entering page (anchor,
-  //    `useEffect` scrollTo, scroll-to-bottom) or by the user — yield
-  //    immediately and never touch scroll again for this navigation.
-  // The baseline is read synchronously at init, before the first write, so a
-  // scroll landing between commit and our first frame (`useLayoutEffect`
-  // timing) is classified the same way instead of being overwritten.
-  const restoreScrollPosition = (path: string) => {
+  let restoreSession: RestoreSession | null = null;
+  // Lazily created, reused across sessions; watches the entering page element
+  // so content growth (images, async data) re-triggers reconciliation.
+  let restoreObserver: ResizeObserver | null = null;
+
+  const superviseRestore = () => {
+    const session = restoreSession;
+    if (!session || session.yielded || !scrollContainer) return;
+
+    const current: ScrollPosition = {
+      x: scrollContainer.scrollLeft,
+      y: scrollContainer.scrollTop,
+    };
+    // Where lastApplied passively sits after any layout shrink — clamping
+    // moves nobody deliberately, so landing exactly there is not a scroll.
+    const expected: ScrollPosition = {
+      x: Math.min(
+        session.lastApplied.x,
+        Math.max(0, scrollContainer.scrollWidth - scrollContainer.clientWidth),
+      ),
+      y: Math.min(
+        session.lastApplied.y,
+        Math.max(
+          0,
+          scrollContainer.scrollHeight - scrollContainer.clientHeight,
+        ),
+      ),
+    };
+
+    const movedExternally =
+      Math.abs(current.x - expected.x) >= 1 ||
+      Math.abs(current.y - expected.y) >= 1;
+
+    if (movedExternally) {
+      const movedToTop = current.x < 1 && current.y < 1;
+      const targetIsTop = session.target.x < 1 && session.target.y < 1;
+      // Only a top reset while we hold a saved position gets fought; any
+      // other movement is someone's intent — stop competing with it.
+      if (!movedToTop || targetIsTop) {
+        session.yielded = true;
+        restoreObserver?.disconnect();
+        return;
+      }
+    }
+
+    const atTarget =
+      Math.abs(current.x - session.target.x) < 1 &&
+      Math.abs(current.y - session.target.y) < 1;
+    if (atTarget) return;
+
+    // behavior:"instant" pins the write against a page-level
+    // `scroll-behavior: smooth`, which would otherwise turn restoration into
+    // a visible crawl and leave the read-back below mid-animation.
+    scrollContainer.scrollTo({
+      top: session.target.y,
+      left: session.target.x,
+      behavior: "instant",
+    });
+    session.lastApplied = {
+      x: scrollContainer.scrollLeft,
+      y: scrollContainer.scrollTop,
+    };
+  };
+
+  const endRestoreSession = () => {
+    restoreObserver?.disconnect();
+    restoreSession = null;
+  };
+
+  const startRestoreSession = (path: string, element: HTMLElement) => {
+    // A newer navigation supersedes any live session — two sessions with
+    // different targets must never fight over one container.
+    endRestoreSession();
     if (!scrollContainer) return;
 
     const policy = getScrollPolicy(path);
+    // Shared-key paths without a saved value: leave the current scroll alone,
+    // a parent transition context may own it.
     if (
       policy.preserves &&
       policy.shared &&
@@ -156,93 +241,42 @@ export function createContextManager(options: ContextManagerOptions = {}) {
       return;
     }
 
-    const target: ScrollPosition =
-      policy.preserves && scrollPositions.has(policy.storageKey)
-        ? scrollPositions.get(policy.storageKey)!
-        : { x: 0, y: 0 };
+    restoreSession = {
+      target:
+        policy.preserves && scrollPositions.has(policy.storageKey)
+          ? scrollPositions.get(policy.storageKey)!
+          : { x: 0, y: 0 },
+      lastApplied: {
+        x: scrollContainer.scrollLeft,
+        y: scrollContainer.scrollTop,
+      },
+      yielded: false,
+    };
 
-    // A newer init supersedes this loop — two live loops with different
-    // targets must never fight over one container during rapid navigation.
-    const myGeneration = initGeneration;
+    if (typeof ResizeObserver !== "undefined") {
+      restoreObserver ??= new ResizeObserver(() => superviseRestore());
+      restoreObserver.observe(element);
+    }
 
-    // Last position WE put the container at (seeded with the pre-write
-    // baseline). Re-read after every write because the browser clamps writes
-    // to the scrollable extent.
-    let lastApplied: ScrollPosition = {
+    // First write is deferred one frame so the entering page has a layout to
+    // scroll against. A stale kick from a superseded navigation is harmless:
+    // the reconciler only ever acts on the CURRENT session.
+    requestAnimationFrame(superviseRestore);
+  };
+
+  const scrollListener = () => {
+    if (!scrollContainer || !currentPath) return;
+    // During the transition window the listener supervises restoration instead
+    // of capturing: OUT scrolls of an unmounted page must not be recorded, but
+    // they are exactly the signals the reconciler classifies.
+    if (isTransitioning) {
+      superviseRestore();
+      return;
+    }
+    scrollPositions.set(getScrollPolicy(currentPath).storageKey, {
       x: scrollContainer.scrollLeft,
       y: scrollContainer.scrollTop,
-    };
-    let frame = 0;
-
-    const tryRestore = () => {
-      if (!scrollContainer) return;
-      if (myGeneration !== initGeneration) return;
-      frame++;
-
-      const current: ScrollPosition = {
-        x: scrollContainer.scrollLeft,
-        y: scrollContainer.scrollTop,
-      };
-      // Where lastApplied passively sits after any layout shrink — clamping
-      // moves nobody deliberately, so landing exactly there is not a scroll.
-      const expected: ScrollPosition = {
-        x: Math.min(
-          lastApplied.x,
-          Math.max(
-            0,
-            scrollContainer.scrollWidth - scrollContainer.clientWidth,
-          ),
-        ),
-        y: Math.min(
-          lastApplied.y,
-          Math.max(
-            0,
-            scrollContainer.scrollHeight - scrollContainer.clientHeight,
-          ),
-        ),
-      };
-
-      const movedExternally =
-        Math.abs(current.x - expected.x) >= 1 ||
-        Math.abs(current.y - expected.y) >= 1;
-
-      if (movedExternally) {
-        const movedToTop = current.x < 1 && current.y < 1;
-        const targetIsTop = target.x < 1 && target.y < 1;
-        // Only a top reset while we hold a saved position gets fought; any
-        // other movement is someone's intent — stop competing with it.
-        if (!movedToTop || targetIsTop) return;
-      }
-
-      const atTarget =
-        Math.abs(current.x - target.x) < 1 &&
-        Math.abs(current.y - target.y) < 1;
-
-      if (!atTarget) {
-        // behavior:"instant" pins the write against a page-level
-        // `scroll-behavior: smooth`, which would otherwise turn restoration
-        // into a visible crawl and leave the read-back below mid-animation.
-        scrollContainer.scrollTo({
-          top: target.y,
-          left: target.x,
-          behavior: "instant",
-        });
-      }
-
-      lastApplied = {
-        x: scrollContainer.scrollLeft,
-        y: scrollContainer.scrollTop,
-      };
-
-      // Keep supervising for the full window even after the target is
-      // reached: a late router reset must still be re-fought, and reads
-      // without writes are cheap.
-      if (frame <= RESTORE_WINDOW_FRAMES) {
-        requestAnimationFrame(tryRestore);
-      }
-    };
-
-    requestAnimationFrame(tryRestore);
+    });
   };
 
   const initializeContext = (element: HTMLElement, path: string) => {
@@ -276,12 +310,12 @@ export function createContextManager(options: ContextManagerOptions = {}) {
     }
 
     currentPath = path;
-    restoreScrollPosition(path);
+    startRestoreSession(path, element);
 
-    // Re-enable scroll capture after the transition window settles. Spans
-    // ~10 frames (~167ms) — long enough for most page transitions and any
-    // router-driven scroll reset to land before we start trusting the
-    // listener again.
+    // Close the transition window after ~10 frames (~167ms) — long enough for
+    // most page transitions and any router-driven scroll reset to land. One
+    // countdown bounds both halves of the window: the restore session ends and
+    // scroll capture resumes.
     let settleCount = 0;
     const trySettle = () => {
       // A newer init started its own settle; this older one must not be the
@@ -290,6 +324,7 @@ export function createContextManager(options: ContextManagerOptions = {}) {
       if (myGeneration !== initGeneration) return;
       settleCount++;
       if (settleCount >= TRANSITION_SETTLE_FRAMES) {
+        endRestoreSession();
         isTransitioning = false;
       } else {
         requestAnimationFrame(trySettle);


### PR DESCRIPTION
## Motivation

Adversarial review of the `preserveScroll` restore retry loop (`create-context-manager.ts`), prompted by the question: *what happens when the **entering page also moves scroll on its own** — an anchor scroll, a `useEffect`/`useLayoutEffect` `scrollTo`, a chat scroll-to-bottom — while the loop is re-applying its target?*

## Problems in the old loop

1. **It stomped deliberate scrolls.** `scrollTo(target)` was re-applied unconditionally for up to 11 frames, with no way to tell "my write didn't stick yet" apart from "someone intentionally scrolled elsewhere". Any scroll by the entering page or the user inside that window was silently reverted — and there was **no escape hatch**: `exclude`d paths ran the same loop toward `(0,0)`, so even opting out of preservation didn't let a page own its entrance scroll.
2. **`useLayoutEffect`-timed scrolls always lost.** A scroll landing between commit (init) and the first rAF was indistinguishable from the previous page's stale position, so the first write overwrote it.
3. **Rapid navigations left two live loops fighting.** `initGeneration` guarded the settle countdown but not the restore loop; A→B→C inside the retry window left two loops writing different targets to the same container every frame.
4. **`scroll-behavior: smooth` broke it** (e.g. Tailwind `scroll-smooth` on `<html>`). `scrollTo` without `behavior` inherits smooth; the reached-check then read a mid-animation position, so every frame restarted the smooth scroll — restoration became a visible crawl, and the transition's `scrollOffset` math ran against a container that wasn't where it claimed to be.
5. **The #324 contract had a hole.** The loop existed to beat router-side top resets (SvelteKit `afterNavigate`), but it died as soon as the target was reached — so a reset landing *after* arrival (the common timing) was never actually re-fought.
6. **Polling itself was the smell.** Retries had no cause — "try again next frame" — plus a second parallel rAF chain next to the settle countdown, coupled by nothing but matching frame counts.

## New design: an event-driven reconciler

Restoration is now a **session** (target + pre-write baseline + yielded flag) and one idempotent reconciler, `superviseRestore`. Nothing polls; the reconciler runs only when something actually happens:

- **one deferred kick** on the next frame (the entering page needs a layout before the first write can stick),
- **every scroll event** during the transition window — the same listener that captures positions outside it,
- **the entering page resizing** (`ResizeObserver`) — growth is what makes a clamped target reachable.

Each invocation classifies how the container moved since *our last write* (seeded with a baseline read synchronously at init, which closes the `useLayoutEffect` hole):

| Movement since our last write | Interpretation | Action |
|---|---|---|
| none, or exactly the layout clamp of our last write | write didn't stick / target not reachable yet | re-apply |
| to `(0,0)` while we hold a non-top target | router-style top reset | re-apply (now works even after the target was reached — closes the #324 hole) |
| anywhere else | deliberate scroll (app effect, anchor, user input) | **yield for the rest of the navigation** |

The clamp row is what keeps the original #324 fix intact: a shorter incoming page passively clamping the stale scroll position is the browser, not intent, and is still overridden to top/saved. There's a dedicated regression-guard test for exactly the #324 failure ("stuck at the previous page's scroll").

The session closes when the existing settle countdown flips `isTransitioning` off — **one shared window** bounds capture suppression and restoration alike. `RESTORE_WINDOW_FRAMES` and the second rAF chain are gone. A newer navigation drops the superseded session (observer disconnected); a stale first-kick is harmless because the reconciler only ever acts on the current session. Writes pass `behavior: "instant"`.

## On router interference in general

Total ownership of scroll is impossible in principle — any party (router, app, browser) can write last, and none of them coordinate. What this PR changes is the *stance*: instead of trying to win every race for N frames, ssgoi corrects only the one unambiguous interference pattern (a jump to exactly `(0,0)` while holding a saved position) inside a bounded window, and defers to everything else as intent. The practical recommendation remains to disable the router's own scroll handling where the framework allows it; the re-fight window is the fallback for routers that can't be configured.

## Known trade-offs (worth discussing on this draft)

- A page that deliberately scrolls itself to exactly `(0,0)` during entrance while a saved position exists is indistinguishable from a router reset and will be re-fought. Escape hatch: `preserveScroll.exclude` that path — the target then *is* top, and any non-top app scroll yields as intended (which it previously didn't).
- A scroll landing exactly at the clamp value (e.g. scroll-to-bottom on a page shorter than the stale position) is indistinguishable from a passive clamp and gets overridden.
- A router whose own restoration targets a *non-zero* position now wins over ours (we yield). For back-nav both sides saved the same page's position, so the destination is effectively identical.
- Environments without `ResizeObserver` lose the late-growth re-apply (the initial write still lands). The old behavior only covered growth within ~167ms of polling anyway.

## Tests

5 new cases alongside the existing 11 (all green, 87/87 in core), now driven by scroll events and resize triggers instead of frame flushing:
- yields to an app-driven scroll during the restore window (and stays yielded through a later resize)
- yields to a scroll that lands before the first restore frame (`useLayoutEffect` timing)
- treats a layout clamp as passive, not as an external scroll (#324 regression guard)
- re-fights a router top reset even after the target was reached (+ asserts `behavior: "instant"`)
- drops a superseded restore session when a newer navigation initializes

🤖 Generated with [Claude Code](https://claude.com/claude-code)