### PR TITLE
docs: simplify mobile navigation header

### DIFF
--- a/apps/docs/src/app/docs/layout.tsx
+++ b/apps/docs/src/app/docs/layout.tsx
@@ -5,7 +5,7 @@ import { DocsSidebar, DocsMobileNav } from "@/page/docs/sidebar";
 export default function DocsLayout({ children }: { children: ReactNode }) {
   return (
     <div className="relative min-h-dvh bg-canvas">
-      <SiteNav active="docs" />
+      <SiteNav active="docs" desktopOnly />
       <DocsMobileNav />
       <div className="mx-auto flex w-full max-w-6xl gap-10 px-6 pt-10 lg:gap-14 lg:pt-16">
         <aside className="hidden w-60 shrink-0 lg:block">

--- a/apps/docs/src/components/site-nav.tsx
+++ b/apps/docs/src/components/site-nav.tsx
@@ -17,9 +17,20 @@ const SECONDARY: Array<{ key: NavKey; label: string; href: string }> = [
   { key: "blog", label: "Blog", href: "/blog" },
 ];
 
-export function SiteNav({ active }: { active?: NavKey }) {
+export function SiteNav({
+  active,
+  desktopOnly = false,
+}: {
+  active?: NavKey;
+  desktopOnly?: boolean;
+}) {
   return (
-    <header className="pointer-events-none sticky top-3 z-50 mt-3 flex justify-center px-3 md:top-4 md:mt-4">
+    <header
+      className={[
+        "pointer-events-none sticky top-3 z-50 mt-3 justify-center px-3 md:top-4 md:mt-4",
+        desktopOnly ? "hidden lg:flex" : "flex",
+      ].join(" ")}
+    >
       <nav className="pointer-events-auto inline-flex h-11 items-center gap-4 rounded-full border border-line-strong bg-panel/75 pl-3 pr-4 backdrop-blur md:h-12 md:gap-5 md:pl-4 md:pr-5">
         <SiteLogo />
 

--- a/apps/docs/src/page/docs/sidebar.tsx
+++ b/apps/docs/src/page/docs/sidebar.tsx
@@ -22,6 +22,7 @@ import {
   SvelteKitMark,
   TanStackRouterMark,
 } from "@/components/router-logos";
+import { SiteLogo } from "@/components/site-logo";
 import {
   DOCS_NAV,
   findDocsLocation,
@@ -260,11 +261,13 @@ function DocsMobileNavForPath({ pathname }: { pathname: string }) {
 
   return (
     <Sheet open={open} onOpenChange={setOpen}>
-      <div className="mx-auto flex w-full max-w-6xl px-5">
+      <div className="mx-auto flex h-14 w-full max-w-6xl items-center gap-3 px-5">
+        <SiteLogo className="shrink-0" />
+        <span className="h-5 w-px shrink-0 bg-line-strong" aria-hidden />
         <SheetTrigger asChild>
           <button
             type="button"
-            className="flex h-12 w-full min-w-0 items-center gap-2.5 rounded-lg px-2 text-left text-sm text-ink-soft transition-colors hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
+            className="flex h-12 min-w-0 flex-1 items-center gap-2.5 rounded-lg px-2 text-left text-sm text-ink-soft transition-colors hover:text-ink focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand/60"
             aria-label={`Open documentation navigation. Current page: ${context}`}
           >
             <Menu aria-hidden className="h-4 w-4 shrink-0 text-ink-faint" />
@@ -304,10 +307,11 @@ function DocsMobileNavForPath({ pathname }: { pathname: string }) {
 export function DocsMobileNav() {
   const pathname = usePathname();
 
-  // Sits flush under the floating site pill so the page has one bar, not two.
+  // This is the only mobile header in docs. The logo provides a direct route
+  // home while the rest of the bar opens the documentation navigation.
   // Remounting on navigation closes the drawer even for browser back/forward.
   return (
-    <div className="sticky top-14 z-40 border-b border-line bg-canvas/90 backdrop-blur md:top-16 lg:hidden">
+    <div className="sticky top-0 z-50 border-b border-line bg-canvas/90 backdrop-blur lg:hidden">
       <DocsMobileNavForPath key={pathname} pathname={pathname} />
     </div>
   );


### PR DESCRIPTION
## Summary

- show only the docs navigation header on mobile docs pages
- add the SSGOI logo as a direct home link in that header
- keep the existing site header and docs sidebar on desktop

## Verification

- docs ESLint checks
- Next.js production build
- mobile and desktop browser checks
- mobile docs drawer and home-link interaction checks