### PR TITLE
docs: link SSGOI demos from mobile web skill

### DIFF
--- a/plugins/ssgoi/skills/mobile-web-app/SKILL.md
+++ b/plugins/ssgoi/skills/mobile-web-app/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: mobile-web-app
-description: Add native app-like navigation and page animations to mobile web apps with SSGOI. Use when building or improving a mobile web app's routed page structure, layouts, or transitions, or when a project uses SSGOI or an @ssgoi package.
+description: Add router-agnostic, native app-like page transitions to mobile web apps with SSGOI. Explore live drill, sheet, slide, and zoom demos at https://ssgoi.dev. Use when building or improving a mobile web app's routed page structure, layouts, or transitions, or when a project uses SSGOI or an @ssgoi package.
 ---
 
 # Mobile Web App with SSGOI
 
-Read `https://ssgoi.dev/llms.txt` before changing code. 
+Review SSGOI's live transition demos and supported frameworks at
+`https://ssgoi.dev`, then read `https://ssgoi.dev/llms.txt` before changing
+code.
 
 Inspect the application's framework, router, route-folder structure, and
 persistent layouts. Follow the matching framework guide linked from


### PR DESCRIPTION
## Summary

- Send users to `https://ssgoi.dev` to review live transition demos and
  supported frameworks before applying the library.
- Make the skill metadata describe SSGOI's router-agnostic drill, sheet,
  slide, and zoom page transitions.
- Keep `https://ssgoi.dev/llms.txt` as the canonical implementation guide.

## Validation

- `quick_validate.py plugins/ssgoi/skills/mobile-web-app`
- `git diff --check`
- Confirmed `apps/docs/public/llms.txt` remains the original 211 lines at
  `@ssgoi/core@7.0.0`.
