### PR TITLE
feat(core): improve drill parallax UX and release 7.0.2

### DIFF
--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -5,7 +5,7 @@ replacing the application router.
 
 Router agnostic. Cross-browser. SSR ready. Web Animations API powered.
 
-Current version: `@ssgoi/core@7.0.1`. Every `@ssgoi/*` framework package
+Current version: `@ssgoi/core@7.0.2`. Every `@ssgoi/*` framework package
 is released in lockstep with core, so install the same version across them.
 
 This file contains the minimal React and Next.js setup. Read linked files only

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/angular",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "Angular bindings for SSGOI - Native app-like page transitions for Angular applications",
   "private": false,
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/core",
-  "version": "7.0.1",
+  "version": "7.0.2-beta",
   "description": "Core animation engine for SSGOI - Native app-like page transitions with spring physics",
   "private": false,
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/core",
-  "version": "7.0.2-beta",
+  "version": "7.0.2",
   "description": "Core animation engine for SSGOI - Native app-like page transitions with spring physics",
   "private": false,
   "type": "module",

--- a/packages/core/src/lib/transitions/drill/provider/parallax.ts
+++ b/packages/core/src/lib/transitions/drill/provider/parallax.ts
@@ -6,10 +6,10 @@ import type {
 } from "../types";
 
 // ease-out (Material decelerated): incoming page settles into place.
-// Primary spring 270/25 settles gently; double spring 600/50 is near-critical.
+// Primary spring 230/25 settles gently; double spring 600/50 is near-critical.
 const PARALLAX_PHYSICS: PhysicsOptions = {
   spring: {
-    stiffness: 270,
+    stiffness: 230,
     damping: 25,
     doubleSpring: {
       stiffness: 600,

--- a/packages/core/src/lib/transitions/zoom/provider/blur.ts
+++ b/packages/core/src/lib/transitions/zoom/provider/blur.ts
@@ -21,8 +21,8 @@ export const BLUR_PHYSICS: PhysicsOptions = {
   spring: {
     stiffness: 380,
     damping: 30,
-    restDelta: 0.5,
-    restSpeed: 0.5,
+    restDelta: 0.1,
+    restSpeed: 0.1,
     doubleSpring: {
       stiffness: 260,
       damping: 30,

--- a/packages/core/src/lib/transitions/zoom/provider/blur.ts
+++ b/packages/core/src/lib/transitions/zoom/provider/blur.ts
@@ -21,6 +21,8 @@ export const BLUR_PHYSICS: PhysicsOptions = {
   spring: {
     stiffness: 380,
     damping: 30,
+    restDelta: 0.5,
+    restSpeed: 0.5,
     doubleSpring: {
       stiffness: 260,
       damping: 30,

--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/qwik",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "Qwik bindings for SSGOI - Native app-like page transitions for Qwik and Qwik City applications",
   "private": false,
   "sideEffects": false,

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/react",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "React bindings for SSGOI - Native app-like page transitions for React applications",
   "private": false,
   "type": "module",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/solid",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "Solid.js bindings for SSGOI - Native app-like page transitions for Solid applications",
   "private": false,
   "type": "module",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/svelte",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "Svelte bindings for SSGOI - Native app-like page transitions for Svelte and SvelteKit applications",
   "private": false,
   "main": "./dist/index.js",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/vue",
-  "version": "7.0.1",
+  "version": "7.0.2",
   "description": "Vue bindings for SSGOI - Native app-like page transitions for Vue applications",
   "private": false,
   "type": "module",


### PR DESCRIPTION
## Summary

- reduce the drill parallax primary spring stiffness from 270 to 230
- bump every publishable `@ssgoi/*` package to `7.0.2`
- update the coding-agent setup guide to install `@ssgoi/core@7.0.2`

## Published

- `@ssgoi/angular@7.0.2`
- `@ssgoi/core@7.0.2`
- `@ssgoi/qwik@7.0.2`
- `@ssgoi/react@7.0.2`
- `@ssgoi/solid@7.0.2`
- `@ssgoi/svelte@7.0.2`
- `@ssgoi/vue@7.0.2`

All packages are published under the npm `latest` tag.

## Verification

- all seven package builds passed
- core test suite passed: 17 files, 109 tests
- registry versions and `latest` dist-tags verified for every package
- consumer validation passed in `~/work/컴윗` with React/Core resolved to `7.0.2`