### PR TITLE
fix(core): distinguish explicit forward navigation

### DIFF
--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -5,7 +5,7 @@ replacing the application router.
 
 Router agnostic. Cross-browser. SSR ready. Web Animations API powered.
 
-Current version: `@ssgoi/core@7.0.4`. Every `@ssgoi/*` framework package
+Current version: `@ssgoi/core@7.1.0-beta.0`. Every `@ssgoi/*` framework package
 is released in lockstep with core, so install the same version across them.
 
 This file contains the minimal Next.js App Router setup. The root React package

--- a/apps/docs/src/page/docs/guide-pages.tsx
+++ b/apps/docs/src/page/docs/guide-pages.tsx
@@ -556,13 +556,11 @@ export function RouteRulesBody() {
         <p className={`mt-4 ${body}`}>
           When both routes are inside the same{" "}
           <code className={inlineCode}>on</code> scope, SSGOI cannot tell
-          entering from leaving, so it falls back to its own history tracking: a
-          destination it recognises as the route you came from — or any
-          navigation that followed a{" "}
-          <code className={inlineCode}>popstate</code> — counts as backward.
-          That is SSGOI&apos;s route stack, not the browser&apos;s, so a
-          &ldquo;back&rdquo; button implemented with{" "}
-          <code className={inlineCode}>push()</code> still reads as backward.
+          entering from leaving, so it uses the browser navigation signal. A
+          navigation following <code className={inlineCode}>popstate</code>
+          counts as backward; explicit router navigation such as{" "}
+          <code className={inlineCode}>push()</code> counts as forward, even
+          when it returns to the previous path.
         </p>
       </Section>
 

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/angular",
-  "version": "7.0.4",
+  "version": "7.1.0-beta.0",
   "description": "Angular bindings for SSGOI - Native app-like page transitions for Angular applications",
   "private": false,
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/core",
-  "version": "7.0.4",
+  "version": "7.1.0-beta.0",
   "description": "Core animation engine for SSGOI - Native app-like page transitions with spring physics",
   "private": false,
   "type": "module",

--- a/packages/core/src/lib/ssgoi-transition/navigation-direction.test.ts
+++ b/packages/core/src/lib/ssgoi-transition/navigation-direction.test.ts
@@ -6,11 +6,11 @@ afterEach(() => {
 });
 
 describe("navigation direction tracker", () => {
-  it("treats a push to the immediately previous path as backward", () => {
+  it("keeps an explicit navigation to the previous path forward", () => {
     const tracker = createNavigationDirectionTracker();
     expect(tracker.resolve("/", "/posts")).toBe("forward");
     expect(tracker.resolve("/posts", "/posts/1")).toBe("forward");
-    expect(tracker.resolve("/posts/1", "/posts")).toBe("backward");
+    expect(tracker.resolve("/posts/1", "/posts")).toBe("forward");
     tracker.dispose();
   });
 

--- a/packages/core/src/lib/ssgoi-transition/navigation-direction.ts
+++ b/packages/core/src/lib/ssgoi-transition/navigation-direction.ts
@@ -1,5 +1,4 @@
 import type { NavigationDirection } from "@types";
-import { normalizePath } from "./path-pattern";
 
 export interface NavigationDirectionTracker {
   resolve(from: string, to: string): NavigationDirection;
@@ -7,13 +6,11 @@ export interface NavigationDirectionTracker {
 }
 
 /**
- * Lightweight semantic history used only where a route rule cannot determine
- * direction from its own boundary/order. A browser pop wins; otherwise a
- * navigation to the immediately previous route is backward even when an app
- * implemented its back button with push().
+ * Navigation hint used only where a route rule cannot determine direction
+ * from its own boundary/order. A browser pop is backward; every explicit
+ * navigation is forward, even when its destination equals the previous path.
  */
 export function createNavigationDirectionTracker(): NavigationDirectionTracker {
-  const stack: string[] = [];
   let popPending = false;
   const onPopState = () => {
     popPending = true;
@@ -24,31 +21,11 @@ export function createNavigationDirectionTracker(): NavigationDirectionTracker {
   }
 
   return {
-    resolve(rawFrom, rawTo) {
-      const from = normalizePath(rawFrom);
-      const to = normalizePath(rawTo);
-
-      if (stack.length === 0) {
-        stack.push(from);
-      } else if (stack[stack.length - 1] !== from) {
-        const knownFrom = stack.lastIndexOf(from);
-        if (knownFrom >= 0) stack.splice(knownFrom + 1);
-        else stack.push(from);
-      }
-
-      const previous = stack[stack.length - 2];
-      const direction: NavigationDirection =
-        popPending || previous === to ? "backward" : "forward";
+    resolve(_rawFrom, _rawTo) {
+      const direction: NavigationDirection = popPending
+        ? "backward"
+        : "forward";
       popPending = false;
-
-      if (direction === "backward") {
-        const knownTo = stack.lastIndexOf(to);
-        if (knownTo >= 0) stack.splice(knownTo + 1);
-        else stack.push(to);
-      } else if (stack[stack.length - 1] !== to) {
-        stack.push(to);
-      }
-
       return direction;
     },
     dispose() {

--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/qwik",
-  "version": "7.0.4",
+  "version": "7.1.0-beta.0",
   "description": "Qwik bindings for SSGOI - Native app-like page transitions for Qwik and Qwik City applications",
   "private": false,
   "sideEffects": false,

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/react-native",
-  "version": "7.0.4",
+  "version": "7.1.0-beta.0",
   "description": "React Native screen transitions for SSGOI with optional Expo Router integration",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/react",
-  "version": "7.0.4",
+  "version": "7.1.0-beta.0",
   "description": "React bindings for SSGOI - Native app-like page transitions for React applications",
   "private": false,
   "type": "module",
@@ -97,6 +97,8 @@
     "@babel/core": "^7.26.10"
   },
   "devDependencies": {
+    "@babel/traverse": "7.28.5",
+    "@babel/types": "7.28.5",
     "@types/babel__core": "^7.20.5",
     "@eslint/js": "^9.30.1",
     "@types/react": "^19.1.8",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/solid",
-  "version": "7.0.4",
+  "version": "7.1.0-beta.0",
   "description": "Solid.js bindings for SSGOI - Native app-like page transitions for Solid applications",
   "private": false,
   "type": "module",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/svelte",
-  "version": "7.0.4",
+  "version": "7.1.0-beta.0",
   "description": "Svelte bindings for SSGOI - Native app-like page transitions for Svelte and SvelteKit applications",
   "private": false,
   "main": "./dist/index.js",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/vue",
-  "version": "7.0.4",
+  "version": "7.1.0-beta.0",
   "description": "Vue bindings for SSGOI - Native app-like page transitions for Vue applications",
   "private": false,
   "type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -384,6 +384,12 @@ importers:
         specifier: ^2.3.2
         version: 2.3.10
     devDependencies:
+      '@babel/traverse':
+        specifier: 7.28.5
+        version: 7.28.5
+      '@babel/types':
+        specifier: 7.28.5
+        version: 7.28.5
       '@eslint/js':
         specifier: ^9.30.1
         version: 9.39.0
@@ -1435,10 +1441,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.4.0 || ^8.0.0-0 <8.0.0
 
-  '@babel/helper-globals@7.28.0':
-    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-globals@7.29.7':
     resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
     engines: {node: '>=6.9.0'}
@@ -1511,16 +1513,8 @@ packages:
     resolution: {integrity: sha512-brcMGQaVzIeUb+6/bs1Av0f8YuNNjKY2JyvfRCsFuFsdKccEQ5Ges2y74D74NZ1Rz8lKJ9ksJkfqwQFJ/iNEyQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@7.27.1':
-    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.29.7':
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/helper-validator-identifier@7.28.5':
-    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.29.7':
@@ -14501,13 +14495,13 @@ snapshots:
 
   '@babel/code-frame@7.26.2':
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
   '@babel/code-frame@7.27.1':
     dependencies:
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       js-tokens: 4.0.0
       picocolors: 1.1.1
 
@@ -14563,7 +14557,7 @@ snapshots:
 
   '@babel/generator@7.28.5':
     dependencies:
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.8
       '@babel/types': 7.28.5
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
@@ -14645,8 +14639,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-globals@7.28.0': {}
-
   '@babel/helper-globals@7.29.7': {}
 
   '@babel/helper-member-expression-to-functions@7.28.5':
@@ -14685,7 +14677,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.3
       '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
@@ -14694,7 +14686,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.5
       '@babel/helper-module-imports': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.28.5
     transitivePeerDependencies:
       - supports-color
@@ -14752,11 +14744,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-string-parser@7.27.1': {}
-
   '@babel/helper-string-parser@7.29.7': {}
-
-  '@babel/helper-validator-identifier@7.28.5': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
 
@@ -14774,7 +14762,7 @@ snapshots:
 
   '@babel/helpers@7.28.4':
     dependencies:
-      '@babel/template': 7.27.2
+      '@babel/template': 7.29.7
       '@babel/types': 7.28.5
 
   '@babel/parser@7.28.5':
@@ -15160,8 +15148,8 @@ snapshots:
 
   '@babel/template@7.27.2':
     dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.28.5
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.8
       '@babel/types': 7.28.5
 
   '@babel/template@7.29.7':
@@ -15172,11 +15160,11 @@ snapshots:
 
   '@babel/traverse@7.28.5':
     dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.5
-      '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.28.5
-      '@babel/template': 7.27.2
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.8
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/template': 7.29.7
       '@babel/types': 7.28.5
       debug: 4.4.3
     transitivePeerDependencies:
@@ -15196,8 +15184,8 @@ snapshots:
 
   '@babel/types@7.28.5':
     dependencies:
-      '@babel/helper-string-parser': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@babel/types@7.29.8':
     dependencies:
@@ -15937,12 +15925,12 @@ snapshots:
 
   '@expo/json-file@10.2.0':
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.7
       json5: 2.2.3
 
   '@expo/json-file@11.0.1':
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.7
       json5: 2.2.3
 
   '@expo/local-build-cache-provider@56.0.12(typescript@5.8.3)':
@@ -16077,7 +16065,7 @@ snapshots:
 
   '@expo/require-utils@56.1.7(typescript@5.8.3)':
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.7
       '@babel/core': 7.28.5
       '@babel/plugin-transform-modules-commonjs': 7.27.1(@babel/core@7.28.5)
     optionalDependencies:
@@ -16131,7 +16119,7 @@ snapshots:
 
   '@expo/xcpretty@4.4.5':
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.7
       chalk: 4.1.2
       js-yaml: 4.1.0
 
@@ -19475,8 +19463,8 @@ snapshots:
   '@tanstack/router-utils@1.143.11':
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/generator': 7.28.5
-      '@babel/parser': 7.28.5
+      '@babel/generator': 7.29.8
+      '@babel/parser': 7.29.8
       ansis: 4.2.0
       diff: 8.0.2
       pathe: 2.0.3
@@ -19490,7 +19478,7 @@ snapshots:
       '@babel/core': 7.28.5
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
       '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.5)
-      '@babel/template': 7.27.2
+      '@babel/template': 7.29.7
       '@babel/traverse': 7.28.5
       '@babel/types': 7.28.5
       '@tanstack/directive-functions-plugin': 1.121.21(vite@7.2.7(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -20250,7 +20238,7 @@ snapshots:
 
   '@vinxi/plugin-directives@0.5.1(vinxi@0.5.11(@types/node@24.10.3)(aws4fetch@1.0.20)(db0@0.3.4)(encoding@0.1.13)(ioredis@5.8.2)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.8
       acorn: 8.15.0
       acorn-jsx: 5.3.2(acorn@8.15.0)
       acorn-loose: 8.5.2
@@ -20445,7 +20433,7 @@ snapshots:
       '@babel/helper-module-imports': 7.27.1
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
-      '@babel/template': 7.27.2
+      '@babel/template': 7.29.7
       '@babel/traverse': 7.28.5
       '@babel/types': 7.28.5
       '@vue/babel-helper-vue-transform-on': 2.0.1
@@ -20458,18 +20446,18 @@ snapshots:
 
   '@vue/babel-plugin-resolve-type@2.0.1(@babel/core@7.28.5)':
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.7
       '@babel/core': 7.28.5
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.8
       '@vue/compiler-sfc': 3.5.22
     transitivePeerDependencies:
       - supports-color
 
   '@vue/compiler-core@3.5.22':
     dependencies:
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.8
       '@vue/shared': 3.5.22
       entities: 4.5.0
       estree-walker: 2.0.2
@@ -20477,7 +20465,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.26':
     dependencies:
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.8
       '@vue/shared': 3.5.26
       entities: 7.0.0
       estree-walker: 2.0.2
@@ -20495,7 +20483,7 @@ snapshots:
 
   '@vue/compiler-sfc@3.5.22':
     dependencies:
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.8
       '@vue/compiler-core': 3.5.22
       '@vue/compiler-dom': 3.5.22
       '@vue/compiler-ssr': 3.5.22
@@ -20507,7 +20495,7 @@ snapshots:
 
   '@vue/compiler-sfc@3.5.26':
     dependencies:
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.8
       '@vue/compiler-core': 3.5.26
       '@vue/compiler-dom': 3.5.26
       '@vue/compiler-ssr': 3.5.26
@@ -21085,7 +21073,7 @@ snapshots:
 
   ast-kit@2.1.3:
     dependencies:
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.8
       pathe: 2.0.3
 
   ast-types-flow@0.0.8: {}
@@ -21096,7 +21084,7 @@ snapshots:
 
   ast-walker-scope@0.8.3:
     dependencies:
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.8
       ast-kit: 2.1.3
 
   astring@1.9.0: {}
@@ -21144,7 +21132,7 @@ snapshots:
   babel-dead-code-elimination@1.0.10:
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.8
       '@babel/traverse': 7.28.5
       '@babel/types': 7.28.5
     transitivePeerDependencies:
@@ -21153,7 +21141,7 @@ snapshots:
   babel-dead-code-elimination@1.0.11:
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.8
       '@babel/traverse': 7.28.5
       '@babel/types': 7.28.5
     transitivePeerDependencies:
@@ -21184,7 +21172,7 @@ snapshots:
 
   babel-plugin-jest-hoist@29.6.3:
     dependencies:
-      '@babel/template': 7.27.2
+      '@babel/template': 7.29.7
       '@babel/types': 7.28.5
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.28.0
@@ -21224,7 +21212,7 @@ snapshots:
 
   babel-plugin-react-compiler@1.0.0:
     dependencies:
-      '@babel/types': 7.29.8
+      '@babel/types': 7.28.5
 
   babel-plugin-react-native-web@0.21.2: {}
 
@@ -22534,8 +22522,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.0
       eslint: 9.39.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.0(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.0(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.0(jiti@2.6.1))
@@ -22554,8 +22542,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.6
       eslint: 9.39.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.0(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.0(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.0(jiti@2.6.1))
@@ -22574,8 +22562,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.3.0-canary.106(eslint@9.39.0(jiti@2.6.1))
       eslint: 9.39.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.0(jiti@2.6.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.0(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.0(jiti@2.6.1))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.0(jiti@2.6.1))
@@ -22601,7 +22589,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.0(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -22612,21 +22600,21 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.0(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       eslint: 9.39.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.0(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.0(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -22637,7 +22625,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.0(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1)))(eslint@9.39.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -24221,7 +24209,7 @@ snapshots:
   istanbul-lib-instrument@5.2.1:
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.8
       '@istanbuljs/schema': 0.1.6
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -24231,7 +24219,7 @@ snapshots:
   istanbul-lib-instrument@6.0.3:
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.8
       '@istanbuljs/schema': 0.1.6
       istanbul-lib-coverage: 3.2.2
       semver: 7.8.5
@@ -24524,7 +24512,7 @@ snapshots:
 
   jest-message-util@29.7.0:
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.7
       '@jest/types': 29.6.3
       '@types/stack-utils': 2.0.3
       chalk: 4.1.2
@@ -24621,7 +24609,7 @@ snapshots:
   jest-snapshot@29.7.0:
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/generator': 7.28.5
+      '@babel/generator': 7.29.8
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.5)
       '@babel/plugin-syntax-typescript': 7.27.1(@babel/core@7.28.5)
       '@babel/types': 7.28.5
@@ -25175,13 +25163,13 @@ snapshots:
 
   magicast@0.2.11:
     dependencies:
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.8
       '@babel/types': 7.28.5
       recast: 0.23.11
 
   magicast@0.5.1:
     dependencies:
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.8
       '@babel/types': 7.28.5
       source-map-js: 1.2.1
 
@@ -27030,7 +27018,7 @@ snapshots:
 
   parse-json@5.2.0:
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.7
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -28529,7 +28517,7 @@ snapshots:
 
   solid-refresh@0.6.3(solid-js@1.9.13):
     dependencies:
-      '@babel/generator': 7.28.5
+      '@babel/generator': 7.29.8
       '@babel/helper-module-imports': 7.27.1
       '@babel/types': 7.28.5
       solid-js: 1.9.13
@@ -29397,7 +29385,7 @@ snapshots:
 
   unplugin-vue-router@0.19.1(@vue/compiler-sfc@3.5.26)(typescript@5.8.3)(vue-router@4.6.3(vue@3.5.22(typescript@5.8.3)))(vue@3.5.26(typescript@5.8.3)):
     dependencies:
-      '@babel/generator': 7.28.5
+      '@babel/generator': 7.29.8
       '@vue-macros/common': 3.1.1(vue@3.5.26(typescript@5.8.3))
       '@vue/compiler-sfc': 3.5.26
       '@vue/language-core': 3.1.8(typescript@5.8.3)
@@ -29423,7 +29411,7 @@ snapshots:
 
   unplugin-vue-router@0.19.1(@vue/compiler-sfc@3.5.26)(typescript@5.9.3)(vue-router@4.6.3(vue@3.5.26(typescript@5.9.3)))(vue@3.5.26(typescript@5.9.3)):
     dependencies:
-      '@babel/generator': 7.28.5
+      '@babel/generator': 7.29.8
       '@vue-macros/common': 3.1.1(vue@3.5.26(typescript@5.9.3))
       '@vue/compiler-sfc': 3.5.26
       '@vue/language-core': 3.1.8(typescript@5.9.3)
@@ -29820,7 +29808,7 @@ snapshots:
 
   vite-plugin-checker@0.12.0(eslint@9.39.0(jiti@2.6.1))(optionator@0.9.4)(typescript@5.8.3)(vite@7.2.7(@types/node@24.10.3)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.8.3)):
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.7
       chokidar: 4.0.3
       npm-run-path: 6.0.0
       picocolors: 1.1.1
@@ -29837,7 +29825,7 @@ snapshots:
 
   vite-plugin-checker@0.12.0(optionator@0.9.4)(typescript@5.9.3)(vite@7.2.7(@types/node@24.10.3)(jiti@1.21.7)(less@4.4.2)(lightningcss@1.30.2)(sass@1.93.3)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.2)):
     dependencies:
-      '@babel/code-frame': 7.27.1
+      '@babel/code-frame': 7.29.7
       chokidar: 4.0.3
       npm-run-path: 6.0.0
       picocolors: 1.1.1

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { readFileSync, writeFileSync, readdirSync } from "node:fs";
-import { join, dirname } from "node:path";
+import { join, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
@@ -16,7 +16,7 @@ export const discoverPackages = () =>
     .filter((rel) => {
       try {
         const pkg = JSON.parse(
-          readFileSync(join(ROOT, rel, "package.json"), "utf8")
+          readFileSync(join(ROOT, rel, "package.json"), "utf8"),
         );
         return !pkg.private;
       } catch {
@@ -26,10 +26,42 @@ export const discoverPackages = () =>
 
 const read = (p) =>
   JSON.parse(readFileSync(join(ROOT, p, "package.json"), "utf8"));
+
+const SEMVER_RE =
+  /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
+const parseSemVer = (version) => {
+  const match = SEMVER_RE.exec(version);
+  if (!match) throw new Error(`Invalid version: ${version}`);
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+    prerelease: match[4]?.split(".") ?? [],
+  };
+};
+const comparePrerelease = (a, b) => {
+  if (!a.length || !b.length) return a.length ? -1 : b.length ? 1 : 0;
+  for (let index = 0; index < Math.max(a.length, b.length); index += 1) {
+    if (a[index] === undefined) return -1;
+    if (b[index] === undefined) return 1;
+    if (a[index] === b[index]) continue;
+    const aNumeric = /^\d+$/.test(a[index]);
+    const bNumeric = /^\d+$/.test(b[index]);
+    if (aNumeric && bNumeric) return Number(a[index]) - Number(b[index]);
+    if (aNumeric !== bNumeric) return aNumeric ? -1 : 1;
+    return a[index].localeCompare(b[index]);
+  }
+  return 0;
+};
 const cmp = (a, b) => {
-  const A = a.split(".").map(Number);
-  const B = b.split(".").map(Number);
-  return A[0] - B[0] || A[1] - B[1] || A[2] - B[2];
+  const A = parseSemVer(a);
+  const B = parseSemVer(b);
+  return (
+    A.major - B.major ||
+    A.minor - B.minor ||
+    A.patch - B.patch ||
+    comparePrerelease(A.prerelease, B.prerelease)
+  );
 };
 
 // Resolve the next lockstep version and (unless write:false) apply it to every
@@ -37,13 +69,16 @@ const cmp = (a, b) => {
 export function bump(arg, { write = true } = {}) {
   const PKGS = discoverPackages();
   const current = PKGS.map((p) => ({ p, v: read(p).version }));
-  const max = current.map((x) => x.v).sort(cmp).at(-1);
+  const max = current
+    .map((x) => x.v)
+    .sort(cmp)
+    .at(-1);
 
   let next;
-  if (/^\d+\.\d+\.\d+$/.test(arg)) {
+  if (SEMVER_RE.test(arg)) {
     next = arg;
   } else {
-    const [maj, min, pat] = max.split(".").map(Number);
+    const { major: maj, minor: min, patch: pat } = parseSemVer(max);
     if (arg === "major") next = `${maj + 1}.0.0`;
     else if (arg === "minor") next = `${maj}.${min + 1}.0`;
     else if (arg === "patch") next = `${maj}.${min}.${pat + 1}`;
@@ -56,7 +91,7 @@ export function bump(arg, { write = true } = {}) {
 
   console.log(
     `${write ? "Bumping" : "[dry] would bump"} ${PKGS.length} packages ` +
-      `(lockstep): max ${max} -> ${next}\n`
+      `(lockstep): max ${max} -> ${next}\n`,
   );
   for (const { p, v } of current) {
     if (write) {
@@ -69,7 +104,9 @@ export function bump(arg, { write = true } = {}) {
     }
     console.log(`  ${p}: ${v} -> ${next}`);
   }
-  console.log(`\n${write ? "Done. All packages now at" : "[dry] target"} ${next}.`);
+  console.log(
+    `\n${write ? "Done. All packages now at" : "[dry] target"} ${next}.`,
+  );
   return next;
 }
 
@@ -79,7 +116,10 @@ export function bump(arg, { write = true } = {}) {
 export function syncToCurrent({ write = true } = {}) {
   const PKGS = discoverPackages();
   const current = PKGS.map((p) => ({ p, v: read(p).version }));
-  const max = current.map((x) => x.v).sort(cmp).at(-1);
+  const max = current
+    .map((x) => x.v)
+    .sort(cmp)
+    .at(-1);
   const laggards = current.filter((x) => cmp(x.v, max) < 0);
 
   if (!laggards.length) {
@@ -89,7 +129,7 @@ export function syncToCurrent({ write = true } = {}) {
 
   console.log(
     `${write ? "Syncing" : "[dry] would sync"} ${laggards.length} package(s) ` +
-      `up to current ${max}\n`
+      `up to current ${max}\n`,
   );
   for (const { p, v } of current) {
     if (cmp(v, max) >= 0) continue;
@@ -103,16 +143,22 @@ export function syncToCurrent({ write = true } = {}) {
     }
     console.log(`  ${p}: ${v} -> ${max}`);
   }
-  console.log(`\n${write ? "Done. All packages now at" : "[dry] target"} ${max}.`);
+  console.log(
+    `\n${write ? "Done. All packages now at" : "[dry] target"} ${max}.`,
+  );
   return max;
 }
 
-// Allow running standalone: `node scripts/bump-version.mjs <major|minor|patch|x.y.z>`
-if (import.meta.url === `file://${process.argv[1]}`) {
+// Allow running standalone:
+// `node scripts/bump-version.mjs <major|minor|patch|x.y.z[-prerelease]>`
+if (
+  process.argv[1] &&
+  fileURLToPath(import.meta.url) === resolve(process.argv[1])
+) {
   const arg = process.argv[2];
   if (!arg) {
     console.error(
-      "Usage: node scripts/bump-version.mjs <major|minor|patch|x.y.z>"
+      "Usage: node scripts/bump-version.mjs <major|minor|patch|x.y.z[-prerelease]>",
     );
     process.exit(1);
   }

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -44,7 +44,9 @@ const version = arg
 // 2) Build. pnpm -r runs in dependency order (core before the adapters).
 if (!run("pnpm", ["-r", "--filter", "./packages/*", "run", "build"])) {
   if (!dry) {
-    console.error("\n✗ Build failed — rolling back version changes. Nothing published.");
+    console.error(
+      "\n✗ Build failed — rolling back version changes. Nothing published.",
+    );
     rollback();
   } else {
     console.error("\n✗ Build failed (dry run — nothing was written).");
@@ -53,18 +55,34 @@ if (!run("pnpm", ["-r", "--filter", "./packages/*", "run", "build"])) {
 }
 
 if (noPublish) {
-  console.log(`\n✓ Build OK at ${version}. --no-publish set, skipping publish.`);
+  console.log(
+    `\n✓ Build OK at ${version}. --no-publish set, skipping publish.`,
+  );
   process.exit(0);
 }
 
 // 3) Publish. workspace:^ is rewritten to ^<version> on publish.
-const pubArgs = ["-r", "--filter", "./packages/*", "publish", "--access", "public", "--no-git-checks"];
+const pubArgs = [
+  "-r",
+  "--filter",
+  "./packages/*",
+  "publish",
+  "--access",
+  "public",
+  "--no-git-checks",
+];
+const prereleaseTag = version.match(/-([0-9A-Za-z-]+)/)?.[1];
+if (prereleaseTag) pubArgs.push("--tag", prereleaseTag);
 if (dry) pubArgs.push("--dry-run");
 if (!run("pnpm", pubArgs)) {
   // Do NOT roll back here: a publish may have partially succeeded on npm, and
   // reverting local versions would desync git from what's already published.
-  console.error("\n✗ Publish failed. Versions left as-is — fix and re-run; npm rejects duplicate versions.");
+  console.error(
+    "\n✗ Publish failed. Versions left as-is — fix and re-run; npm rejects duplicate versions.",
+  );
   process.exit(1);
 }
 
-console.log(`\n✓ Released @ssgoi/* at ${version}${dry ? " (dry run — nothing published)" : ""}`);
+console.log(
+  `\n✓ Released @ssgoi/* at ${version}${dry ? " (dry run — nothing published)" : ""}`,
+);


### PR DESCRIPTION
## Summary

- treat explicit router navigation as forward even when it returns to the previous path
- keep popstate-triggered navigation backward
- release all lockstep packages as 7.1.0-beta.0 with the npm beta tag
- support prerelease semver in the release scripts and pin React Babel types for reproducible builds

## Validation

- pnpm --filter @ssgoi/core test:run (116 tests)
- pnpm --filter @ssgoi/core lint
- pnpm --filter @ssgoi/react lint
- pnpm release --no-publish (all 8 packages)