### PR TITLE
fix(core): preserve selected effects across history traversal

### DIFF
--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -5,7 +5,7 @@ replacing the application router.
 
 Router agnostic. Cross-browser. SSR ready. Web Animations API powered.
 
-Current version: `@ssgoi/core@7.1.0-beta.3`. Every `@ssgoi/*` framework package
+Current version: `@ssgoi/core@7.1.0-beta.4`. Every `@ssgoi/*` framework package
 is released in lockstep with core, so install the same version across them.
 
 This file contains the minimal Next.js App Router setup. The root React package

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -5,7 +5,7 @@ replacing the application router.
 
 Router agnostic. Cross-browser. SSR ready. Web Animations API powered.
 
-Current version: `@ssgoi/core@7.1.0-beta.0`. Every `@ssgoi/*` framework package
+Current version: `@ssgoi/core@7.1.0-beta.2`. Every `@ssgoi/*` framework package
 is released in lockstep with core, so install the same version across them.
 
 This file contains the minimal Next.js App Router setup. The root React package

--- a/apps/docs/public/llms.txt
+++ b/apps/docs/public/llms.txt
@@ -5,7 +5,7 @@ replacing the application router.
 
 Router agnostic. Cross-browser. SSR ready. Web Animations API powered.
 
-Current version: `@ssgoi/core@7.1.0-beta.2`. Every `@ssgoi/*` framework package
+Current version: `@ssgoi/core@7.1.0-beta.3`. Every `@ssgoi/*` framework package
 is released in lockstep with core, so install the same version across them.
 
 This file contains the minimal Next.js App Router setup. The root React package
