### PR TITLE
feat: add installable SSGOI agent plugin

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "ssgoi",
+  "interface": {
+    "displayName": "SSGOI"
+  },
+  "plugins": [
+    {
+      "name": "ssgoi",
+      "source": {
+        "source": "local",
+        "path": "./plugins/ssgoi"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,28 @@
+{
+  "name": "ssgoi",
+  "owner": {
+    "name": "MeurSyphus",
+    "email": "tmdeoans@snu.ac.kr"
+  },
+  "description": "Official SSGOI skills for native app-like mobile web apps.",
+  "plugins": [
+    {
+      "name": "ssgoi",
+      "source": "./plugins/ssgoi",
+      "description": "Build mobile web app routing, layouts, and native app-like page transitions with SSGOI.",
+      "author": {
+        "name": "MeurSyphus",
+        "email": "tmdeoans@snu.ac.kr"
+      },
+      "homepage": "https://ssgoi.dev",
+      "repository": "https://github.com/meursyphus/ssgoi",
+      "license": "MIT",
+      "category": "development",
+      "tags": [
+        "mobile-web",
+        "page-transitions",
+        "animation"
+      ]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -36,6 +36,30 @@ Nuxt, Solid and SolidStart, Angular, and Qwik.
 
 ---
 
+## Or install the agent plugin
+
+The same `mobile-web-app` skill works in Codex and Claude Code.
+
+Codex:
+
+```bash
+codex plugin marketplace add meursyphus/ssgoi
+codex plugin add ssgoi@ssgoi
+```
+
+Claude Code:
+
+```bash
+claude plugin marketplace add meursyphus/ssgoi
+claude plugin install ssgoi@ssgoi
+```
+
+Then ask the agent to apply SSGOI to the current mobile web app. The skill reads
+the canonical `llms.txt`, selects the matching framework guide, and follows the
+app's existing router and layout structure.
+
+---
+
 ## Or add it in just 2–3 files
 
 The React and Next.js setup is one config, one provider, and one simple

--- a/plugins/ssgoi/.claude-plugin/plugin.json
+++ b/plugins/ssgoi/.claude-plugin/plugin.json
@@ -1,0 +1,18 @@
+{
+  "name": "ssgoi",
+  "version": "0.1.0",
+  "description": "Build mobile web app routing, layouts, and native app-like page transitions with SSGOI.",
+  "author": {
+    "name": "MeurSyphus",
+    "email": "tmdeoans@snu.ac.kr"
+  },
+  "homepage": "https://ssgoi.dev",
+  "repository": "https://github.com/meursyphus/ssgoi",
+  "license": "MIT",
+  "keywords": [
+    "mobile-web",
+    "page-transitions",
+    "animation",
+    "ssgoi"
+  ]
+}

--- a/plugins/ssgoi/.codex-plugin/plugin.json
+++ b/plugins/ssgoi/.codex-plugin/plugin.json
@@ -1,0 +1,37 @@
+{
+  "name": "ssgoi",
+  "version": "0.1.0",
+  "description": "Build mobile web app routing, layouts, and native app-like page transitions with SSGOI.",
+  "author": {
+    "name": "MeurSyphus",
+    "email": "tmdeoans@snu.ac.kr",
+    "url": "https://github.com/meursyphus"
+  },
+  "homepage": "https://ssgoi.dev",
+  "repository": "https://github.com/meursyphus/ssgoi",
+  "license": "MIT",
+  "keywords": [
+    "mobile-web",
+    "page-transitions",
+    "animation",
+    "ssgoi"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "SSGOI",
+    "shortDescription": "Build native app-like mobile web experiences",
+    "longDescription": "Apply SSGOI to a mobile web app by following its canonical framework, routing, layout, and transition guides.",
+    "developerName": "MeurSyphus",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Read",
+      "Write"
+    ],
+    "websiteURL": "https://ssgoi.dev",
+    "defaultPrompt": [
+      "Turn this project into a native app-like mobile web experience with SSGOI.",
+      "Apply SSGOI to this app's routing and layouts.",
+      "Fix the SSGOI setup in this mobile web app."
+    ]
+  }
+}

--- a/plugins/ssgoi/skills/mobile-web-app/SKILL.md
+++ b/plugins/ssgoi/skills/mobile-web-app/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: mobile-web-app
+description: Add native app-like navigation and page animations to mobile web apps with SSGOI. Use when building or improving a mobile web app's routed page structure, layouts, or transitions, or when a project uses SSGOI or an @ssgoi package.
+---
+
+# Mobile Web App with SSGOI
+
+Read `https://ssgoi.dev/llms.txt` before changing code. Treat it as the single
+source of truth for the current version and setup.
+
+Inspect the application's framework, router, route-folder structure, and
+persistent layouts. Follow the matching framework guide linked from
+`llms.txt` to install SSGOI, place the provider and transition boundaries, and
+configure route relationships without replacing the existing router.
+
+Read only the linked transition, complex-routing, or troubleshooting guides
+needed for the task. Apply the guide, then verify the project build and
+forward/back navigation.

--- a/plugins/ssgoi/skills/mobile-web-app/SKILL.md
+++ b/plugins/ssgoi/skills/mobile-web-app/SKILL.md
@@ -5,8 +5,7 @@ description: Add native app-like navigation and page animations to mobile web ap
 
 # Mobile Web App with SSGOI
 
-Read `https://ssgoi.dev/llms.txt` before changing code. Treat it as the single
-source of truth for the current version and setup.
+Read `https://ssgoi.dev/llms.txt` before changing code. 
 
 Inspect the application's framework, router, route-folder structure, and
 persistent layouts. Follow the matching framework guide linked from

--- a/plugins/ssgoi/skills/mobile-web-app/agents/openai.yaml
+++ b/plugins/ssgoi/skills/mobile-web-app/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Mobile Web App"
+  short_description: "Build mobile web navigation with SSGOI"
+  default_prompt: "Use $mobile-web-app to apply SSGOI to this app by following its canonical llms.txt guide."


### PR DESCRIPTION
## Summary

- add a shared `mobile-web-app` skill that works in Codex and Claude Code
- package the skill with native Codex and Claude plugin manifests
- add repository marketplace catalogs for GitHub-based installation
- document installation commands in the README
- keep `https://ssgoi.dev/llms.txt` unchanged as the canonical setup guide and single source of truth

## Install

### Codex

```bash
codex plugin marketplace add meursyphus/ssgoi
codex plugin add ssgoi@ssgoi
```

### Claude Code

```bash
claude plugin marketplace add meursyphus/ssgoi
claude plugin install ssgoi@ssgoi
```

Then ask the agent to apply SSGOI to the current mobile web app. The skill reads the canonical `llms.txt`, selects the matching framework guide, and follows the project's existing router, route folders, and layout structure.

## Publishing status

- Merged into `latest`; the GitHub marketplace is live for both CLI install flows.
- Release bundles: [SSGOI Agent Plugin v0.1.0](https://github.com/meursyphus/ssgoi/releases/tag/plugin-v0.1.0)
- OpenAI public directory: submit the standalone skill ZIP as a **Skills only** plugin through the [OpenAI submission portal](https://platform.openai.com/plugins). The publisher needs a verified identity and Apps Management write access. The review form also requires listing assets, public support/privacy/terms URLs, starter prompts, five positive tests, and three negative tests.
- Claude community marketplace: submit the GitHub repository through the [Claude plugin submission form](https://platform.claude.com/plugins/submit). Use marketplace `ssgoi` and plugin source `plugins/ssgoi`.

## Validation

- Codex skill validation passed
- Codex plugin validation passed
- Claude marketplace and plugin validation passed with `--strict`
- Remote GitHub marketplace install/uninstall passed in Codex
- Remote GitHub marketplace install/uninstall passed in Claude Code
- Claude direct `/ssgoi:mobile-web-app` invocation passed
- `pnpm docs:build` passed