@@ -200,6 +200,10 @@ const config = {
 - `from` / `to` defines a precise pair, bidirectional by default. Set
   `bidirectional: false` for a one-way pair.
 - `ordered` derives direction from path order.
+
+On web, Back to an observed entry's source reuses its recorded effect with
+direction and scroll endpoints reversed; Forward replays the original choice.
+Links/push/replace match current rules. Unrecorded returns also rematch.
 
 Wildcards, arrays, priority, matching order, and mobile/desktop configs:
 https://ssgoi.dev/llms/route-rules.txt

--- a/apps/docs/public/llms/route-rules.txt
+++ b/apps/docs/public/llms/route-rules.txt
@@ -5,6 +5,32 @@ relationship receives an effect and what forward/backward means.
 
 Main setup: https://ssgoi.dev/llms.txt
 
+## Browser Back and Forward
+
+On web, SSGOI remembers the selected effect, semantic direction, and physical
+scroll policy for each observed pushed history entry. Back to that entry's
+source reuses the same effect with its direction and scroll endpoints reversed.
+Forward to that entry replays the original selection. This also works when the
+entry rule has `bidirectional: false`: undoing an observed visit does not need
+another matching rule.
+
+Links, push, and replace always match the current rules below. A fresh push to
+the same URL is a new visit; it does not reuse an older visit's effect. The rule
+still determines semantic direction (`ordered` and explicit pairs retain their
+orientation). Within one `on` scope, a fresh push defaults to forward.
+
+Only exact observed entry pairs are replayed. Reloads/provider disconnection,
+unknown entries, replacements of a route, and multi-step jumps without a saved
+direct pair use current matching. The last 100 entry effects are retained in
+memory, without page DOM or animation instances. Pushing after Back discards
+the old forward branch. The portable native rule matcher is unchanged.
+
+Entry identity comes from the Navigation API where available. Older browsers
+use an `__ssgoi_entry_v1` field in null/plain-object history.state while keeping
+router fields. Primitive/array state is not reshaped and cannot support recorded
+replay there. Observation starts on boundary registration and is released when
+the root observer disconnects; manual integrations can call context.disconnect().
+
 ## `on` and `except`
 
 Use `on` for a route family. Entering the scope is forward, leaving is

--- a/apps/docs/public/llms/route-rules.txt
+++ b/apps/docs/public/llms/route-rules.txt
@@ -25,10 +25,12 @@ direct pair use current matching. The last 100 entry effects are retained in
 memory, without page DOM or animation instances. Pushing after Back discards
 the old forward branch. The portable native rule matcher is unchanged.
 
-Entry identity comes from the Navigation API where available. Older browsers
-use an `__ssgoi_entry_v1` field in null/plain-object history.state while keeping
-router fields. Primitive/array state is not reshaped and cannot support recorded
-replay there. Observation starts on boundary registration and is released when
+History API commits carry an `__ssgoi_entry_v1` field in null/plain-object
+history.state while keeping router fields. This is authoritative even when a
+browser exposes a Navigation API whose entries lag behind pushState. Native
+entry identity is a fallback for opaque state only when its URL matches the
+committed location. Primitive/array state is never reshaped; without reliable
+native entry identity it cannot support replay. Observation starts on boundary registration and is released when
 the root observer disconnects; manual integrations can call context.disconnect().
 
 ## `on` and `except`

--- a/apps/docs/public/llms/troubleshooting.txt
+++ b/apps/docs/public/llms/troubleshooting.txt
@@ -32,6 +32,25 @@ paint context:
 
 Also give routed pages a full-height background when the design requires one.
 
+## Back uses a different effect
+
+Rules are matched again for the return path pair; history direction does not
+remember or replay the entry rule. A `bidirectional: false` pair is excluded on
+its reverse, so the return may select a different fallback effect. Include the
+source (for example `/cart`) in a specific bidirectional supplier rule if that
+relationship should use the same effect on return. Keep it specific when other
+supplier relationships, such as opening a product, should use another effect.
+
+## The outgoing page paints beneath the incoming page
+
+Inspect ancestor stacking contexts as well as each boundary's z-index. A portal
+host with a high z-index traps its entire subtree above an ordinary sibling
+page, even when that outgoing sibling has the foreground z-index. Full-page
+route portals should share the page stacking context: keep the host mounted and
+positioned, but leave its z-index auto and avoid ancestor transform, opacity or
+isolation that would create a separate stacking context. Apply transition styles
+to the page boundaries themselves. Ordinary dialogs can keep their own layers.
+
 ## Scroll is unexpected
 
 Scroll behavior belongs to the matched route relationship, not to an effect.

--- a/apps/docs/public/llms/troubleshooting.txt
+++ b/apps/docs/public/llms/troubleshooting.txt
@@ -34,12 +34,12 @@ Also give routed pages a full-height background when the design requires one.
 
 ## Back uses a different effect
 
-Rules are matched again for the return path pair; history direction does not
-remember or replay the entry rule. A `bidirectional: false` pair is excluded on
-its reverse, so the return may select a different fallback effect. Include the
-source (for example `/cart`) in a specific bidirectional supplier rule if that
-relationship should use the same effect on return. Keep it specific when other
-supplier relationships, such as opening a product, should use another effect.
+Browser Back replays the effect recorded for the exact entry pair in reverse,
+even for a `bidirectional: false` entry rule. Confirm the button performs a
+history traversal: push/replace deliberately match the current rules instead.
+Also check that the same provider observed the entry and return. Reloads,
+untracked entries, replaced routes and unrecorded multi-step jumps must rematch.
+Details: https://ssgoi.dev/llms/route-rules.txt
 
 ## The outgoing page paints beneath the incoming page
 

--- a/apps/docs/src/page/docs/guide-pages.tsx
+++ b/apps/docs/src/page/docs/guide-pages.tsx
@@ -545,8 +545,8 @@ export function RouteRulesBody() {
           <code className={inlineCode}>to</code> pair matches in both
           orientations. Set{" "}
           <code className={inlineCode}>bidirectional: false</code> when only the
-          orientation you wrote should match at all — it does not mean &ldquo;
-          match, but always play forward&rdquo;.
+          orientation you wrote should match for a fresh navigation. Browser
+          Back can still undo an observed entry using its recorded effect.
         </p>
         <p className={`mt-4 ${body}`}>
           In an <code className={inlineCode}>ordered</code> array both routes
@@ -554,13 +554,14 @@ export function RouteRulesBody() {
           same one, the rule does not match.
         </p>
         <p className={`mt-4 ${body}`}>
-          When both routes are inside the same{" "}
-          <code className={inlineCode}>on</code> scope, SSGOI cannot tell
-          entering from leaving, so it uses the browser navigation signal. A
-          navigation following <code className={inlineCode}>popstate</code>
-          counts as backward; explicit router navigation such as{" "}
-          <code className={inlineCode}>push()</code> counts as forward, even
-          when it returns to the previous path.
+          Browser Back to a recorded entry&apos;s source uses the same effect
+          with reversed direction and scroll endpoints. Browser Forward replays
+          the original selection. Links and{" "}
+          <code className={inlineCode}>push()</code> match current rules, even
+          when revisiting the previous URL. Within one{" "}
+          <code className={inlineCode}>on</code> scope that fresh visit is
+          forward. Direct entries and unrecorded history pairs fall back to
+          current rules.
         </p>
       </Section>
 

--- a/apps/docs/src/page/docs/sections.tsx
+++ b/apps/docs/src/page/docs/sections.tsx
@@ -696,10 +696,10 @@ export function CompatibilityBody() {
       <Heading3>Your router keeps navigation</Heading3>
       <p className={`mt-3 ${measure} ${prose}`}>
         SSGOI watches the route boundary your framework already mounts and
-        unmounts. There is no replacement router and no navigation wrapper, and
-        it never writes to history — it only listens for{" "}
-        <code className={inlineCode}>popstate</code> to tell forward from
-        backward.
+        unmounts. It reads browser history entry identities to remember each
+        visit&apos;s effect. Where the Navigation API is unavailable, it wraps
+        pushState/replaceState to retain a namespaced entry marker alongside
+        existing router state. Your router still owns URLs and navigation.
       </p>
 
       <div className="mt-8">

--- a/apps/docs/src/page/docs/sections.tsx
+++ b/apps/docs/src/page/docs/sections.tsx
@@ -697,9 +697,10 @@ export function CompatibilityBody() {
       <p className={`mt-3 ${measure} ${prose}`}>
         SSGOI watches the route boundary your framework already mounts and
         unmounts. It reads browser history entry identities to remember each
-        visit&apos;s effect. Where the Navigation API is unavailable, it wraps
-        pushState/replaceState to retain a namespaced entry marker alongside
-        existing router state. Your router still owns URLs and navigation.
+        visit&apos;s effect. It wraps pushState/replaceState to retain a
+        namespaced entry marker alongside existing router state, even when
+        native entry information arrives late. Your router still owns URLs and
+        navigation.
       </p>
 
       <div className="mt-8">

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/angular",
-  "version": "7.1.0-beta.2",
+  "version": "7.1.0-beta.3",
   "description": "Angular bindings for SSGOI - Native app-like page transitions for Angular applications",
   "private": false,
   "type": "module",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/angular",
-  "version": "7.1.0-beta.0",
+  "version": "7.1.0-beta.2",
   "description": "Angular bindings for SSGOI - Native app-like page transitions for Angular applications",
   "private": false,
   "type": "module",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/angular",
-  "version": "7.1.0-beta.3",
+  "version": "7.1.0-beta.4",
   "description": "Angular bindings for SSGOI - Native app-like page transitions for Angular applications",
   "private": false,
   "type": "module",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -49,6 +49,9 @@ Rule forms:
 - `from`/`to`: precise pair. Reverse matching is enabled by default.
 - `ordered`: array order decides forward and backward.
 - `priority`: higher values win before path specificity.
+- Web Back reverses the effect recorded for the exact visited entry pair;
+  Forward replays it. Fresh push/replace rematch these rules. Unrecorded returns
+  also rematch. See [history behavior](https://ssgoi.dev/llms/route-rules.txt).
 - Scroll is automatic: `on` and `from`/`to` restore the forward `from` side
   and reset `to`; `ordered` restores both. Use
   `preserveScroll: { from: boolean, to: boolean }` for an exact override.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/core",
-  "version": "7.1.0-beta.0",
+  "version": "7.1.0-beta.2",
   "description": "Core animation engine for SSGOI - Native app-like page transitions with spring physics",
   "private": false,
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/core",
-  "version": "7.1.0-beta.3",
+  "version": "7.1.0-beta.4",
   "description": "Core animation engine for SSGOI - Native app-like page transitions with spring physics",
   "private": false,
   "type": "module",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/core",
-  "version": "7.1.0-beta.2",
+  "version": "7.1.0-beta.3",
   "description": "Core animation engine for SSGOI - Native app-like page transitions with spring physics",
   "private": false,
   "type": "module",

--- a/packages/core/src/lib/ssgoi-transition/browser-history.ts
+++ b/packages/core/src/lib/ssgoi-transition/browser-history.ts
@@ -1,0 +1,157 @@
+export type HistoryEntry = { key: string; index: number; url: string };
+
+type NavigationPort = {
+  currentEntry: HistoryEntry | null;
+  entries(): HistoryEntry[];
+};
+
+export type BrowserHistory = {
+  read(): HistoryEntry | null;
+  previous(): HistoryEntry | null;
+  dispose(): void;
+};
+
+const STATE_KEY = "__ssgoi_entry_v1";
+type SharedHistory = BrowserHistory & { users: number };
+const histories = new WeakMap<Window, SharedHistory>();
+const emptyHistory: BrowserHistory = {
+  read: () => null,
+  previous: () => null,
+  dispose() {},
+};
+
+/** Read committed entries, not a pending back() intent or a late popstate flag. */
+export function connectBrowserHistory(): BrowserHistory {
+  if (typeof window === "undefined") return emptyHistory;
+  const navigation = (window as Window & { navigation?: NavigationPort })
+    .navigation;
+  if (navigation?.currentEntry?.key && navigation.currentEntry.index >= 0) {
+    return {
+      read: () => snapshot(navigation.currentEntry),
+      previous: () => {
+        const index = navigation.currentEntry?.index;
+        return snapshot(
+          navigation.entries().find((e) => e.index === (index ?? 0) - 1),
+        );
+      },
+      dispose() {},
+    };
+  }
+
+  const target = window;
+  let shared = histories.get(target);
+  if (!shared) {
+    shared = createLegacyHistory(target);
+    histories.set(target, shared);
+  }
+  shared.users++;
+  const source = shared;
+  let released = false;
+  return {
+    read: source.read,
+    previous: source.previous,
+    dispose() {
+      if (released) return;
+      released = true;
+      if (--source.users === 0) {
+        source.dispose();
+        histories.delete(target);
+      }
+    },
+  };
+}
+
+function snapshot(entry: HistoryEntry | null | undefined): HistoryEntry | null {
+  return entry &&
+    typeof entry.key === "string" &&
+    typeof entry.url === "string" &&
+    Number.isSafeInteger(entry.index) &&
+    entry.index >= 0
+    ? { key: entry.key, index: entry.index, url: entry.url }
+    : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    Object.getPrototypeOf(value) === Object.prototype
+  );
+}
+
+/** Older browsers have no entry keys. Add only our namespaced state field. */
+function createLegacyHistory(target: Window): SharedHistory {
+  const history = target.history;
+  const push = history.pushState;
+  const replace = history.replaceState;
+  const prefix = `${Date.now()}-${Math.random().toString(36).slice(2)}-`;
+  let serial = 0;
+  let active = true;
+  let previous: HistoryEntry | null = null;
+  const read = (): HistoryEntry | null => {
+    const state: unknown = history.state;
+    const stamp = isRecord(state) ? state[STATE_KEY] : null;
+    if (
+      !isRecord(stamp) ||
+      typeof stamp.key !== "string" ||
+      !stamp.key.startsWith(prefix) ||
+      !Number.isSafeInteger(stamp.index)
+    )
+      return null;
+    return {
+      key: stamp.key,
+      index: stamp.index as number,
+      url: target.location.href,
+    };
+  };
+  const stamp = (data: unknown, entry: { key: string; index: number }) => {
+    // Do not turn primitive, array or structured state into a different shape.
+    if (data !== null && !isRecord(data)) return data;
+    return { ...data, [STATE_KEY]: entry };
+  };
+  const fresh = (index: number) => ({ key: `${prefix}${++serial}`, index });
+
+  try {
+    replace.call(history, stamp(history.state, fresh(0)), "");
+  } catch {
+    // A sandbox may deny history writes. Keep route matching available.
+    return { ...emptyHistory, users: 0 };
+  }
+
+  const wrappedPush: History["pushState"] = function (
+    this: History,
+    data,
+    unused,
+    url,
+  ) {
+    if (!active) return push.call(this, data, unused, url);
+    const from = read();
+    const next = fresh((from?.index ?? 0) + 1);
+    push.call(this, stamp(data, next), unused, url);
+    previous = from;
+  };
+  const wrappedReplace: History["replaceState"] = function (
+    this: History,
+    data,
+    unused,
+    url,
+  ) {
+    if (!active) return replace.call(this, data, unused, url);
+    const current = read();
+    replace.call(this, stamp(data, current ?? fresh(0)), unused, url);
+  };
+  history.pushState = wrappedPush;
+  history.replaceState = wrappedReplace;
+
+  return {
+    users: 0,
+    read,
+    previous: () => previous,
+    dispose() {
+      active = false;
+      if (history.pushState === wrappedPush) history.pushState = push;
+      if (history.replaceState === wrappedReplace)
+        history.replaceState = replace;
+    },
+  };
+}

--- a/packages/core/src/lib/ssgoi-transition/browser-history.ts
+++ b/packages/core/src/lib/ssgoi-transition/browser-history.ts
@@ -25,23 +25,10 @@ export function connectBrowserHistory(): BrowserHistory {
   if (typeof window === "undefined") return emptyHistory;
   const navigation = (window as Window & { navigation?: NavigationPort })
     .navigation;
-  if (navigation?.currentEntry?.key && navigation.currentEntry.index >= 0) {
-    return {
-      read: () => snapshot(navigation.currentEntry),
-      previous: () => {
-        const index = navigation.currentEntry?.index;
-        return snapshot(
-          navigation.entries().find((e) => e.index === (index ?? 0) - 1),
-        );
-      },
-      dispose() {},
-    };
-  }
-
   const target = window;
   let shared = histories.get(target);
   if (!shared) {
-    shared = createLegacyHistory(target);
+    shared = createTrackedHistory(target, navigation);
     histories.set(target, shared);
   }
   shared.users++;
@@ -79,8 +66,16 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   );
 }
 
-/** Older browsers have no entry keys. Add only our namespaced state field. */
-function createLegacyHistory(target: Window): SharedHistory {
+/**
+ * History API commits are authoritative, including when a browser exposes a
+ * Navigation API whose currentEntry has not caught up. Merely detecting that
+ * API is insufficient: a push can otherwise look like replace and lose the
+ * selected entry effect. Keep one marker alongside the router's own state.
+ */
+function createTrackedHistory(
+  target: Window,
+  navigation?: NavigationPort,
+): SharedHistory {
   const history = target.history;
   const push = history.pushState;
   const replace = history.replaceState;
@@ -88,6 +83,13 @@ function createLegacyHistory(target: Window): SharedHistory {
   let serial = 0;
   let active = true;
   let previous: HistoryEntry | null = null;
+  let previousForKey: string | null = null;
+  const readNative = () => {
+    const entry = snapshot(navigation?.currentEntry);
+    // An opaque History state cannot carry our marker. Use native identity
+    // only if it describes the committed URL, never a stale previous page.
+    return entry?.url === target.location.href ? entry : null;
+  };
   const read = (): HistoryEntry | null => {
     const state: unknown = history.state;
     const stamp = isRecord(state) ? state[STATE_KEY] : null;
@@ -97,7 +99,7 @@ function createLegacyHistory(target: Window): SharedHistory {
       !stamp.key.startsWith(prefix) ||
       !Number.isSafeInteger(stamp.index)
     )
-      return null;
+      return readNative();
     return {
       key: stamp.key,
       index: stamp.index as number,
@@ -112,10 +114,14 @@ function createLegacyHistory(target: Window): SharedHistory {
   const fresh = (index: number) => ({ key: `${prefix}${++serial}`, index });
 
   try {
-    replace.call(history, stamp(history.state, fresh(0)), "");
+    replace.call(
+      history,
+      stamp(history.state, fresh(readNative()?.index ?? 0)),
+      "",
+    );
   } catch {
     // A sandbox may deny history writes. Keep route matching available.
-    return { ...emptyHistory, users: 0 };
+    return { ...emptyHistory, read: readNative, users: 0 };
   }
 
   const wrappedPush: History["pushState"] = function (
@@ -129,6 +135,7 @@ function createLegacyHistory(target: Window): SharedHistory {
     const next = fresh((from?.index ?? 0) + 1);
     push.call(this, stamp(data, next), unused, url);
     previous = from;
+    previousForKey = read()?.key ?? null;
   };
   const wrappedReplace: History["replaceState"] = function (
     this: History,
@@ -146,7 +153,15 @@ function createLegacyHistory(target: Window): SharedHistory {
   return {
     users: 0,
     read,
-    previous: () => previous,
+    previous: () => {
+      if (read()?.key === previousForKey) return previous;
+      const entry = readNative();
+      return entry
+        ? snapshot(
+            navigation?.entries().find((e) => e.index === entry.index - 1),
+          )
+        : null;
+    },
     dispose() {
       active = false;
       if (history.pushState === wrappedPush) history.pushState = push;

--- a/packages/core/src/lib/ssgoi-transition/create-ssgoi-transition-context.ts
+++ b/packages/core/src/lib/ssgoi-transition/create-ssgoi-transition-context.ts
@@ -14,7 +14,7 @@ import { prepareOutgoing, promiseAll } from "@utils";
 import { createContextManager } from "./create-context-manager";
 import { createSwipeBackDetector } from "./create-swipe-back-detector";
 import { resolveTransitionRule } from "./resolve-transition-rule";
-import { createNavigationDirectionTracker } from "./navigation-direction";
+import { createNavigationTransitionResolver } from "./navigation-transition";
 import { createNavigationDetector } from "./navigation-detector-strategy";
 import { watchUnmount, type UnmountAnchor } from "./unmount-observer";
 import { watchVisibility, type VisibilityHandle } from "./visibility-observer";
@@ -84,7 +84,8 @@ export function createSggoiTransitionContext(
     // side/path repeats before pairing, the outermost DOM boundary owns it.
     keepCurrent: ({ current, next }) => current.element.contains(next.element),
   });
-  const directionTracker = createNavigationDirectionTracker();
+  const navigationResolver =
+    createNavigationTransitionResolver<AnyTransitionConfig>();
 
   // Normalize both accepted shapes to the functional form up front so the rest
   // of the file deals with exactly one shape: a static list becomes a function
@@ -456,15 +457,16 @@ export function createSggoiTransitionContext(
         pair.to,
       );
 
-      const historyDirection = directionTracker.resolve(
-        transformedFrom,
-        transformedTo,
-      );
-      const resolved = resolveTransitionRule(
-        transformedFrom,
-        transformedTo,
-        getProcessedTransitions(),
-        historyDirection,
+      const resolved = navigationResolver.resolve(
+        pair.from,
+        pair.to,
+        (historyDirection) =>
+          resolveTransitionRule(
+            transformedFrom,
+            transformedTo,
+            getProcessedTransitions(),
+            historyDirection,
+          ),
       );
 
       // Reset is the safe fallback when no rule owns this navigation. The
@@ -648,6 +650,7 @@ export function createSggoiTransitionContext(
     element,
     { enter = true } = {},
   ) => {
+    navigationResolver.connect();
     if (registered.has(element)) {
       const state = hiddenState.get(element);
       if (state && state.currentPath !== path) {
@@ -731,5 +734,5 @@ export function createSggoiTransitionContext(
     return cb;
   };
 
-  return { register, refFor };
+  return { register, refFor, disconnect: navigationResolver.dispose };
 }

--- a/packages/core/src/lib/ssgoi-transition/navigation-direction.test.ts
+++ b/packages/core/src/lib/ssgoi-transition/navigation-direction.test.ts
@@ -1,89 +1,373 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createNavigationDirectionTracker } from "./navigation-direction";
+import { createNavigationTransitionResolver } from "./navigation-transition";
+import { resolveTransitionRule } from "../runtime/resolve-transition-rule";
+import type { RouteRule } from "../runtime/types";
+
+function browser(
+  modern: boolean,
+  initialState: unknown = { __NA: true, tree: "owned" },
+) {
+  let serial = 0;
+  let index = 0;
+  const entries = [
+    {
+      key: "initial",
+      index: 0,
+      url: "https://app.test/cart",
+      state: initialState,
+    },
+  ];
+  const target = {
+    location: {
+      get href() {
+        return entries[index]!.url;
+      },
+    },
+    history: {
+      get state() {
+        return entries[index]!.state;
+      },
+      pushState: vi.fn(
+        (data: unknown, _unused: string, url?: string | URL | null) => {
+          const href = new URL(url ?? entries[index]!.url, entries[index]!.url)
+            .href;
+          entries.splice(index + 1);
+          index++;
+          entries.push({
+            key: `entry-${++serial}`,
+            index,
+            url: href,
+            state: structuredClone(data),
+          });
+        },
+      ),
+      replaceState: vi.fn(
+        (data: unknown, _unused: string, url?: string | URL | null) => {
+          entries[index] = {
+            ...entries[index]!,
+            url: new URL(url ?? entries[index]!.url, entries[index]!.url).href,
+            state: structuredClone(data),
+          };
+        },
+      ),
+      back() {
+        if (index > 0) index--;
+      },
+      forward() {
+        if (index + 1 < entries.length) index++;
+      },
+      go(delta: number) {
+        if (index + delta >= 0 && index + delta < entries.length)
+          index += delta;
+      },
+    },
+    ...(modern
+      ? {
+          navigation: {
+            get currentEntry() {
+              return entries[index];
+            },
+            entries: () => entries,
+          },
+        }
+      : {}),
+  };
+  vi.stubGlobal("window", target);
+  return target;
+}
+
+const slide = { effect: "slide" };
+const parallax = { effect: "parallax" };
+const rules: RouteRule<typeof slide>[] = [
+  {
+    from: "/**",
+    to: "/shops/*",
+    bidirectional: false,
+    priority: 10,
+    transition: slide,
+  },
+  { on: "/**", priority: -100, transition: parallax },
+];
+const cleanups: (() => void)[] = [];
+function resolver() {
+  const history = createNavigationTransitionResolver<typeof slide>();
+  cleanups.push(history.dispose);
+  history.connect();
+  return {
+    ...history,
+    select: (from: string, to: string, config = rules) =>
+      history.resolve(from, to, (direction) =>
+        resolveTransitionRule(from, to, config, direction),
+      ),
+  };
+}
 
 afterEach(() => {
+  cleanups.splice(0).forEach((dispose) => dispose());
   vi.unstubAllGlobals();
 });
 
-describe("navigation direction tracker", () => {
-  it("keeps an explicit navigation to the previous path forward", () => {
-    const tracker = createNavigationDirectionTracker();
-    expect(tracker.resolve("/", "/posts")).toBe("forward");
-    expect(tracker.resolve("/posts", "/posts/1")).toBe("forward");
-    expect(tracker.resolve("/posts/1", "/posts")).toBe("forward");
-    tracker.dispose();
-  });
-
-  it("uses popstate as a backward hint for the next paired navigation", () => {
-    let popListener: (() => void) | undefined;
-    const addEventListener = vi.fn(
-      (_name: string, listener: () => void, _capture: boolean) => {
-        popListener = listener;
-      },
-    );
-    const removeEventListener = vi.fn();
-    const back = vi.fn();
-    const forward = vi.fn();
-    const go = vi.fn();
-    const history = { back, forward, go };
-    vi.stubGlobal("window", {
-      addEventListener,
-      removeEventListener,
-      history,
+describe.each([true, false])(
+  "entry transitions (Navigation API: %s)",
+  (modern) => {
+    it("reverses the exact entry effect on Back and replays it on Forward", () => {
+      const { history } = browser(modern);
+      const transitions = resolver();
+      history.pushState({ __NA: true }, "", "/shops/one");
+      const entry = transitions.select("/cart", "/shops/one");
+      expect(entry).toMatchObject({
+        transition: slide,
+        direction: "forward",
+        preserveScroll: { from: true, to: false },
+      });
+      history.back(); // The entry changes before any router/popstate callback.
+      const back = transitions.select("/shops/one", "/cart");
+      expect(back).toMatchObject({
+        transition: slide,
+        direction: "backward",
+        preserveScroll: { from: false, to: true },
+      });
+      history.forward();
+      expect(transitions.select("/cart", "/shops/one")).toEqual(entry);
     });
 
-    const tracker = createNavigationDirectionTracker();
-    expect(addEventListener).toHaveBeenCalledWith(
-      "popstate",
-      expect.any(Function),
-      true,
-    );
-    expect(tracker.resolve("/", "/posts")).toBe("forward");
-    popListener?.();
-    expect(tracker.resolve("/posts", "/some-known-by-router")).toBe("backward");
-    tracker.dispose();
-    expect(removeEventListener).toHaveBeenCalledWith(
-      "popstate",
-      popListener,
-      true,
-    );
-    expect(history).toEqual({ back, forward, go });
-  });
-
-  it("marks history traversal before popstate and ignores its late duplicate", () => {
-    let popListener: (() => void) | undefined;
-    const back = vi.fn();
-    const forward = vi.fn();
-    const go = vi.fn();
-    const history = { back, forward, go };
-    vi.stubGlobal("window", {
-      addEventListener: (
-        _name: string,
-        listener: () => void,
-        _capture: boolean,
-      ) => {
-        popListener = listener;
-      },
-      removeEventListener: vi.fn(),
-      history,
+    it("recognizes a restored entry even when the router replaces its state before pairing", () => {
+      const { history } = browser(modern);
+      const transitions = resolver();
+      history.pushState({ __NA: true }, "", "/shops/one");
+      transitions.select("/cart", "/shops/one");
+      history.back();
+      history.replaceState({ __NA: true, tree: "restored" }, "");
+      expect(transitions.select("/shops/one", "/cart")).toMatchObject({
+        transition: slide,
+        direction: "backward",
+      });
     });
 
+    it("undoes the original semantic direction rather than forcing every effect backward", () => {
+      const { history } = browser(modern);
+      const transitions = resolver();
+      history.pushState({}, "", "/products/one");
+      const entry = transitions.select("/cart", "/products/one", [
+        {
+          from: "/products/*",
+          to: "/cart",
+          transition: slide,
+        },
+      ]);
+      expect(entry?.direction).toBe("backward");
+      history.back();
+      expect(transitions.select("/products/one", "/cart")).toMatchObject({
+        transition: slide,
+        direction: "forward",
+        preserveScroll: { from: true, to: false },
+      });
+    });
+
+    it("fresh pushes to the same URL rematch instead of reusing a return effect", () => {
+      const { history } = browser(modern);
+      const transitions = resolver();
+      history.pushState({}, "", "/shops/one");
+      transitions.select("/cart", "/shops/one");
+      history.pushState({}, "", "/cart");
+      expect(transitions.select("/shops/one", "/cart")).toMatchObject({
+        transition: parallax,
+        direction: "forward",
+      });
+      history.back();
+      expect(transitions.select("/cart", "/shops/one")).toMatchObject({
+        transition: parallax,
+        direction: "backward",
+      });
+      history.back();
+      expect(transitions.select("/shops/one", "/cart")).toMatchObject({
+        transition: slide,
+        direction: "backward",
+      });
+    });
+
+    it("the next push after Back does not inherit a consumed backward hint", () => {
+      const { history } = browser(modern);
+      const transitions = resolver();
+      history.pushState({}, "", "/products/one");
+      transitions.select("/cart", "/products/one");
+      history.back();
+      transitions.select("/products/one", "/cart");
+      history.pushState({}, "", "/products/one");
+      expect(transitions.select("/cart", "/products/one")).toMatchObject({
+        direction: "forward",
+      });
+    });
+
+    it("discards replaced edges and matches a return to an unrecorded pair", () => {
+      const { history } = browser(modern);
+      const transitions = resolver();
+      history.pushState({}, "", "/shops/one");
+      transitions.select("/cart", "/shops/one");
+      history.replaceState({}, "", "/products/one");
+      transitions.select("/shops/one", "/products/one");
+      history.back();
+      expect(transitions.select("/products/one", "/cart")).toMatchObject({
+        transition: parallax,
+        direction: "backward",
+      });
+    });
+
+    it("a push after Back creates a new branch even when it reuses a URL", () => {
+      const { history } = browser(modern);
+      const transitions = resolver();
+      history.pushState({}, "", "/shops/one");
+      transitions.select("/cart", "/shops/one");
+      history.back();
+      transitions.select("/shops/one", "/cart");
+      history.pushState({}, "", "/shops/one");
+      transitions.select("/cart", "/shops/one", [
+        { on: "/**", transition: parallax },
+      ]);
+      history.back();
+      expect(transitions.select("/shops/one", "/cart")).toMatchObject({
+        transition: parallax,
+        direction: "backward",
+      });
+    });
+
+    it("no-op back/go calls cannot affect a later explicit navigation", () => {
+      const { history } = browser(modern);
+      const transitions = resolver();
+      history.back();
+      history.go(-5);
+      history.pushState({}, "", "/products/one");
+      expect(transitions.select("/cart", "/products/one")).toMatchObject({
+        direction: "forward",
+      });
+    });
+
+    it("rematches skipped multi-step pairs rather than replaying an unrelated effect", () => {
+      const { history } = browser(modern);
+      const transitions = resolver();
+      history.pushState({}, "", "/products/one");
+      transitions.select("/cart", "/products/one");
+      history.pushState({}, "", "/shops/one");
+      transitions.select("/products/one", "/shops/one");
+      history.go(-2);
+      expect(transitions.select("/shops/one", "/cart")).toMatchObject({
+        transition: parallax,
+        direction: "backward",
+      });
+    });
+
+    it("preserves the selected effect even if the current rule list changes", () => {
+      const { history } = browser(modern);
+      const transitions = resolver();
+      history.pushState({}, "", "/shops/one");
+      transitions.select("/cart", "/shops/one");
+      history.back();
+      expect(transitions.select("/shops/one", "/cart", [])).toMatchObject({
+        transition: slide,
+        direction: "backward",
+      });
+    });
+
+    it("records an unmatched entry as no effect, including the return", () => {
+      const { history } = browser(modern);
+      const transitions = resolver();
+      history.pushState({}, "", "/shops/one");
+      expect(transitions.select("/cart", "/shops/one", [])).toBeNull();
+      history.back();
+      expect(transitions.select("/shops/one", "/cart")).toBeNull();
+    });
+
+    it("uses the actual predecessor after query-only pushes with no boundary pair", () => {
+      const { history } = browser(modern);
+      const transitions = resolver();
+      history.pushState({}, "", "/cart?filter=one");
+      history.pushState({}, "", "/shops/one");
+      transitions.select("/cart", "/shops/one");
+      history.back();
+      expect(transitions.select("/shops/one", "/cart")).toMatchObject({
+        transition: slide,
+        direction: "backward",
+      });
+    });
+  },
+);
+
+describe("history observation lifetime", () => {
+  it("does not touch the browser while constructing a render-time context", () => {
+    const { history } = browser(false);
+    const push = history.pushState;
+    const transitions = createNavigationTransitionResolver();
+    expect(history.pushState).toBe(push);
+    expect(history.replaceState).not.toHaveBeenCalled();
+    transitions.dispose();
+  });
+
+  it("uses native entry identities without patching history or its state", () => {
+    const { history } = browser(true);
+    const original = { ...history };
+    resolver();
+    expect(history.pushState).toBe(original.pushState);
+    expect(history.replaceState).toBe(original.replaceState);
+    expect(history.replaceState).not.toHaveBeenCalled();
+  });
+
+  it("shares legacy wrappers, preserves router fields and cleans up the last subscriber", () => {
+    const { history } = browser(false);
+    const push = history.pushState,
+      replace = history.replaceState,
+      back = history.back;
+    const first = resolver(),
+      wrapped = history.pushState;
+    const second = resolver();
+    expect(history.pushState).toBe(wrapped);
+    expect(history.back).toBe(back);
+    expect(history.state).toMatchObject({ __NA: true, tree: "owned" });
+    history.pushState({ __NA: true, custom: 42 }, "", "/shops/one");
+    expect(history.state).toMatchObject({ __NA: true, custom: 42 });
+    expect(first.select("/cart", "/shops/one")).toEqual(
+      second.select("/cart", "/shops/one"),
+    );
+    first.dispose();
+    expect(history.pushState).toBe(wrapped);
+    second.dispose();
+    expect(history.pushState).toBe(push);
+    expect(history.replaceState).toBe(replace);
+  });
+
+  it("keeps an outer router wrapper intact and leaves its captured wrapper inert", () => {
+    const { history } = browser(false);
+    const transitions = resolver();
+    const captured = history.pushState;
+    const outer = (...args: Parameters<typeof captured>) =>
+      captured.apply(history, args);
+    history.pushState = outer as typeof history.pushState;
+    transitions.dispose();
+    expect(history.pushState).toBe(outer);
+    history.pushState({ custom: "after dispose" }, "", "/other");
+    expect(history.state).toEqual({ custom: "after dispose" });
+  });
+
+  it.each([42, "opaque", ["array"]])(
+    "does not reshape unsupported legacy state: %s",
+    (state) => {
+      const { history } = browser(false, state);
+      const transitions = resolver();
+      expect(history.state).toEqual(state);
+      history.pushState(state, "", "/other");
+      expect(history.state).toEqual(state);
+      expect(transitions.select("/cart", "/other")).toMatchObject({
+        direction: "forward",
+      });
+    },
+  );
+
+  it("works without a browser", () => {
     const tracker = createNavigationDirectionTracker();
-    history.back();
-    expect(back).toHaveBeenCalledOnce();
-    expect(tracker.resolve("/cart", "/products/1")).toBe("backward");
-    popListener?.();
-    expect(tracker.resolve("/products/1", "/cart")).toBe("forward");
-
-    history.forward();
-    expect(forward).toHaveBeenCalledOnce();
-    expect(tracker.resolve("/products/1", "/cart")).toBe("forward");
-    popListener?.();
-
-    history.go(-2);
-    expect(go).toHaveBeenCalledWith(-2);
-    expect(tracker.resolve("/cart", "/")).toBe("backward");
+    expect(tracker.resolve("/a", "/b")).toMatchObject({
+      kind: "unknown",
+      direction: "forward",
+    });
     tracker.dispose();
-    expect(history).toEqual({ back, forward, go });
   });
 });

--- a/packages/core/src/lib/ssgoi-transition/navigation-direction.test.ts
+++ b/packages/core/src/lib/ssgoi-transition/navigation-direction.test.ts
@@ -294,6 +294,34 @@ describe.each([true, false])(
 );
 
 describe("history observation lifetime", () => {
+  it("records the winning slide even when Navigation API entries lag behind History API commits", () => {
+    const target = browser(true);
+    const nativeEntry = { ...target.navigation!.currentEntry! };
+    Object.defineProperty(target.navigation, "currentEntry", {
+      value: nativeEntry,
+    });
+    const transitions = resolver();
+    target.history.pushState({ __NA: true }, "", "/shops/one");
+    expect(transitions.select("/cart", "/shops/one")).toMatchObject({
+      transition: slide,
+    });
+    target.history.back();
+    expect(transitions.select("/shops/one", "/cart")).toMatchObject({
+      transition: slide,
+      direction: "backward",
+    });
+    target.history.forward();
+    expect(transitions.select("/cart", "/shops/one")).toMatchObject({
+      transition: slide,
+      direction: "forward",
+    });
+    target.history.pushState({}, "", "/cart");
+    expect(transitions.select("/shops/one", "/cart")).toMatchObject({
+      transition: parallax,
+      direction: "forward",
+    });
+  });
+
   it("does not touch the browser while constructing a render-time context", () => {
     const { history } = browser(false);
     const push = history.pushState;
@@ -303,13 +331,16 @@ describe("history observation lifetime", () => {
     transitions.dispose();
   });
 
-  it("uses native entry identities without patching history or its state", () => {
+  it("tracks History API commits even when a Navigation API is exposed", () => {
     const { history } = browser(true);
     const original = { ...history };
-    resolver();
+    const transitions = resolver();
+    expect(history.pushState).not.toBe(original.pushState);
+    expect(history.replaceState).not.toBe(original.replaceState);
+    expect(history.state).toMatchObject({ __NA: true, tree: "owned" });
+    transitions.dispose();
     expect(history.pushState).toBe(original.pushState);
     expect(history.replaceState).toBe(original.replaceState);
-    expect(history.replaceState).not.toHaveBeenCalled();
   });
 
   it("shares legacy wrappers, preserves router fields and cleans up the last subscriber", () => {

--- a/packages/core/src/lib/ssgoi-transition/navigation-direction.test.ts
+++ b/packages/core/src/lib/ssgoi-transition/navigation-direction.test.ts
@@ -16,17 +16,74 @@ describe("navigation direction tracker", () => {
 
   it("uses popstate as a backward hint for the next paired navigation", () => {
     let popListener: (() => void) | undefined;
-    vi.stubGlobal("window", {
-      addEventListener: (_name: string, listener: () => void) => {
+    const addEventListener = vi.fn(
+      (_name: string, listener: () => void, _capture: boolean) => {
         popListener = listener;
       },
-      removeEventListener: vi.fn(),
+    );
+    const removeEventListener = vi.fn();
+    const back = vi.fn();
+    const forward = vi.fn();
+    const go = vi.fn();
+    const history = { back, forward, go };
+    vi.stubGlobal("window", {
+      addEventListener,
+      removeEventListener,
+      history,
     });
 
     const tracker = createNavigationDirectionTracker();
+    expect(addEventListener).toHaveBeenCalledWith(
+      "popstate",
+      expect.any(Function),
+      true,
+    );
     expect(tracker.resolve("/", "/posts")).toBe("forward");
     popListener?.();
     expect(tracker.resolve("/posts", "/some-known-by-router")).toBe("backward");
     tracker.dispose();
+    expect(removeEventListener).toHaveBeenCalledWith(
+      "popstate",
+      popListener,
+      true,
+    );
+    expect(history).toEqual({ back, forward, go });
+  });
+
+  it("marks history traversal before popstate and ignores its late duplicate", () => {
+    let popListener: (() => void) | undefined;
+    const back = vi.fn();
+    const forward = vi.fn();
+    const go = vi.fn();
+    const history = { back, forward, go };
+    vi.stubGlobal("window", {
+      addEventListener: (
+        _name: string,
+        listener: () => void,
+        _capture: boolean,
+      ) => {
+        popListener = listener;
+      },
+      removeEventListener: vi.fn(),
+      history,
+    });
+
+    const tracker = createNavigationDirectionTracker();
+    history.back();
+    expect(back).toHaveBeenCalledOnce();
+    expect(tracker.resolve("/cart", "/products/1")).toBe("backward");
+    popListener?.();
+    expect(tracker.resolve("/products/1", "/cart")).toBe("forward");
+
+    history.forward();
+    expect(forward).toHaveBeenCalledOnce();
+    expect(tracker.resolve("/products/1", "/cart")).toBe("forward");
+    popListener?.();
+
+    history.go(-2);
+    expect(go).toHaveBeenCalledWith(-2);
+    expect(tracker.resolve("/cart", "/")).toBe("backward");
+    tracker.dispose();
+    expect(history).toEqual({ back, forward, go });
   });
 });

--- a/packages/core/src/lib/ssgoi-transition/navigation-direction.ts
+++ b/packages/core/src/lib/ssgoi-transition/navigation-direction.ts
@@ -11,26 +11,90 @@ export interface NavigationDirectionTracker {
  * navigation is forward, even when its destination equals the previous path.
  */
 export function createNavigationDirectionTracker(): NavigationDirectionTracker {
-  let popPending = false;
+  let pendingDirection: NavigationDirection | null = null;
+  let programmaticTraversal: NavigationDirection | null = null;
+  let traversalTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  const clearTraversalTimeout = () => {
+    if (traversalTimeout !== null) clearTimeout(traversalTimeout);
+    traversalTimeout = null;
+  };
+  const markProgrammaticTraversal = (direction: NavigationDirection) => {
+    pendingDirection = direction;
+    programmaticTraversal = direction;
+    clearTraversalTimeout();
+    // history.back() can be a no-op at the beginning of the session. Do not
+    // let that uncommitted hint leak into a later explicit navigation.
+    traversalTimeout = setTimeout(() => {
+      if (programmaticTraversal !== direction) return;
+      programmaticTraversal = null;
+      if (pendingDirection === direction) pendingDirection = null;
+      traversalTimeout = null;
+    }, 1_000);
+  };
   const onPopState = () => {
-    popPending = true;
+    if (programmaticTraversal !== null) {
+      // The method wrapper already marked this traversal before the router
+      // could commit. Ignore its later popstate so it cannot poison the next
+      // explicit navigation after the current hint has been consumed.
+      programmaticTraversal = null;
+      clearTraversalTimeout();
+      return;
+    }
+    pendingDirection = "backward";
   };
 
+  let historyRef: History | null = null;
+  let originalBack: History["back"] | null = null;
+  let originalForward: History["forward"] | null = null;
+  let originalGo: History["go"] | null = null;
+  let wrappedBack: History["back"] | null = null;
+  let wrappedForward: History["forward"] | null = null;
+  let wrappedGo: History["go"] | null = null;
+
   if (typeof window !== "undefined") {
-    window.addEventListener("popstate", onPopState);
+    window.addEventListener("popstate", onPopState, true);
+
+    historyRef = window.history;
+    originalBack = historyRef.back;
+    originalForward = historyRef.forward;
+    originalGo = historyRef.go;
+    wrappedBack = () => {
+      markProgrammaticTraversal("backward");
+      return originalBack?.call(historyRef);
+    };
+    wrappedForward = () => {
+      markProgrammaticTraversal("forward");
+      return originalForward?.call(historyRef);
+    };
+    wrappedGo = (delta = 0) => {
+      if (delta < 0) markProgrammaticTraversal("backward");
+      else if (delta > 0) markProgrammaticTraversal("forward");
+      return originalGo?.call(historyRef, delta);
+    };
+    historyRef.back = wrappedBack;
+    historyRef.forward = wrappedForward;
+    historyRef.go = wrappedGo;
   }
 
   return {
     resolve(_rawFrom, _rawTo) {
-      const direction: NavigationDirection = popPending
-        ? "backward"
-        : "forward";
-      popPending = false;
+      const direction = pendingDirection ?? "forward";
+      pendingDirection = null;
       return direction;
     },
     dispose() {
+      clearTraversalTimeout();
       if (typeof window !== "undefined") {
-        window.removeEventListener("popstate", onPopState);
+        window.removeEventListener("popstate", onPopState, true);
+      }
+      if (historyRef) {
+        if (historyRef.back === wrappedBack && originalBack)
+          historyRef.back = originalBack;
+        if (historyRef.forward === wrappedForward && originalForward)
+          historyRef.forward = originalForward;
+        if (historyRef.go === wrappedGo && originalGo)
+          historyRef.go = originalGo;
       }
     },
   };

--- a/packages/core/src/lib/ssgoi-transition/navigation-direction.ts
+++ b/packages/core/src/lib/ssgoi-transition/navigation-direction.ts
@@ -1,101 +1,74 @@
 import type { NavigationDirection } from "@types";
+import {
+  connectBrowserHistory,
+  type BrowserHistory,
+  type HistoryEntry,
+} from "./browser-history";
+import { normalizePath } from "./path-pattern";
 
-export interface NavigationDirectionTracker {
-  resolve(from: string, to: string): NavigationDirection;
-  dispose(): void;
-}
+export type NavigationChange = {
+  kind: "push" | "replace" | "back" | "forward" | "unknown";
+  direction: NavigationDirection;
+  from: HistoryEntry | null;
+  to: HistoryEntry | null;
+};
 
-/**
- * Navigation hint used only where a route rule cannot determine direction
- * from its own boundary/order. A browser pop is backward; every explicit
- * navigation is forward, even when its destination equals the previous path.
- */
-export function createNavigationDirectionTracker(): NavigationDirectionTracker {
-  let pendingDirection: NavigationDirection | null = null;
-  let programmaticTraversal: NavigationDirection | null = null;
-  let traversalTimeout: ReturnType<typeof setTimeout> | null = null;
-
-  const clearTraversalTimeout = () => {
-    if (traversalTimeout !== null) clearTimeout(traversalTimeout);
-    traversalTimeout = null;
+/** Created during render, connected only when a boundary is actually observed. */
+export function createNavigationDirectionTracker() {
+  let history: BrowserHistory | null = null;
+  let current: HistoryEntry | null = null;
+  const visited = new Set<string>();
+  const remember = (entry: HistoryEntry | null) => {
+    if (entry) visited.add(entry.key);
+    if (visited.size > 200) visited.delete(visited.values().next().value!);
   };
-  const markProgrammaticTraversal = (direction: NavigationDirection) => {
-    pendingDirection = direction;
-    programmaticTraversal = direction;
-    clearTraversalTimeout();
-    // history.back() can be a no-op at the beginning of the session. Do not
-    // let that uncommitted hint leak into a later explicit navigation.
-    traversalTimeout = setTimeout(() => {
-      if (programmaticTraversal !== direction) return;
-      programmaticTraversal = null;
-      if (pendingDirection === direction) pendingDirection = null;
-      traversalTimeout = null;
-    }, 1_000);
+  const connect = () => {
+    if (history) return;
+    history = connectBrowserHistory();
+    current = history.read();
+    remember(current);
   };
-  const onPopState = () => {
-    if (programmaticTraversal !== null) {
-      // The method wrapper already marked this traversal before the router
-      // could commit. Ignore its later popstate so it cannot poison the next
-      // explicit navigation after the current hint has been consumed.
-      programmaticTraversal = null;
-      clearTraversalTimeout();
-      return;
-    }
-    pendingDirection = "backward";
-  };
-
-  let historyRef: History | null = null;
-  let originalBack: History["back"] | null = null;
-  let originalForward: History["forward"] | null = null;
-  let originalGo: History["go"] | null = null;
-  let wrappedBack: History["back"] | null = null;
-  let wrappedForward: History["forward"] | null = null;
-  let wrappedGo: History["go"] | null = null;
-
-  if (typeof window !== "undefined") {
-    window.addEventListener("popstate", onPopState, true);
-
-    historyRef = window.history;
-    originalBack = historyRef.back;
-    originalForward = historyRef.forward;
-    originalGo = historyRef.go;
-    wrappedBack = () => {
-      markProgrammaticTraversal("backward");
-      return originalBack?.call(historyRef);
-    };
-    wrappedForward = () => {
-      markProgrammaticTraversal("forward");
-      return originalForward?.call(historyRef);
-    };
-    wrappedGo = (delta = 0) => {
-      if (delta < 0) markProgrammaticTraversal("backward");
-      else if (delta > 0) markProgrammaticTraversal("forward");
-      return originalGo?.call(historyRef, delta);
-    };
-    historyRef.back = wrappedBack;
-    historyRef.forward = wrappedForward;
-    historyRef.go = wrappedGo;
-  }
 
   return {
-    resolve(_rawFrom, _rawTo) {
-      const direction = pendingDirection ?? "forward";
-      pendingDirection = null;
-      return direction;
+    connect,
+    resolve(rawFrom: string, _rawTo: string): NavigationChange {
+      connect();
+      const to = history!.read();
+      let from = current;
+      let kind: NavigationChange["kind"] = "unknown";
+      if (from && to) {
+        if (to.key === from.key || to.index === from.index) kind = "replace";
+        else if (to.index < from.index) kind = "back";
+        else kind = visited.has(to.key) ? "forward" : "push";
+      }
+      if (kind === "push") {
+        // Query/hash-only history entries may not mount a new page boundary.
+        // Use the actual predecessor when it still represents the OUT route.
+        const predecessor = history!.previous();
+        if (
+          predecessor &&
+          predecessor.index === to!.index - 1 &&
+          normalizePath(new URL(predecessor.url).pathname) ===
+            normalizePath(rawFrom)
+        ) {
+          from = predecessor;
+        }
+      }
+      current = to;
+      remember(from);
+      remember(to);
+      return {
+        kind,
+        direction: kind === "back" ? "backward" : "forward",
+        from,
+        to,
+      };
     },
     dispose() {
-      clearTraversalTimeout();
-      if (typeof window !== "undefined") {
-        window.removeEventListener("popstate", onPopState, true);
-      }
-      if (historyRef) {
-        if (historyRef.back === wrappedBack && originalBack)
-          historyRef.back = originalBack;
-        if (historyRef.forward === wrappedForward && originalForward)
-          historyRef.forward = originalForward;
-        if (historyRef.go === wrappedGo && originalGo)
-          historyRef.go = originalGo;
-      }
+      history?.dispose();
+      history = null;
+      current = null;
+      visited.clear();
     },
   };
 }

--- a/packages/core/src/lib/ssgoi-transition/navigation-transition.ts
+++ b/packages/core/src/lib/ssgoi-transition/navigation-transition.ts
@@ -1,0 +1,81 @@
+import type { NavigationDirection } from "@types";
+import type { ResolvedTransitionRule } from "../runtime/resolve-transition-rule";
+import { createNavigationDirectionTracker } from "./navigation-direction";
+
+type Edge<T> = {
+  source: string;
+  index: number;
+  from: string;
+  to: string;
+  rule: ResolvedTransitionRule<T> | null;
+};
+
+/** Remember effects per visited entry, without retaining page DOM or animations. */
+export function createNavigationTransitionResolver<T>() {
+  const tracker = createNavigationDirectionTracker();
+  const arrivals = new Map<string, Edge<T>>();
+  return {
+    connect: tracker.connect,
+    resolve(
+      from: string,
+      to: string,
+      match: (
+        direction: NavigationDirection,
+      ) => ResolvedTransitionRule<T> | null,
+    ): ResolvedTransitionRule<T> | null {
+      const navigation = tracker.resolve(from, to);
+      const source = navigation.from?.key;
+      const destination = navigation.to?.key;
+      if (navigation.kind === "back" && source && destination) {
+        const edge = arrivals.get(source);
+        if (
+          edge?.source === destination &&
+          edge.from === to &&
+          edge.to === from
+        ) {
+          if (!edge.rule) return null;
+          return {
+            ...edge.rule,
+            direction:
+              edge.rule.direction === "forward" ? "backward" : "forward",
+            preserveScroll: {
+              from: edge.rule.preserveScroll.to,
+              to: edge.rule.preserveScroll.from,
+            },
+          };
+        }
+      }
+      if (navigation.kind === "forward" && source && destination) {
+        const edge = arrivals.get(destination);
+        if (edge?.source === source && edge.from === from && edge.to === to)
+          return edge.rule;
+      }
+
+      const rule = match(navigation.direction);
+      if (destination && navigation.kind === "replace")
+        arrivals.delete(destination);
+      if (destination && source && navigation.kind === "push") {
+        // A new push after Back discards the old forward branch.
+        for (const [key, edge] of arrivals) {
+          if (edge.index >= navigation.to!.index) arrivals.delete(key);
+        }
+        arrivals.set(destination, {
+          source,
+          index: navigation.to!.index,
+          from,
+          to,
+          rule: rule
+            ? { ...rule, preserveScroll: { ...rule.preserveScroll } }
+            : null,
+        });
+        // Keep the provider's memory bounded even in long-running sessions.
+        if (arrivals.size > 100) arrivals.delete(arrivals.keys().next().value!);
+      }
+      return rule;
+    },
+    dispose() {
+      tracker.dispose();
+      arrivals.clear();
+    },
+  };
+}

--- a/packages/core/src/lib/ssgoi-transition/observe-ssgoi-transitions.ts
+++ b/packages/core/src/lib/ssgoi-transition/observe-ssgoi-transitions.ts
@@ -131,5 +131,8 @@ export function observeSsgoiTransitions(
   collectNode(root, initialElements);
   registerTransitionBatch(initialElements, ssgoi);
 
-  return () => observer.disconnect();
+  return () => {
+    observer.disconnect();
+    ssgoi.disconnect?.();
+  };
 }

--- a/packages/core/src/lib/types/index.ts
+++ b/packages/core/src/lib/types/index.ts
@@ -184,6 +184,8 @@ export type SsgoiConfig =
  * cancellation helpers) without breaking call sites that destructure.
  */
 export type SsgoiContext = {
+  /** Release browser-history observation when the owning root disconnects. */
+  disconnect?: () => void;
   /**
    * Tell the dispatcher this DOM node has mounted under `path`. The
    * dispatcher handles pairing with the outgoing page, running the matched

--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/qwik",
-  "version": "7.1.0-beta.0",
+  "version": "7.1.0-beta.2",
   "description": "Qwik bindings for SSGOI - Native app-like page transitions for Qwik and Qwik City applications",
   "private": false,
   "sideEffects": false,

--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/qwik",
-  "version": "7.1.0-beta.3",
+  "version": "7.1.0-beta.4",
   "description": "Qwik bindings for SSGOI - Native app-like page transitions for Qwik and Qwik City applications",
   "private": false,
   "sideEffects": false,

--- a/packages/qwik/package.json
+++ b/packages/qwik/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/qwik",
-  "version": "7.1.0-beta.2",
+  "version": "7.1.0-beta.3",
   "description": "Qwik bindings for SSGOI - Native app-like page transitions for Qwik and Qwik City applications",
   "private": false,
   "sideEffects": false,

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/react-native",
-  "version": "7.1.0-beta.2",
+  "version": "7.1.0-beta.3",
   "description": "React Native screen transitions for SSGOI with optional Expo Router integration",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/react-native",
-  "version": "7.1.0-beta.0",
+  "version": "7.1.0-beta.2",
   "description": "React Native screen transitions for SSGOI with optional Expo Router integration",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/react-native",
-  "version": "7.1.0-beta.3",
+  "version": "7.1.0-beta.4",
   "description": "React Native screen transitions for SSGOI with optional Expo Router integration",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/react",
-  "version": "7.1.0-beta.3",
+  "version": "7.1.0-beta.4",
   "description": "React bindings for SSGOI - Native app-like page transitions for React applications",
   "private": false,
   "type": "module",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/react",
-  "version": "7.1.0-beta.2",
+  "version": "7.1.0-beta.3",
   "description": "React bindings for SSGOI - Native app-like page transitions for React applications",
   "private": false,
   "type": "module",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/react",
-  "version": "7.1.0-beta.0",
+  "version": "7.1.0-beta.2",
   "description": "React bindings for SSGOI - Native app-like page transitions for React applications",
   "private": false,
   "type": "module",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/solid",
-  "version": "7.1.0-beta.0",
+  "version": "7.1.0-beta.2",
   "description": "Solid.js bindings for SSGOI - Native app-like page transitions for Solid applications",
   "private": false,
   "type": "module",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/solid",
-  "version": "7.1.0-beta.3",
+  "version": "7.1.0-beta.4",
   "description": "Solid.js bindings for SSGOI - Native app-like page transitions for Solid applications",
   "private": false,
   "type": "module",

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/solid",
-  "version": "7.1.0-beta.2",
+  "version": "7.1.0-beta.3",
   "description": "Solid.js bindings for SSGOI - Native app-like page transitions for Solid applications",
   "private": false,
   "type": "module",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/svelte",
-  "version": "7.1.0-beta.2",
+  "version": "7.1.0-beta.3",
   "description": "Svelte bindings for SSGOI - Native app-like page transitions for Svelte and SvelteKit applications",
   "private": false,
   "main": "./dist/index.js",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/svelte",
-  "version": "7.1.0-beta.0",
+  "version": "7.1.0-beta.2",
   "description": "Svelte bindings for SSGOI - Native app-like page transitions for Svelte and SvelteKit applications",
   "private": false,
   "main": "./dist/index.js",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/svelte",
-  "version": "7.1.0-beta.3",
+  "version": "7.1.0-beta.4",
   "description": "Svelte bindings for SSGOI - Native app-like page transitions for Svelte and SvelteKit applications",
   "private": false,
   "main": "./dist/index.js",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/vue",
-  "version": "7.1.0-beta.2",
+  "version": "7.1.0-beta.3",
   "description": "Vue bindings for SSGOI - Native app-like page transitions for Vue applications",
   "private": false,
   "type": "module",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/vue",
-  "version": "7.1.0-beta.3",
+  "version": "7.1.0-beta.4",
   "description": "Vue bindings for SSGOI - Native app-like page transitions for Vue applications",
   "private": false,
   "type": "module",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssgoi/vue",
-  "version": "7.1.0-beta.0",
+  "version": "7.1.0-beta.2",
   "description": "Vue bindings for SSGOI - Native app-like page transitions for Vue applications",
   "private": false,
   "type": "module",


### PR DESCRIPTION
Browser Back now reverses the effect recorded when an observed page was opened, and Forward replays that choice. For example, cart → supplier can select a one-way drill slide rule; actual Back returns with slide backward, while a fresh supplier → cart link rematches the current parallax rule.

The web context records the effect, semantic direction and scroll policy per history entry. Shared, reference-counted pushState/replaceState wrappers preserve router fields and add a namespaced marker to null/plain-object state. The committed History API marker takes precedence over Navigation API entries: a browser can expose that API while its key/index still describe the previous page after pushState. Treating that stale identity as replace dropped the winning slide rule and allowed the parallax fallback on return. A regression reproduces that failure and now passes.

Primitive/array state is not reshaped; native identity is used as a fallback only when its URL matches the committed location. Observation starts at boundary registration and is released at root disconnect. Only exact recorded entry pairs replay; unknown entries, replaced routes, unrecorded multi-step jumps and reloads/provider disconnection rematch. Memory is bounded to 100 arrival effects with discarded forward branches pruned. Native runtime matching is unchanged.

All eight packages and llms.txt are at 7.1.0-beta.4, published under beta. The library no longer relies on a popstate timing flag or a back/forward/go timeout.

Validation:

- 147 core tests, core lint/typecheck, and all eight package builds pass.
- Reproduced loss of the selected effect on the deployed Loomport URL: slide frames on entry with no recorded rule, then a parallax fallback on Back.
- Fixed preview passes Chromium and WebKit with Navigation API exposed and disabled: rule index 4 is recorded on entry and the same record is found on Back; cart IN is -100% → 0% with opacity 0.5 → 1.
- Loomport installs core/react beta.4 from npm with no local overrides; typecheck, lint and 309 tests pass. Its cart-specific bidirectional workaround remains removed.
- Troubleshooting documents rule replay and the shared stacking context required by full-page portals.
- Deployed Loomport source `02ab113` as active build `b_e47df213ce60b2a6`. The supplied public URL serves that version. Its real authenticated cart supplier link → actual app-bar Back passes all four Chromium/WebKit and Navigation API exposed/disabled checks: the stored and restored rule indexes are both 4 (slide), not fallback rule 5 (parallax). The QA login session was signed out afterward; cart data was unchanged.
